### PR TITLE
Add Playwright E2E test suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,97 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  POSTGRES_PASSWORD: testpassword
+  JWT_SECRET: e2e-test-secret-key
+  SECURE_COOKIES: "false"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start services
+        working-directory: docker
+        run: docker compose up --build -d
+
+      - name: Wait for backend health
+        run: |
+          echo "Waiting for backend..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "Backend healthy"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "Backend failed to start"
+              docker compose -f docker/docker-compose.yml logs backend
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Wait for frontend
+        run: |
+          echo "Waiting for frontend..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "Frontend healthy"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "Frontend failed to start"
+              docker compose -f docker/docker-compose.yml logs frontend
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: frontend
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        working-directory: frontend
+        run: npx playwright test
+        env:
+          BASE_URL: http://localhost:3000
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Upload traces on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-traces
+          path: frontend/e2e/test-results/
+          retention-days: 7
+
+      - name: Teardown
+        if: always()
+        working-directory: docker
+        run: docker compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,9 @@ node_modules/
 # Agent memory (session context)
 tasks/
 
+# Playwright
+e2e/test-results/
+playwright-report/
+
 # OS
 .DS_Store

--- a/frontend/e2e/global-setup.js
+++ b/frontend/e2e/global-setup.js
@@ -1,0 +1,34 @@
+const { request } = require('@playwright/test');
+
+/**
+ * Registers a throwaway user so the SetupWizard (first-run screen) is bypassed.
+ * If the user already exists (e.g. from a previous run), that's fine.
+ */
+module.exports = async function globalSetup(config) {
+  const baseURL =
+    config.projects?.[0]?.use?.baseURL ||
+    process.env.BASE_URL ||
+    'http://localhost:3000';
+
+  const ctx = await request.newContext({ baseURL });
+
+  try {
+    const status = await ctx.get('/api/setup/status');
+    const { needs_setup } = await status.json();
+
+    if (needs_setup) {
+      await ctx.post('/api/auth/register', {
+        data: {
+          email: 'setup@example.com',
+          password: 'Setup1234',
+          display_name: 'Setup',
+          family_name: 'Setup Family',
+        },
+      });
+    }
+  } catch {
+    // Server might not be running yet during `--list`, ignore
+  } finally {
+    await ctx.dispose();
+  }
+};

--- a/frontend/e2e/helpers/api-setup.js
+++ b/frontend/e2e/helpers/api-setup.js
@@ -1,0 +1,85 @@
+/**
+ * Seed helpers — create test data via API.
+ * All functions take `request` (page.request) which shares the auth cookie.
+ */
+
+async function getFamilyId(request) {
+  const res = await request.get('/api/families/me');
+  if (!res.ok()) {
+    throw new Error(`GET /api/families/me failed (${res.status()}): ${await res.text()}`);
+  }
+  const families = await res.json();
+  return families[0].family_id;
+}
+
+async function seedCalendarEvent(request, familyId, overrides = {}) {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(10, 0, 0, 0);
+
+  const res = await request.post('/api/calendar/events', {
+    data: {
+      family_id: familyId,
+      title: 'Test Event',
+      starts_at: tomorrow.toISOString(),
+      ...overrides,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/calendar/events failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function seedTask(request, familyId, overrides = {}) {
+  const res = await request.post('/api/tasks', {
+    data: {
+      family_id: familyId,
+      title: 'Test Task',
+      ...overrides,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/tasks failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function completeTask(request, taskId) {
+  const res = await request.patch(`/api/tasks/${taskId}`, {
+    data: { status: 'done' },
+  });
+  if (!res.ok()) {
+    throw new Error(`PATCH /api/tasks/${taskId} failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function seedShoppingList(request, familyId, name = 'Test List') {
+  const res = await request.post('/api/shopping/lists', {
+    data: { family_id: familyId, name },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/shopping/lists failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function seedShoppingItem(request, listId, name = 'Milk', spec = '') {
+  const res = await request.post(`/api/shopping/lists/${listId}/items`, {
+    data: { name, spec },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/shopping/lists/${listId}/items failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
+module.exports = {
+  getFamilyId,
+  seedCalendarEvent,
+  seedTask,
+  completeTask,
+  seedShoppingList,
+  seedShoppingItem,
+};

--- a/frontend/e2e/helpers/auth.js
+++ b/frontend/e2e/helpers/auth.js
@@ -1,0 +1,46 @@
+let counter = 0;
+
+/**
+ * Returns a unique test-user payload.
+ * Password satisfies Tribu rules: ≥8 chars, 1 uppercase, 1 digit.
+ */
+function createTestUser() {
+  counter++;
+  const id = `${Date.now()}-${counter}`;
+  return {
+    email: `test-${id}@example.com`,
+    password: 'Test1234',
+    displayName: `Tester ${counter}`,
+    familyName: `Family ${counter}`,
+  };
+}
+
+/**
+ * Register & log in a test user via API, then navigate to the dashboard.
+ * Uses page.request so the auth cookie lands in the browser context.
+ */
+async function loginAsUser(page, user) {
+  const res = await page.request.post('/api/auth/register', {
+    data: {
+      email: user.email,
+      password: user.password,
+      display_name: user.displayName,
+      family_name: user.familyName,
+    },
+  });
+
+  if (!res.ok()) {
+    // User might already exist — try login instead
+    const loginRes = await page.request.post('/api/auth/login', {
+      data: { email: user.email, password: user.password },
+    });
+    if (!loginRes.ok()) {
+      throw new Error(`Auth failed for ${user.email}: ${loginRes.status()}`);
+    }
+  }
+
+  await page.goto('/');
+  await page.locator('#main-content').waitFor({ timeout: 15000 });
+}
+
+module.exports = { createTestUser, loginAsUser };

--- a/frontend/e2e/helpers/fixtures.js
+++ b/frontend/e2e/helpers/fixtures.js
@@ -1,0 +1,60 @@
+const { test: base, expect } = require('@playwright/test');
+const { createTestUser } = require('./auth');
+
+/**
+ * Custom fixtures:
+ *  - workerUser — one user per worker (registered + logged in once)
+ *  - testUser   — alias for workerUser
+ *  - authedPage — page with auth cookie, on the dashboard (NO API login call)
+ *  - apiCtx     — page.request with auth cookie (for seeding data)
+ */
+const test = base.extend({
+  // Register + login once per worker. Store the cookies so we don't
+  // hit the 20 req/min login rate limit.
+  workerUser: [async ({ playwright }, use) => {
+    const user = createTestUser();
+    const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+    const ctx = await playwright.request.newContext({ baseURL });
+
+    // Register
+    const regRes = await ctx.post('/api/auth/register', {
+      data: {
+        email: user.email,
+        password: user.password,
+        display_name: user.displayName,
+        family_name: user.familyName,
+      },
+    });
+    if (!regRes.ok()) {
+      const body = await regRes.text();
+      throw new Error(`Register worker user failed (${regRes.status()}): ${body}`);
+    }
+
+    // The register call sets the auth cookie. Grab it.
+    const state = await ctx.storageState();
+    user.cookies = state.cookies;
+
+    await ctx.dispose();
+    await use(user);
+  }, { scope: 'worker' }],
+
+  testUser: async ({ workerUser }, use) => {
+    await use(workerUser);
+  },
+
+  // Inject the auth cookie directly — zero API calls per test.
+  authedPage: async ({ page, workerUser }, use) => {
+    if (workerUser.cookies.length > 0) {
+      await page.context().addCookies(workerUser.cookies);
+    }
+    await page.goto('/');
+    await page.locator('#main-content').waitFor({ timeout: 15000 });
+    await use(page);
+  },
+
+  apiCtx: async ({ authedPage }, use) => {
+    await use(authedPage.request);
+  },
+});
+
+module.exports = { test, expect };

--- a/frontend/e2e/helpers/navigation.js
+++ b/frontend/e2e/helpers/navigation.js
@@ -1,0 +1,43 @@
+// Mobile bottom-nav uses mobileLabel which differs from the sidebar label
+const MOBILE_ALIASES = {
+  Dashboard: 'Home',
+};
+
+/**
+ * Navigate to a view in the app.
+ * On desktop: clicks sidebar .nav-item
+ * On mobile: uses bottom-nav items or the "More" overflow popup
+ */
+async function navigateTo(page, viewName) {
+  const isMobile = await page.evaluate(() => window.innerWidth < 768);
+
+  if (!isMobile) {
+    // Desktop sidebar: use the viewName directly (e.g. "Dashboard", "Calendar")
+    // Handle reverse alias: "Home" → "Dashboard" for desktop
+    const desktopName = Object.entries(MOBILE_ALIASES)
+      .find(([, mobile]) => mobile === viewName)?.[0] || viewName;
+    await page.locator('.nav-item', { hasText: desktopName }).first().click();
+    return;
+  }
+
+  // Mobile: resolve alias (e.g. "Dashboard" → "Home")
+  const mobileName = MOBILE_ALIASES[viewName] || viewName;
+
+  // Try bottom-nav first
+  const bottomNavItem = page.locator('.bottom-nav-item', { hasText: mobileName });
+  if (await bottomNavItem.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await bottomNavItem.click();
+    return;
+  }
+
+  // Not in bottom nav → open "More" overflow, then click the item
+  const moreBtn = page.locator('.bottom-nav-item', { hasText: 'More' })
+    .or(page.locator('.bottom-nav .bottom-nav-overflow > button'));
+  await moreBtn.first().click();
+
+  const overflowItem = page.locator('.bottom-nav-overflow-item', { hasText: mobileName });
+  await overflowItem.waitFor({ timeout: 3000 });
+  await overflowItem.click();
+}
+
+module.exports = { navigateTo };

--- a/frontend/e2e/tests/admin.spec.js
+++ b/frontend/e2e/tests/admin.spec.js
@@ -1,0 +1,23 @@
+const { test, expect } = require('../helpers/fixtures');
+const { navigateTo } = require('../helpers/navigation');
+
+test.describe('Admin', () => {
+  test('admin panel shows member list with own user', async ({ authedPage: page, testUser }) => {
+    await navigateTo(page, 'Admin');
+
+    await expect(page.locator('.profile-name', { hasText: testUser.displayName })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.profile-email', { hasText: testUser.email })).toBeVisible();
+  });
+
+  test('invite section renders', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Admin');
+
+    await expect(page.getByRole('heading', { name: 'Invitations' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('audit log section renders', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Admin');
+
+    await expect(page.getByRole('heading', { name: 'Audit Log' })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/e2e/tests/auth.spec.js
+++ b/frontend/e2e/tests/auth.spec.js
@@ -1,0 +1,62 @@
+const { test, expect } = require('../helpers/fixtures');
+const { createTestUser } = require('../helpers/auth');
+
+test.describe('Authentication', () => {
+  test('register a new user', async ({ page }) => {
+    const user = createTestUser();
+    await page.goto('/');
+
+    // Switch to register tab
+    await page.locator('#tab-register').click();
+    await page.locator('#panel-register').waitFor();
+
+    // Fill register form
+    await page.locator('#register-email').fill(user.email);
+    await page.locator('#register-password').fill(user.password);
+    await page.locator('#register-name').fill(user.displayName);
+    await page.locator('#register-family').fill(user.familyName);
+
+    // Submit
+    await page.locator('#panel-register button[type="submit"]').click();
+
+    // Should land on dashboard
+    await page.locator('#main-content').waitFor({ timeout: 15000 });
+    await expect(page.locator('#main-content')).toBeVisible();
+  });
+
+  test('logout', async ({ authedPage: page }) => {
+    // On mobile, the sidebar logout is hidden; use the mobile-header one
+    const isMobile = await page.evaluate(() => window.innerWidth < 768);
+    if (isMobile) {
+      await page.locator('.mobile-header [aria-label="Log out"]').click();
+    } else {
+      await page.locator('.sidebar-user [aria-label="Log out"]').click();
+    }
+
+    // Should see auth page
+    await expect(page.locator('#tab-login')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('login with existing user', async ({ page, testUser }) => {
+    await page.goto('/');
+    await page.locator('#tab-login').waitFor({ timeout: 10000 });
+
+    await page.locator('#login-email').fill(testUser.email);
+    await page.locator('#login-password').fill(testUser.password);
+    await page.locator('#panel-login button[type="submit"]').click();
+
+    await page.locator('#main-content').waitFor({ timeout: 15000 });
+    await expect(page.locator('#main-content')).toBeVisible();
+  });
+
+  test('invalid login shows error', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('#tab-login').waitFor({ timeout: 10000 });
+
+    await page.locator('#login-email').fill('wrong@example.com');
+    await page.locator('#login-password').fill('Wrong1234');
+    await page.locator('#panel-login button[type="submit"]').click();
+
+    await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/e2e/tests/calendar.spec.js
+++ b/frontend/e2e/tests/calendar.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require('../helpers/fixtures');
+const { getFamilyId, seedCalendarEvent } = require('../helpers/api-setup');
+const { navigateTo } = require('../helpers/navigation');
+
+test.describe('Calendar', () => {
+  test('navigate to calendar and see month view', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Calendar');
+    await expect(page.locator('.calendar-grid-wrapper')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('create and view an event', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Calendar');
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+
+    // Click on day 15
+    await page.locator('.calendar-day:not(.other-month)', { hasText: /^15$/ }).first().click();
+
+    // Fill event title in the form that appears
+    const titleInput = page.locator('input[placeholder="New event..."]');
+    await titleInput.waitFor({ timeout: 5000 });
+    await titleInput.fill('E2E Test Event');
+
+    // Submit
+    await page.locator('button[type="submit"]').first().click();
+
+    // Event should appear
+    await expect(page.getByText('E2E Test Event')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('delete an event', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+
+    // Seed event on the 20th of the current month
+    const now = new Date();
+    const eventDate = new Date(now.getFullYear(), now.getMonth(), 20, 14, 0, 0);
+    await seedCalendarEvent(apiCtx, familyId, {
+      title: 'Delete Me',
+      starts_at: eventDate.toISOString(),
+    });
+
+    await navigateTo(page, 'Calendar');
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+
+    // Click on day 20
+    await page.locator('.calendar-day:not(.other-month)', { hasText: /^20$/ }).first().click();
+
+    // Wait for event to appear
+    await expect(page.getByText('Delete Me')).toBeVisible({ timeout: 10000 });
+
+    // Delete it
+    await page.locator('[aria-label="Delete event: Delete Me"]').click();
+    await expect(page.getByText('Delete Me')).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('navigate months forward and back', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Calendar');
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+
+    const monthLabel = page.locator('.calendar-month-label');
+    const currentMonth = await monthLabel.textContent();
+
+    // Next month
+    await page.locator('[aria-label="Next month"]').click();
+    await expect(monthLabel).not.toHaveText(currentMonth, { timeout: 5000 });
+
+    // Previous month
+    await page.locator('[aria-label="Previous month"]').click();
+    await expect(monthLabel).toHaveText(currentMonth, { timeout: 5000 });
+  });
+});

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -1,0 +1,34 @@
+const { test, expect } = require('../helpers/fixtures');
+const { navigateTo } = require('../helpers/navigation');
+
+test.describe('Dashboard', () => {
+  test('shows greeting with username', async ({ authedPage: page, testUser }) => {
+    const greeting = page.locator('.bento-welcome h2');
+    await expect(greeting).toBeVisible({ timeout: 10000 });
+    await expect(greeting).toContainText(testUser.displayName);
+  });
+
+  test('quick-action buttons navigate to correct views', async ({ authedPage: page }) => {
+    await page.locator('.bento-welcome').waitFor({ timeout: 10000 });
+
+    // Event → Calendar
+    await page.locator('.bento-welcome .btn-ghost', { hasText: 'Event' }).click();
+    await expect(page.locator('.calendar-grid-wrapper')).toBeVisible({ timeout: 10000 });
+
+    // Back to Dashboard — on mobile, bottom-nav uses "Home" not "Dashboard"
+    await navigateTo(page, 'Home');
+    await page.locator('.bento-welcome').waitFor({ timeout: 10000 });
+
+    // Task → Tasks
+    await page.locator('.bento-welcome .btn-ghost', { hasText: 'Task' }).click();
+    await expect(page.locator('.tasks-filter-tabs')).toBeVisible({ timeout: 10000 });
+
+    // Back to Dashboard
+    await navigateTo(page, 'Home');
+    await page.locator('.bento-welcome').waitFor({ timeout: 10000 });
+
+    // Contact → Contacts
+    await page.locator('.bento-welcome .btn-ghost', { hasText: 'Contact' }).click();
+    await expect(page.locator('#main-content')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/e2e/tests/settings.spec.js
+++ b/frontend/e2e/tests/settings.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('../helpers/fixtures');
+const { navigateTo } = require('../helpers/navigation');
+
+test.describe('Settings', () => {
+  test('open settings and see account tab', async ({ authedPage: page, testUser }) => {
+    await navigateTo(page, 'Settings');
+
+    // On mobile, settings shows a list of tabs — click "Account" first
+    const accountItem = page.locator('.settings-mobile-item', { hasText: 'Account' });
+    if (await accountItem.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await accountItem.click();
+    }
+
+    await expect(page.locator('.profile-name')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.profile-name')).toContainText(testUser.displayName);
+    await expect(page.locator('.profile-email')).toContainText(testUser.email);
+  });
+
+  test('switch theme and verify data-theme attribute', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Settings');
+
+    // On mobile, click Account tab first
+    const accountItem = page.locator('.settings-mobile-item', { hasText: 'Account' });
+    if (await accountItem.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await accountItem.click();
+    }
+
+    await page.locator('.profile-name').waitFor({ timeout: 10000 });
+
+    const html = page.locator('html');
+    const initialTheme = await html.getAttribute('data-theme');
+
+    const inactiveTheme = page.locator('.theme-item:not(.active)').first();
+    if (await inactiveTheme.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await inactiveTheme.click();
+      const newTheme = await html.getAttribute('data-theme');
+      expect(newTheme).not.toBe(initialTheme);
+    }
+  });
+});

--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -1,0 +1,74 @@
+const { test, expect } = require('../helpers/fixtures');
+const { getFamilyId, seedShoppingList, seedShoppingItem } = require('../helpers/api-setup');
+const { navigateTo } = require('../helpers/navigation');
+
+test.describe('Shopping', () => {
+  test('create a shopping list', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Shopping');
+
+    await page.getByText('New list').click();
+    await page.locator('input[placeholder="e.g. Grocery Store"]').fill('E2E Groceries');
+    await page.locator('.shopping-new-list-form .btn-sm').first().click();
+
+    await expect(page.getByText('E2E Groceries')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('add an item to a list', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedShoppingList(apiCtx, familyId, 'Item Test List');
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ timeout: 10000 });
+    await navigateTo(page, 'Shopping');
+
+    await page.getByText('Item Test List').click();
+    await page.locator('input[placeholder="Add an item..."]').fill('Bread');
+    await page.locator('.shopping-spec-input').fill('whole wheat');
+    await page.locator('[aria-label="Add item"]').click();
+
+    await expect(page.getByText('Bread')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('whole wheat')).toBeVisible();
+  });
+
+  test('toggle an item checked / unchecked', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    const list = await seedShoppingList(apiCtx, familyId, 'Toggle List');
+    await seedShoppingItem(apiCtx, list.id, 'Apples');
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ timeout: 10000 });
+    await navigateTo(page, 'Shopping');
+
+    await page.getByText('Toggle List').click();
+
+    const item = page.locator('[role="checkbox"][aria-label="Apples"]');
+    await expect(item).toBeVisible({ timeout: 10000 });
+    await expect(item).toHaveAttribute('aria-checked', 'false');
+
+    await item.click();
+    await expect(item).toHaveAttribute('aria-checked', 'true', { timeout: 5000 });
+
+    await item.click();
+    await expect(item).toHaveAttribute('aria-checked', 'false', { timeout: 5000 });
+  });
+
+  test('delete a shopping list', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedShoppingList(apiCtx, familyId, 'Delete This List');
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ timeout: 10000 });
+    await navigateTo(page, 'Shopping');
+
+    await page.getByText('Delete This List').click();
+
+    // deleteList() uses window.confirm() — accept it
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.locator('[aria-label="Delete list: Delete This List"]').click();
+
+    await expect(page.getByText('Delete This List')).not.toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/e2e/tests/tasks.spec.js
+++ b/frontend/e2e/tests/tasks.spec.js
@@ -1,0 +1,92 @@
+const { test, expect } = require('../helpers/fixtures');
+const { getFamilyId, seedTask, completeTask } = require('../helpers/api-setup');
+const { navigateTo } = require('../helpers/navigation');
+
+test.describe('Tasks', () => {
+  test('create a task via quick-add', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Tasks');
+    await page.locator('.tasks-filter-tabs').waitFor({ timeout: 10000 });
+
+    await page.locator('.quick-add-input').first().fill('E2E Quick Task');
+    await page.locator('[aria-label="Add task"]').click();
+
+    await expect(page.getByText('E2E Quick Task')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('toggle a task open → done', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedTask(apiCtx, familyId, { title: 'Toggle Me' });
+
+    // Navigate to tasks — the view fetches fresh data from API
+    await navigateTo(page, 'Tasks');
+    await page.locator('.tasks-filter-tabs').waitFor({ timeout: 10000 });
+
+    // If the task isn't visible yet, reload to pick up seeded data
+    const checkbox = page.locator('[role="checkbox"][aria-label="Mark task: Toggle Me"]');
+    if (!await checkbox.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await page.reload();
+      await page.locator('#main-content').waitFor({ timeout: 10000 });
+      await navigateTo(page, 'Tasks');
+      await page.locator('.tasks-filter-tabs').waitFor({ timeout: 10000 });
+    }
+
+    // Switch to "All" tab so the task stays visible after toggling to done
+    await page.locator('.tasks-filter-btn', { hasText: 'All' }).click();
+
+    await expect(checkbox).toBeVisible({ timeout: 10000 });
+    await expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+    await checkbox.click();
+    await expect(checkbox).toHaveAttribute('aria-checked', 'true', { timeout: 5000 });
+  });
+
+  test('delete a task', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedTask(apiCtx, familyId, { title: 'Delete This Task' });
+
+    await navigateTo(page, 'Tasks');
+    await page.locator('.tasks-filter-tabs').waitFor({ timeout: 10000 });
+
+    if (!await page.getByText('Delete This Task').isVisible({ timeout: 3000 }).catch(() => false)) {
+      await page.reload();
+      await page.locator('#main-content').waitFor({ timeout: 10000 });
+      await navigateTo(page, 'Tasks');
+      await page.locator('.tasks-filter-tabs').waitFor({ timeout: 10000 });
+    }
+
+    await expect(page.getByText('Delete This Task')).toBeVisible({ timeout: 10000 });
+    await page.locator('[aria-label="Delete task: Delete This Task"]').click();
+    await expect(page.getByText('Delete This Task')).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('filter tabs work (All / Open / Done)', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedTask(apiCtx, familyId, { title: 'Still Open' });
+    const doneTask = await seedTask(apiCtx, familyId, { title: 'Already Done' });
+    await completeTask(apiCtx, doneTask.id);
+
+    await navigateTo(page, 'Tasks');
+    await page.locator('.tasks-filter-tabs').waitFor({ timeout: 10000 });
+
+    if (!await page.getByText('Still Open').isVisible({ timeout: 3000 }).catch(() => false)) {
+      await page.reload();
+      await page.locator('#main-content').waitFor({ timeout: 10000 });
+      await navigateTo(page, 'Tasks');
+      await page.locator('.tasks-filter-tabs').waitFor({ timeout: 10000 });
+    }
+
+    // "All" tab
+    await page.locator('.tasks-filter-btn', { hasText: 'All' }).click();
+    await expect(page.getByText('Still Open')).toBeVisible({ timeout: 5000 });
+
+    // "Open" tab
+    await page.locator('.tasks-filter-btn', { hasText: 'Open' }).click();
+    await expect(page.getByText('Still Open')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Already Done')).not.toBeVisible({ timeout: 3000 });
+
+    // "Done" tab
+    await page.locator('.tasks-filter-btn', { hasText: 'Done' }).click();
+    await expect(page.getByText('Already Done')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Still Open')).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.50.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "jest": "^30.2.0",
@@ -1837,6 +1838,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5183,6 +5200,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "test": "jest"
+    "test": "jest",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "lucide-react": "^0.542.0",
@@ -15,6 +18,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "jest": "^30.2.0",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,29 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e/tests',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'html' : 'list',
+
+  globalSetup: './e2e/global-setup.js',
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    locale: 'en-US',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'Desktop Chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds **46 Playwright E2E tests** across 7 spec files (auth, calendar, tasks, shopping, dashboard, settings, admin)
- Tests run on **Desktop Chrome** and **Mobile Chrome (Pixel 7)** — both viewports fully covered
- Cookie-based auth fixtures avoid login rate limits (1 registration per worker, zero login API calls)
- API seed helpers create test data (events, tasks, shopping lists) per test for isolation
- Global setup bypasses SetupWizard on fresh databases
- CI workflow builds the full stack via Docker Compose and runs tests on push/PR to main

## Test coverage
| Spec | Tests | What's covered |
|---|---|---|
| auth | 4 | Register, login, logout, invalid credentials |
| calendar | 4 | Month view, create/delete event, month navigation |
| tasks | 4 | Quick-add, toggle open→done, delete, filter tabs |
| shopping | 4 | Create list, add item, toggle check, delete list |
| dashboard | 2 | Greeting with username, quick-action navigation |
| settings | 2 | Account tab visibility, theme switching |
| admin | 3 | Member list, invite section, audit log |

## Test plan
- [x] `npx playwright test` — 46/46 passing locally (Desktop + Mobile)
- [x] Clean DB reset and full re-run verified
- [ ] CI workflow runs on this PR

Closes #42