### PR TITLE
fix: clear #auth URL hash after login

### DIFF
--- a/frontend/contexts/AppContext.js
+++ b/frontend/contexts/AppContext.js
@@ -171,6 +171,11 @@ function AppOrchestrator({ children }) {
   useEffect(() => {
     if (!loggedIn || demoMode) return;
 
+    // Clear landing page hash fragment (e.g. #auth) after login
+    if (window.location.hash) {
+      history.replaceState(null, '', window.location.pathname);
+    }
+
     (async () => {
       setLoading(true);
       const { ok: meOk, data: meData } = await api.apiGetMe();


### PR DESCRIPTION
## Summary

The landing page "Sign in" link uses `href="#auth"` to scroll to the auth form. After login, the hash fragment stayed in the URL permanently. Now cleared via `history.replaceState` in the bootstrap effect.

Closes #97

## Test plan

- [ ] Login via landing page, verify URL shows `/` not `/#auth`
- [ ] Direct login (no hash), verify no side effects
- [ ] E2E tests pass