### PR TITLE
feat: show member birthdays in calendar

### DIFF
--- a/frontend/components/calendar/CalendarHelpers.js
+++ b/frontend/components/calendar/CalendarHelpers.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Repeat, Trash2 } from 'lucide-react';
+import { Cake, Repeat, Trash2 } from 'lucide-react';
 import { prettyDate } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import { getMemberColor } from '../../lib/member-colors';
@@ -151,6 +151,7 @@ export function EventCard({ ev, index, messages, onDelete, members }) {
     <div className="day-event-card" style={{ borderColor: ev.color || getMemberColor(null, index) }}>
       <div style={{ flex: 1 }}>
         <div style={{ fontWeight: 500, fontSize: '0.9rem', display: 'flex', alignItems: 'center', gap: 6 }}>
+          {ev._isBirthday && <Cake size={14} style={{ color: '#f43f5e', flexShrink: 0 }} aria-hidden="true" />}
           {ev.title}
           {ev.is_recurring && <Repeat size={13} style={{ color: 'var(--text-muted)', flexShrink: 0 }} aria-hidden="true" />}
         </div>

--- a/frontend/hooks/useCalendar.js
+++ b/frontend/hooks/useCalendar.js
@@ -97,7 +97,7 @@ export function useCalendar() {
       const startsAt = new Date(viewYear, mo - 1, d, 0, 0, 0).toISOString();
       birthdayEvents.push({
         id: `bday-${m.user_id}-${viewYear}`,
-        title: `🎂 ${m.display_name}` + (age > 0 ? ` (${age})` : ''),
+        title: m.display_name + (age > 0 ? ` (${age})` : ''),
         starts_at: startsAt,
         ends_at: null,
         all_day: true,


### PR DESCRIPTION
## Summary

Family members with a date of birth set now appear as birthday events in the calendar.

- Birthday events generated from member `date_of_birth` with cake emoji, name, and age
- Red color (#f43f5e) for birthday events
- Visible in month view (dots), week view, and day detail
- Year-aware: shows correct age when browsing future/past months
- Cannot be deleted (synthetic events, `_isBirthday` guard on EventCard + deleteEvent)

## Test plan

- [ ] Set a member's birthdate, verify birthday appears in the correct month
- [ ] Navigate to next year, birthday still shows with incremented age
- [ ] Birthday events have red dot in month view
- [ ] Cannot delete a birthday event
- [ ] Members without date_of_birth don't show birthday events
- [ ] E2E tests pass