### PR TITLE
fix: pin Settings and Admin to sidebar bottom, always in mobile overflow

### DIFF
--- a/backend/app/modules/nav_router.py
+++ b/backend/app/modules/nav_router.py
@@ -10,7 +10,7 @@ from app.core.errors import error_detail, UNKNOWN_NAV_KEYS
 
 router = APIRouter(prefix="/nav", tags=["nav"], responses={**AUTH_RESPONSES})
 
-DEFAULT_NAV_ORDER = ["dashboard", "calendar", "shopping", "tasks", "contacts", "notifications", "settings"]
+DEFAULT_NAV_ORDER = ["dashboard", "calendar", "shopping", "tasks", "contacts", "notifications", "settings", "admin"]
 KNOWN_KEYS = {"dashboard", "calendar", "shopping", "tasks", "contacts", "notifications", "settings", "admin"}
 
 

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -103,10 +103,11 @@ export default function AppShell() {
     return items;
   }, [itemRegistry, isAdmin]);
 
-  // Mobile bottom nav: sortable items only, pinned items always in overflow
-  const hasOverflow = orderedItems.length > MAX_BOTTOM_NAV || pinnedItems.length > 0;
-  const visibleItems = hasOverflow ? orderedItems.slice(0, MAX_BOTTOM_NAV - 1) : orderedItems.slice(0, MAX_BOTTOM_NAV);
-  const overflowItems = hasOverflow ? [...orderedItems.slice(MAX_BOTTOM_NAV - 1), ...pinnedItems] : [];
+  // Mobile bottom nav: pinned items (settings/admin) always in overflow
+  const hasOverflow = pinnedItems.length > 0 || orderedItems.length > MAX_BOTTOM_NAV;
+  const maxVisible = hasOverflow ? MAX_BOTTOM_NAV - 1 : MAX_BOTTOM_NAV;
+  const visibleItems = orderedItems.slice(0, maxVisible);
+  const overflowItems = [...orderedItems.slice(maxVisible), ...pinnedItems];
   const activeInOverflow = overflowItems.some((item) => item.key === activeView);
 
   const navigate = useCallback((key) => {

--- a/frontend/components/settings/NavigationTab.js
+++ b/frontend/components/settings/NavigationTab.js
@@ -31,7 +31,7 @@ export default function NavigationTab() {
   }
 
   async function handleSaveNavOrder() {
-    const fullOrder = [...localNavOrder, 'settings', 'admin'];
+    const fullOrder = [...localNavOrder, 'settings', ...(isAdmin ? ['admin'] : [])];
     if (demoMode) {
       setNavOrder(fullOrder);
     } else {

--- a/frontend/e2e/helpers/navigation.js
+++ b/frontend/e2e/helpers/navigation.js
@@ -3,6 +3,9 @@ const MOBILE_ALIASES = {
   Dashboard: 'Home',
 };
 
+// Items pinned to overflow on mobile - skip bottom-nav check
+const ALWAYS_OVERFLOW = new Set(['Settings', 'Admin']);
+
 /**
  * Navigate to a view in the app.
  * On desktop: clicks sidebar .nav-item
@@ -24,14 +27,16 @@ async function navigateTo(page, viewName) {
   // Mobile: resolve alias (e.g. "Dashboard" → "Home")
   const mobileName = MOBILE_ALIASES[viewName] || viewName;
 
-  // Try bottom-nav first
-  const bottomNavItem = page.locator('.bottom-nav-item', { hasText: mobileName });
-  if (await bottomNavItem.isVisible({ timeout: 1000 }).catch(() => false)) {
-    await bottomNavItem.click();
-    return;
+  // Skip bottom-nav check for items that are always in overflow
+  if (!ALWAYS_OVERFLOW.has(viewName)) {
+    const bottomNavItem = page.locator('.bottom-nav-item', { hasText: mobileName });
+    if (await bottomNavItem.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await bottomNavItem.click();
+      return;
+    }
   }
 
-  // Not in bottom nav → open "More" overflow, then click the item
+  // Open "More" overflow, then click the item
   const moreBtn = page.locator('.bottom-nav-item', { hasText: 'More' })
     .or(page.locator('.bottom-nav .bottom-nav-overflow > button'));
   await moreBtn.first().click();


### PR DESCRIPTION
## Summary

Settings and Admin are now pinned to the bottom of the sidebar and always accessible via "More" on mobile. They are no longer sortable in the Navigation settings.

**Sidebar:**
- Settings/Admin render below the flex spacer, always at the bottom
- Separate nav section with no divider clutter

**Mobile:**
- Settings/Admin always in the "More" overflow menu
- Never appear in the visible bottom nav items

**Navigation Settings:**
- Settings/Admin removed from the sortable list
- Automatically re-appended when saving (admin only for admin users)

**Other:**
- Backend DEFAULT_NAV_ORDER synced with frontend (includes 'admin')
- E2E navigation helper skips bottom-nav check for pinned items

## Test plan

- [ ] Settings/Admin appear at sidebar bottom on desktop
- [ ] Settings/Admin always in "More" on mobile
- [ ] Navigation sort in Settings does not show Settings/Admin
- [ ] Non-admin users don't get 'admin' in their saved order
- [ ] E2E tests pass