### PR TITLE
fix: review findings from PR #106

### DIFF
--- a/frontend/components/RewardsView.js
+++ b/frontend/components/RewardsView.js
@@ -28,6 +28,7 @@ export default function RewardsView() {
   const [earnUserId, setEarnUserId] = useState('');
   const [earnAmount, setEarnAmount] = useState(1);
   const [earnNote, setEarnNote] = useState('');
+  const [creatingCurrency, setCreatingCurrency] = useState(false);
 
   const loadAll = useCallback(async () => {
     if (demoMode) return;
@@ -136,12 +137,14 @@ export default function RewardsView() {
           <h3 style={{ marginBottom: 16 }}>{t(messages, 'module.rewards.currency_setup')}</h3>
           <div style={{ display: 'grid', gap: 8 }}>
             {CURRENCY_PRESETS.map(p => (
-              <button key={p.name} className="glass-sm" onClick={async () => {
-                setCurrName(p.name); setCurrIcon(p.icon);
+              <button key={p.name} className="glass-sm" disabled={creatingCurrency} onClick={async () => {
+                if (creatingCurrency) return;
+                setCreatingCurrency(true);
                 const { ok, data } = await api.apiCreateRewardCurrency({ family_id: Number(familyId), name: p.name, icon: p.icon });
+                setCreatingCurrency(false);
                 if (!ok) return toastError(errorText(data?.detail, 'Error', messages));
                 await loadAll();
-              }} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px', border: 'none', cursor: 'pointer', borderRadius: 10, textAlign: 'left' }}>
+              }} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px', border: 'none', cursor: 'pointer', borderRadius: 10, textAlign: 'left', opacity: creatingCurrency ? 0.5 : 1 }}>
                 <p.Icon size={24} style={{ color: p.color, flexShrink: 0 }} />
                 <div>
                   <div style={{ fontWeight: 600, fontSize: '0.95rem' }}>{p.icon} {p.name}</div>

--- a/frontend/components/settings/AccountTab.js
+++ b/frontend/components/settings/AccountTab.js
@@ -76,7 +76,9 @@ export default function AccountTab() {
             value={currentMember?.date_of_birth || ''}
             onChange={async (e) => {
               const val = e.target.value || null;
-              await api.apiSetMemberBirthdate(familyId, me?.user_id, val);
+              if (val && !/^\d{4}-\d{2}-\d{2}$/.test(val)) return;
+              const { ok, data } = await api.apiSetMemberBirthdate(familyId, me?.user_id, val);
+              if (!ok) return toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
               await loadMembers();
             }}
             style={{ maxWidth: 200 }}


### PR DESCRIPTION
## Summary

Post-merge review of #106 found 2 issues:

1. **AccountTab birthdate**: fired API call on partial date input (typing in progress), no error toast on failure. Fixed with regex guard for complete YYYY-MM-DD and ok/error check.

2. **Currency presets**: no double-click protection, concurrent clicks could fire duplicate API calls. Fixed with disabled state + opacity while creating.

Security check passed: birthdate endpoint correctly gates self-update vs admin.

## Test plan

- [ ] Typing a partial date does not fire API call
- [ ] Clearing birthdate works
- [ ] API error shows toast
- [ ] Clicking currency preset disables all buttons while creating
- [ ] E2E tests pass