### PR TITLE
feat: admin can set member avatars

### DIFF
--- a/backend/app/modules/families_router.py
+++ b/backend/app/modules/families_router.py
@@ -7,7 +7,7 @@ from app.core.deps import current_user, ensure_family_admin, ensure_family_membe
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import AuditLog, Family, Membership, User
-from app.schemas import AUTH_RESPONSES, ADMIN_RESPONSES, CONFLICT_RESPONSE, NOT_FOUND_RESPONSE, ErrorResponse, AuditLogEntry, CreateMemberRequest, CreateMemberResponse, FamilyMemberResponse, FamilySummary, MemberAdultUpdate, MemberBirthdateUpdate, MemberColorUpdate, MemberRoleUpdate, PaginatedAuditLog, ResetPasswordResponse
+from app.schemas import AUTH_RESPONSES, ADMIN_RESPONSES, CONFLICT_RESPONSE, NOT_FOUND_RESPONSE, ErrorResponse, AuditLogEntry, CreateMemberRequest, CreateMemberResponse, FamilyMemberResponse, FamilySummary, MemberAdultUpdate, MemberBirthdateUpdate, MemberColorUpdate, MemberRoleUpdate, PaginatedAuditLog, ProfileImageUpdate, ResetPasswordResponse
 from app.security import generate_temp_password, hash_password
 from app.core.errors import error_detail, NOT_A_MEMBER, COLOR_NOT_ALLOWED, COLOR_ALREADY_TAKEN, INVALID_ROLE, ONLY_ADULTS_ADMIN, EMAIL_ALREADY_EXISTS, MEMBER_NOT_FOUND, CANNOT_CHANGE_OWN_ADULT, CANNOT_DEMOTE_SELF, CANNOT_RESET_OWN_PASSWORD, USER_NOT_FOUND, CANNOT_REMOVE_SELF
 
@@ -271,7 +271,7 @@ def update_member_birthdate(
 def update_member_avatar(
     family_id: int,
     target_user_id: int,
-    payload: dict,
+    payload: ProfileImageUpdate,
     user: User = Depends(current_user),
     db: Session = Depends(get_db),
     _scope=require_scope("families:write"),
@@ -284,9 +284,14 @@ def update_member_avatar(
     if not membership:
         raise HTTPException(status_code=404, detail=error_detail(MEMBER_NOT_FOUND))
     target_user = db.query(User).filter(User.id == target_user_id).first()
-    target_user.profile_image = payload.get("profile_image")
+    if not target_user:
+        raise HTTPException(status_code=404, detail=error_detail(USER_NOT_FOUND))
+    target_user.profile_image = payload.profile_image
     db.commit()
-    cache.invalidate(f"tribu:members:{family_id}")
+    # Invalidate cache for all families this user belongs to
+    family_ids = [m.family_id for m in db.query(Membership).filter(Membership.user_id == target_user_id).all()]
+    for fid in family_ids:
+        cache.invalidate(f"tribu:members:{fid}")
     return {"status": "ok"}
 
 

--- a/backend/app/modules/families_router.py
+++ b/backend/app/modules/families_router.py
@@ -262,6 +262,35 @@ def update_member_birthdate(
 
 
 @router.patch(
+    "/{family_id}/members/{target_user_id}/avatar",
+    summary="Set member profile image",
+    description="Upload a profile image for a family member. Admin role required. Scope: `families:write`.",
+    response_description="Avatar updated",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def update_member_avatar(
+    family_id: int,
+    target_user_id: int,
+    payload: dict,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("families:write"),
+):
+    ensure_family_admin(db, user.id, family_id)
+    membership = db.query(Membership).filter(
+        Membership.family_id == family_id,
+        Membership.user_id == target_user_id,
+    ).first()
+    if not membership:
+        raise HTTPException(status_code=404, detail=error_detail(MEMBER_NOT_FOUND))
+    target_user = db.query(User).filter(User.id == target_user_id).first()
+    target_user.profile_image = payload.get("profile_image")
+    db.commit()
+    cache.invalidate(f"tribu:members:{family_id}")
+    return {"status": "ok"}
+
+
+@router.patch(
     "/{family_id}/members/{target_user_id}/role",
     summary="Update member role",
     description="Change a member's role to admin or member. Only adults can be promoted to admin. Admin role required. Scope: `families:write`.",

--- a/frontend/components/admin/index.js
+++ b/frontend/components/admin/index.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMemo } from 'react';
-import { Plus, Check, Copy, X, KeyRound, Shield } from 'lucide-react';
+import { Plus, Check, Copy, X, KeyRound, Shield, ImageIcon } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import MemberAvatar from '../MemberAvatar';
 import { useToast } from '../../contexts/ToastContext';
@@ -54,6 +54,18 @@ export default function AdminView() {
       toastInfo(t(messages, 'admin_demoted'));
     }
     await loadMembers();
+  }
+
+  async function handleSetAvatar(userId, e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = async () => {
+      const { ok, data } = await api.apiSetMemberAvatar(familyId, userId, reader.result);
+      if (!ok) return toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
+      await loadMembers();
+    };
+    reader.readAsDataURL(file);
   }
 
   async function handleSetBirthdate(userId, dateOfBirth) {
@@ -187,7 +199,7 @@ export default function AdminView() {
         </div>
       )}
 
-      <MemberGroups members={members} me={me} messages={messages} onSetAdult={handleSetAdult} onSetRole={handleSetRole} onResetPassword={handleResetPassword} onRemoveMember={handleRemoveMember} onSetBirthdate={handleSetBirthdate} />
+      <MemberGroups members={members} me={me} messages={messages} onSetAdult={handleSetAdult} onSetRole={handleSetRole} onResetPassword={handleResetPassword} onRemoveMember={handleRemoveMember} onSetBirthdate={handleSetBirthdate} onSetAvatar={handleSetAvatar} />
 
       {/* Add Member */}
       {!demoMode && (
@@ -272,7 +284,7 @@ function getAge(dateOfBirth) {
   return age;
 }
 
-function MemberGroups({ members, me, messages, onSetAdult, onSetRole, onResetPassword, onRemoveMember, onSetBirthdate }) {
+function MemberGroups({ members, me, messages, onSetAdult, onSetRole, onResetPassword, onRemoveMember, onSetBirthdate, onSetAvatar }) {
   const { adults, children } = useMemo(() => {
     const roleRank = (r) => r === 'owner' ? 0 : r === 'admin' ? 1 : 2;
     const sorted = [...members].sort((a, b) => {
@@ -315,6 +327,10 @@ function MemberGroups({ members, me, messages, onSetAdult, onSetRole, onResetPas
               value={m.date_of_birth || ''}
               onChange={(e) => onSetBirthdate(m.user_id, e.target.value || null)}
               aria-label={t(messages, 'birthdate')} />
+            <label className="btn-ghost" style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              <ImageIcon size={13} /> {t(messages, 'set_avatar')}
+              <input type="file" accept="image/*" style={{ display: 'none' }} onChange={(e) => onSetAvatar(m.user_id, e)} />
+            </label>
             <button className="btn-ghost" onClick={() => onResetPassword(m.user_id)}><KeyRound size={13} /> {t(messages, 'reset_password')}</button>
             <button className="btn-ghost btn-outline-danger" onClick={() => onRemoveMember(m.user_id)}><X size={13} /> {t(messages, 'remove_member')}</button>
           </>

--- a/frontend/components/admin/index.js
+++ b/frontend/components/admin/index.js
@@ -59,9 +59,14 @@ export default function AdminView() {
   async function handleSetAvatar(userId, e) {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (file.size > 2 * 1024 * 1024) {
+      return toastError(t(messages, 'avatar_too_large'));
+    }
+    const input = e.target;
     const reader = new FileReader();
     reader.onload = async () => {
       const { ok, data } = await api.apiSetMemberAvatar(familyId, userId, reader.result);
+      input.value = '';
       if (!ok) return toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
       await loadMembers();
     };

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -416,6 +416,7 @@
   "years_old": "Jahre alt",
   "birthdate": "Geburtsdatum",
   "set_avatar": "Avatar",
+  "avatar_too_large": "Bild zu groß (max. 2 MB)",
   "time_format": "Zeitformat",
   "search.title": "Suche",
   "search.placeholder": "Termine, Aufgaben, Kontakte suchen...",

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -415,6 +415,7 @@
   "member_group_children": "Kinder",
   "years_old": "Jahre alt",
   "birthdate": "Geburtsdatum",
+  "set_avatar": "Avatar",
   "time_format": "Zeitformat",
   "search.title": "Suche",
   "search.placeholder": "Termine, Aufgaben, Kontakte suchen...",

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -415,6 +415,7 @@
   "member_group_children": "Children",
   "years_old": "years old",
   "birthdate": "Date of birth",
+  "set_avatar": "Avatar",
   "time_format": "Time format",
   "search.title": "Search",
   "search.placeholder": "Search events, tasks, contacts...",

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -416,6 +416,7 @@
   "years_old": "years old",
   "birthdate": "Date of birth",
   "set_avatar": "Avatar",
+  "avatar_too_large": "Image too large (max 2 MB)",
   "time_format": "Time format",
   "search.title": "Search",
   "search.placeholder": "Search events, tasks, contacts...",

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -429,6 +429,10 @@ export function apiSearch(familyId, query) {
 }
 
 // Rewards
+export function apiSetMemberAvatar(familyId, userId, profileImage) {
+  return patch(`/families/${familyId}/members/${userId}/avatar`, { profile_image: profileImage });
+}
+
 export function apiSetMemberBirthdate(familyId, userId, dateOfBirth) {
   return patch(`/families/${familyId}/members/${userId}/birthdate`, { date_of_birth: dateOfBirth });
 }


### PR DESCRIPTION
## Summary

Admins can now upload profile images for family members from the member management panel.

**Backend:**
- PATCH /families/{id}/members/{uid}/avatar (admin only)
- Uses typed ProfileImageUpdate schema
- Null-safe user lookup
- Invalidates member cache for all families the target user belongs to

**Frontend:**
- Lucide ImageIcon button with hidden file input
- 2 MB file size limit with localized error message
- File input resets after upload for re-selection
- i18n: EN + DE

## Test plan

- [ ] Admin can upload avatar for another member
- [ ] Image shows immediately after upload
- [ ] Files over 2 MB show error toast
- [ ] Re-uploading same file works
- [ ] E2E tests pass