### PR TITLE
feat: show assigned members on dashboard upcoming events

### DIFF
--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -107,7 +107,7 @@ export default function DashboardView() {
                   <div className="event-meta">
                     {prettyDate(ev.starts_at, lang, timeFormat)}
                     {ev.assigned_to && ev.assigned_to !== 'all' && Array.isArray(ev.assigned_to) && (() => {
-                      const names = ev.assigned_to.map(uid => members.find(m => m.user_id === uid)?.display_name).filter(Boolean);
+                      const names = ev.assigned_to.map(uid => members.find(m => m.user_id === Number(uid))?.display_name).filter(Boolean);
                       return names.length > 0 ? <span style={{ marginLeft: 6, color: 'var(--amethyst)' }}>{names.join(', ')}</span> : null;
                     })()}
                     {ev.assigned_to === 'all' && <span style={{ marginLeft: 6, color: 'var(--amethyst)' }}>{t(messages, 'module.calendar.assign_all')}</span>}


### PR DESCRIPTION
## Summary

Display assigned member names next to event date/time in the dashboard upcoming events card. Names shown in amethyst. "Alle" for whole-family events.

## Test plan

- [ ] Events with assigned members show names
- [ ] "all" assignment shows "Alle"
- [ ] Unassigned events show no extra text
- [ ] E2E tests pass