### PR TITLE
fix: event dates stored and displayed as local time

### DIFF
--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,6 +1,6 @@
 import { CalendarClock, ListChecks, Cake, BarChart3, Users, Calendar, CheckCircle, Plus, CheckSquare, UserPlus, Clock } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
-import { prettyDate, parseUtc } from '../lib/helpers';
+import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { getMemberColor } from '../lib/member-colors';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
@@ -95,7 +95,7 @@ export default function DashboardView() {
             )}
             {summary.next_events?.slice(0, 4).map((ev, i) => (
               <div key={ev.id} className="event-item">
-                <div className="event-time">{parseUtc(ev.starts_at).toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' })}</div>
+                <div className="event-time">{parseDate(ev.starts_at).toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' })}</div>
                 <div className="event-dot" style={{ background: ev.color || getMemberColor(null, i) }} aria-hidden="true" />
                 <div className="event-info">
                   <div className="event-title">{ev.title}</div>

--- a/frontend/components/RewardsView.js
+++ b/frontend/components/RewardsView.js
@@ -4,7 +4,7 @@ import { useApp } from '../contexts/AppContext';
 import { useToast } from '../contexts/ToastContext';
 import { useRewards } from '../hooks/useRewards';
 import { t } from '../lib/i18n';
-import { errorText, parseUtc } from '../lib/helpers';
+import { errorText, parseDate } from '../lib/helpers';
 import * as api from '../lib/api';
 
 const CURRENCY_PRESETS = [
@@ -300,7 +300,7 @@ export default function RewardsView() {
           <button className="btn-ghost" onClick={() => setTab('overview')} style={{ marginBottom: 12, fontSize: '0.82rem' }}>&larr; {t(messages, 'module.rewards.tab_overview')}</button>
           {rw.transactions.map(tx => {
             const memberName = members.find(m => m.user_id === tx.user_id)?.display_name || '?';
-            const date = parseUtc(tx.created_at).toLocaleDateString();
+            const date = parseDate(tx.created_at).toLocaleDateString();
             return (
               <div key={tx.id} className="glass-sm" style={{ display: 'flex', gap: 8, padding: '8px 12px', marginBottom: 4, borderRadius: 8, fontSize: '0.82rem', alignItems: 'center' }}>
                 {tx.kind === 'earn' ? <ArrowUpCircle size={14} style={{ color: 'var(--success)' }} /> : <ArrowDownCircle size={14} style={{ color: 'var(--danger)' }} />}

--- a/frontend/components/calendar/index.js
+++ b/frontend/components/calendar/index.js
@@ -137,10 +137,10 @@ export default function CalendarView() {
                       const picked = new Date(cal.calendarMonth.getFullYear(), cal.calendarMonth.getMonth(), c.day);
                       cal.setSelectedDate(picked);
                       if (!cal.startsAt) {
-                        const local = new Date(picked.getFullYear(), picked.getMonth(), picked.getDate(), 9, 0);
-                        const offset = local.getTimezoneOffset();
-                        const localIso = new Date(local.getTime() - offset * 60000).toISOString().slice(0, 16);
-                        cal.setStartsAt(localIso);
+                        const y = picked.getFullYear();
+                        const m = String(picked.getMonth() + 1).padStart(2, '0');
+                        const d = String(picked.getDate()).padStart(2, '0');
+                        cal.setStartsAt(`${y}-${m}-${d}T09:00`);
                       }
                     }}
                   >

--- a/frontend/hooks/useCalendar.js
+++ b/frontend/hooks/useCalendar.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useApp } from '../contexts/AppContext';
 import { useToast } from '../contexts/ToastContext';
-import { errorText, toIsoOrNull, parseUtc } from '../lib/helpers';
+import { errorText, toIsoOrNull, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { announce } from '../lib/announce';
 import * as api from '../lib/api';
@@ -115,7 +115,7 @@ export function useCalendar() {
     const m = selectedDate.getMonth();
     const d = selectedDate.getDate();
     return allEvents.filter((ev) => {
-      const dt = parseUtc(ev.starts_at);
+      const dt = parseDate(ev.starts_at);
       return dt.getFullYear() === y && dt.getMonth() === m && dt.getDate() === d;
     });
   }, [allEvents, selectedDate]);
@@ -129,7 +129,7 @@ export function useCalendar() {
 
     const dayEvents = {};
     for (const ev of allEvents) {
-      const d = parseUtc(ev.starts_at);
+      const d = parseDate(ev.starts_at);
       if (d.getFullYear() === y && d.getMonth() === m) {
         const day = d.getDate();
         if (!dayEvents[day]) dayEvents[day] = [];
@@ -165,7 +165,7 @@ export function useCalendar() {
     const weekNumber = Math.floor(diffMs / (7 * 24 * 60 * 60 * 1000)) + 1;
 
     const weekEvents = allEvents.filter((ev) => {
-      const dt = parseUtc(ev.starts_at);
+      const dt = parseDate(ev.starts_at);
       return dt >= weekStart && dt < weekEnd;
     });
 
@@ -174,7 +174,7 @@ export function useCalendar() {
       const date = new Date(weekStart);
       date.setDate(weekStart.getDate() + i);
       const dayEvents = allEvents.filter((ev) => {
-        const dt = parseUtc(ev.starts_at);
+        const dt = parseDate(ev.starts_at);
         return dt.getFullYear() === date.getFullYear() && dt.getMonth() === date.getMonth() && dt.getDate() === date.getDate();
       }).sort((a, b) => new Date(a.starts_at) - new Date(b.starts_at));
       days.push({ date, dayEvents });
@@ -210,7 +210,7 @@ export function useCalendar() {
       family_id: Number(familyId), title, description: description || null,
       starts_at: toIsoOrNull(startsAt), ends_at: toIsoOrNull(endsAt), all_day: allDay,
       recurrence: recurrence || null,
-      recurrence_end: recurrenceEnd ? new Date(recurrenceEnd).toISOString() : null,
+      recurrence_end: toIsoOrNull(recurrenceEnd),
       assigned_to: assignedPayload,
       color: color || null,
       category: category || null,
@@ -221,7 +221,7 @@ export function useCalendar() {
       setSummary((prev) => ({
         ...prev,
         next_events: [...(prev.next_events || []), newEvent]
-          .filter((ev) => parseUtc(ev.starts_at) >= new Date())
+          .filter((ev) => parseDate(ev.starts_at) >= new Date())
           .sort((a, b) => new Date(a.starts_at) - new Date(b.starts_at))
           .slice(0, 5),
       }));

--- a/frontend/lib/helpers.js
+++ b/frontend/lib/helpers.js
@@ -1,21 +1,27 @@
 export function toIsoOrNull(localValue) {
   if (!localValue) return null;
-  return new Date(localValue).toISOString();
+  // datetime-local inputs return "YYYY-MM-DDTHH:mm" in local time.
+  // Send as-is without UTC conversion - the backend stores naive local time.
+  const s = String(localValue);
+  // Already has seconds or Z? Return as-is.
+  if (s.length > 16) return s;
+  // Add seconds for consistency
+  return s + ':00';
 }
 
 /**
- * Parse a date string from the API as UTC.
- * The backend stores naive UTC datetimes without a Z suffix.
+ * Parse a datetime string from the API.
+ * Backend stores naive local time (no timezone).
+ * Browsers interpret strings without Z as local time, which is correct here.
  */
-export function parseUtc(value) {
+export function parseDate(value) {
   if (!value) return null;
-  const s = String(value);
-  return new Date(s.endsWith('Z') || s.includes('+') ? s : s + 'Z');
+  return new Date(String(value));
 }
 
 export function prettyDate(value, lang = 'en') {
   if (!value) return '-';
-  const d = parseUtc(value);
+  const d = parseDate(value);
   const locale = lang === 'de' ? 'de-DE' : 'en-US';
   return d.toLocaleString(locale, {
     weekday: 'short', day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',


### PR DESCRIPTION
## Summary

Events were being stored with wrong dates/times due to UTC conversion in the frontend.

**The bug**: `toIsoOrNull()` called `new Date(value).toISOString()` which converted local time to UTC. The backend stored these naive UTC values, but the frontend displayed them as local time, causing 1-2 hour offsets. Additionally, the day-click date prefill used a broken timezone offset calculation that could cause multi-day discrepancies.

**The fix**: Store and display as local time throughout.
- `toIsoOrNull()`: sends datetime-local value as-is (no UTC conversion)
- `parseDate()`: replaces `parseUtc()`, no Z appending
- Day-click prefill: builds string directly instead of offset hack
- `recurrence_end`: uses `toIsoOrNull` consistently

**Note**: Existing events in the DB may have incorrect timestamps from the old UTC conversion. Dennis may need to re-enter affected events.

Closes the timezone display issue.

## Test plan

- [ ] Create event at 11:30, verify it shows as 11:30
- [ ] Click a calendar day, verify prefilled date is correct
- [ ] Dashboard event times match the entered time
- [ ] E2E tests pass