### PR TITLE
fix: Morning Mist glass effect too heavy on cards

### DIFF
--- a/frontend/components/settings/AccountTab.js
+++ b/frontend/components/settings/AccountTab.js
@@ -11,7 +11,7 @@ const THEME_DESCS = {
   de: { light: 'Warm und einladend', dark: 'Dezent und dunkel', 'midnight-glass': 'Glassmorphism, tiefes Violett' },
 };
 const THEME_PREVIEWS = {
-  light: { bg: '#f8f6f3', surface: '#ffffff', accent: '#7c3aed' },
+  light: { bg: '#f0ecf8', surface: '#faf9fd', accent: '#7c3aed' },
   dark: { bg: '#0f172a', surface: '#1e293b', accent: '#7c3aed' },
   'midnight-glass': { bg: '#06080f', surface: '#111628', accent: '#7c3aed' },
 };

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -102,7 +102,7 @@
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   border: 1px solid rgba(0, 0, 0, 0.07);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 12px -2px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.8) inset, 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 12px -2px rgba(0, 0, 0, 0.06);
 }
 
 [data-theme="light"] .glow-purple { box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04), 0 8px 32px -8px rgba(124, 58, 237, 0.1); }
@@ -267,7 +267,7 @@
 [data-theme="light"] .welcome-avatar::after { border-color: #ffffff; }
 
 [data-theme="light"] .bottom-nav {
-  background: rgba(248, 246, 243, 0.92);
+  background: rgba(240, 236, 248, 0.92);
   border: 1px solid rgba(0, 0, 0, 0.06);
   box-shadow: 0 -2px 20px -4px rgba(0, 0, 0, 0.08);
 }

--- a/frontend/themes/light.json
+++ b/frontend/themes/light.json
@@ -6,7 +6,7 @@
   "description": "Warm and inviting",
   "dataTheme": "light",
   "tokens": {
-    "bg": "#f8f6f3",
+    "bg": "#f0ecf8",
     "surface": "#ffffff",
     "text": "#1a1520",
     "muted": "#9b93a8",


### PR DESCRIPTION
## Summary

Redesign the Morning Mist light theme glass effect to eliminate the washed-out/milky card appearance.

**Background:**
- Tinted lavender (#f0ecf8) so blur reveals actual color instead of white-on-white
- Mesh gradient blobs strengthened (0.18/0.15 -> 0.35/0.30)

**Glass cards:**
- Opacity reduced (0.7 -> 0.55) to let background color show through
- Blur reduced (20px -> 8px) to eliminate milky smear
- Saturate increased (1.1 -> 1.4) to pull mesh color into card surface
- Shine gradient (::before) removed, replaced with 1px inset top-edge shadow
- glass-sm adjusted similarly with matching inset highlight

**Token sync:**
- Bottom-nav, light.json, and AccountTab theme preview updated to match new lavender tokens

## Test plan

- [ ] Cards show subtle color through glass on light theme
- [ ] No washed-out/milky appearance
- [ ] Text readability maintained (WCAG AAA)
- [ ] Theme preview swatch in Settings matches actual theme
- [ ] Bottom nav blends with page background on mobile
- [ ] Dark theme (Velvet Void) unaffected