### PR TITLE
chore: bump VERSION to 1.0.0

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,7 +2,7 @@ import os
 
 from app.security import JWT_EXPIRE_HOURS
 
-VERSION = "0.9.0"
+VERSION = "1.0.0"
 
 COOKIE_NAME = "tribu_token"
 COOKIE_MAX_AGE = JWT_EXPIRE_HOURS * 3600


### PR DESCRIPTION
## Summary

Update the hardcoded `VERSION` string in `backend/app/core/config.py` from `0.9.0` to `1.0.0`. This is what the Settings > About page displays.

## Test plan

- [ ] Settings page shows "Version: v1.0.0"