### PR TITLE
fix: use member color badges for event assignees on dashboard

### DIFF
--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -3,6 +3,7 @@ import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { getMemberColor } from '../lib/member-colors';
+import { AssignedBadges } from './calendar/CalendarHelpers';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
 
 function getGreeting(messages) {
@@ -104,13 +105,9 @@ export default function DashboardView() {
                 <div className="event-dot" style={{ background: ev.color || getMemberColor(null, i) }} aria-hidden="true" />
                 <div className="event-info">
                   <div className="event-title">{ev.title}</div>
-                  <div className="event-meta">
+                  <div className="event-meta" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                     {prettyDate(ev.starts_at, lang, timeFormat)}
-                    {ev.assigned_to && ev.assigned_to !== 'all' && Array.isArray(ev.assigned_to) && (() => {
-                      const names = ev.assigned_to.map(uid => members.find(m => m.user_id === Number(uid))?.display_name).filter(Boolean);
-                      return names.length > 0 ? <span style={{ marginLeft: 6, color: 'var(--amethyst)' }}>{names.join(', ')}</span> : null;
-                    })()}
-                    {ev.assigned_to === 'all' && <span style={{ marginLeft: 6, color: 'var(--amethyst)' }}>{t(messages, 'module.calendar.assign_all')}</span>}
+                    <AssignedBadges assignedTo={ev.assigned_to} members={members} />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Replace plain amethyst text names with the existing `AssignedBadges` component on dashboard upcoming events. Now shows colored circles with member initials, consistent with calendar event cards.

## Test plan

- [ ] Assigned events show colored initial badges
- [ ] Unassigned events show no badges
- [ ] Colors match member's chosen color