### PR TITLE
Remove dead code (ruff + vulture + knip)

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,4 +1,4 @@
-from datetime import UTC, date, datetime
+from datetime import UTC, date
 
 from app.core.utils import utcnow
 from typing import Optional

--- a/backend/app/core/ics_utils.py
+++ b/backend/app/core/ics_utils.py
@@ -4,7 +4,7 @@ from datetime import datetime, date, timedelta
 
 from app.core.utils import utcnow
 
-from icalendar import Calendar, Event, vDate, vDatetime, vRecur
+from icalendar import Calendar, Event
 
 RECURRENCE_MAP = {
     "daily": "DAILY",

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 
 from app.core.utils import utcnow
 

--- a/backend/app/core/ws_manager.py
+++ b/backend/app/core/ws_manager.py
@@ -2,7 +2,7 @@
 
 import logging
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from starlette.websockets import WebSocket, WebSocketState
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,13 +8,12 @@ from slowapi.extension import _rate_limit_exceeded_handler
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 
-import os
 
 from app.core.deps import current_user
 from app.core.scopes import require_scope, SCOPE_DESCRIPTIONS
 from app.core.errors import error_detail, EMAIL_ALREADY_EXISTS, INVALID_CREDENTIALS, OLD_PASSWORD_INCORRECT, LAST_ADMIN, MEMBER_NOT_FOUND, INVALID_CONFIRMATION
 from app.database import get_db, SessionLocal
-from app.models import AuditLog, CalendarEvent, Family, Membership, ShoppingItem, ShoppingList, SystemSetting, Task, User
+from app.models import AuditLog, CalendarEvent, Family, Membership, ShoppingList, SystemSetting, Task, User
 from app.modules.birthdays_router import router as birthdays_router
 from app.modules.calendar_router import router as calendar_router
 from app.modules.dashboard_router import router as dashboard_router

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 
 from app.core.utils import utcnow
 

--- a/backend/app/modules/backup_router.py
+++ b/backend/app/modules/backup_router.py
@@ -1,6 +1,4 @@
-import json
 import os
-from datetime import datetime
 
 from app.core.utils import utcnow
 
@@ -13,7 +11,7 @@ from app.core.deps import current_user
 from app.core.scheduler import configure_backup_schedule
 from app.database import get_db
 from app.models import Membership, SystemSetting, User
-from app.schemas import ADMIN_RESPONSES, NOT_FOUND_RESPONSE, ErrorResponse, BackupConfigResponse, BackupConfigUpdate, BackupEntry, BackupSchedule
+from app.schemas import ADMIN_RESPONSES, NOT_FOUND_RESPONSE, BackupConfigResponse, BackupConfigUpdate, BackupEntry
 from app.core.errors import error_detail, ADMIN_REQUIRED, BACKUP_NOT_FOUND, BACKUP_FAILED
 
 router = APIRouter(prefix="/admin/backup", tags=["backup"], responses={**ADMIN_RESPONSES})

--- a/backend/app/modules/birthdays_router.py
+++ b/backend/app/modules/birthdays_router.py
@@ -6,7 +6,7 @@ from app.core.deps import current_user, ensure_family_membership
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import FamilyBirthday, User
-from app.schemas import AUTH_RESPONSES, CRUD_RESPONSES, ErrorResponse, BirthdayCreate, BirthdayUpdate, BirthdayResponse
+from app.schemas import AUTH_RESPONSES, CRUD_RESPONSES, BirthdayCreate, BirthdayUpdate, BirthdayResponse
 from app.core.errors import error_detail, BIRTHDAY_NOT_FOUND, INVALID_MONTH, INVALID_DAY
 
 router = APIRouter(prefix="/birthdays", tags=["birthdays"], responses={**AUTH_RESPONSES})

--- a/backend/app/modules/calendar_router.py
+++ b/backend/app/modules/calendar_router.py
@@ -12,7 +12,7 @@ from app.core.recurrence import VALID_RECURRENCES, expand_event
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import CalendarEvent, Membership, Notification, User
-from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, ErrorResponse, CalendarEventCreate, CalendarEventResponse, CalendarEventUpdate, CalendarIcsImport, PaginatedCalendarEvents
+from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, CalendarEventCreate, CalendarEventResponse, CalendarEventUpdate, CalendarIcsImport, PaginatedCalendarEvents
 from app.core.errors import error_detail, EVENT_NOT_FOUND, END_BEFORE_START, INVALID_RECURRENCE
 
 router = APIRouter(prefix="/calendar", tags=["calendar"], responses={**AUTH_RESPONSES})

--- a/backend/app/modules/contacts_router.py
+++ b/backend/app/modules/contacts_router.py
@@ -11,7 +11,7 @@ from app.core.scopes import require_scope
 from app.core.vcf_utils import contacts_to_vcf
 from app.database import get_db
 from app.models import Contact, FamilyBirthday, User
-from app.schemas import AUTH_RESPONSES, CRUD_RESPONSES, ErrorResponse, ContactCreate, ContactResponse, ContactUpdate, ContactsCsvImport
+from app.schemas import AUTH_RESPONSES, CRUD_RESPONSES, ContactCreate, ContactResponse, ContactUpdate, ContactsCsvImport
 from app.core.errors import error_detail, CONTACT_NOT_FOUND, CSV_MISSING_COLUMN
 
 router = APIRouter(prefix="/contacts", tags=["contacts"], responses={**AUTH_RESPONSES})

--- a/backend/app/modules/dashboard_router.py
+++ b/backend/app/modules/dashboard_router.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from app.core.utils import utcnow
 
@@ -11,7 +11,7 @@ from app.core.recurrence import expand_event
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import CalendarEvent, FamilyBirthday, User
-from app.schemas import AUTH_RESPONSES, ErrorResponse, CalendarEventResponse, DashboardSummary, UpcomingBirthday
+from app.schemas import AUTH_RESPONSES, CalendarEventResponse, DashboardSummary
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"], responses={**AUTH_RESPONSES})
 

--- a/backend/app/modules/families_router.py
+++ b/backend/app/modules/families_router.py
@@ -6,8 +6,8 @@ from app.core import cache
 from app.core.deps import current_user, ensure_family_admin, ensure_family_membership
 from app.core.scopes import require_scope
 from app.database import get_db
-from app.models import AuditLog, Family, Membership, User
-from app.schemas import AUTH_RESPONSES, ADMIN_RESPONSES, CONFLICT_RESPONSE, NOT_FOUND_RESPONSE, ErrorResponse, AuditLogEntry, CreateMemberRequest, CreateMemberResponse, FamilyMemberResponse, FamilySummary, MemberAdultUpdate, MemberBirthdateUpdate, MemberColorUpdate, MemberRoleUpdate, PaginatedAuditLog, ProfileImageUpdate, ResetPasswordResponse
+from app.models import AuditLog, Membership, User
+from app.schemas import AUTH_RESPONSES, CONFLICT_RESPONSE, NOT_FOUND_RESPONSE, AuditLogEntry, CreateMemberRequest, CreateMemberResponse, FamilyMemberResponse, FamilySummary, MemberAdultUpdate, MemberBirthdateUpdate, MemberColorUpdate, MemberRoleUpdate, PaginatedAuditLog, ProfileImageUpdate, ResetPasswordResponse
 from app.security import generate_temp_password, hash_password
 from app.core.errors import error_detail, NOT_A_MEMBER, COLOR_NOT_ALLOWED, COLOR_ALREADY_TAKEN, INVALID_ROLE, ONLY_ADULTS_ADMIN, EMAIL_ALREADY_EXISTS, MEMBER_NOT_FOUND, CANNOT_CHANGE_OWN_ADULT, CANNOT_DEMOTE_SELF, CANNOT_RESET_OWN_PASSWORD, USER_NOT_FOUND, CANNOT_REMOVE_SELF
 

--- a/backend/app/modules/invitations_router.py
+++ b/backend/app/modules/invitations_router.py
@@ -1,6 +1,6 @@
 import os
 import secrets
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from app.core.utils import utcnow
 
@@ -17,8 +17,7 @@ from app.models import (
     AuditLog, Family, FamilyInvitation, Membership, SystemSetting, User,
 )
 from app.schemas import (
-    AUTH_RESPONSES, ADMIN_RESPONSES, NOT_FOUND_RESPONSE, ErrorResponse,
-    BaseUrlUpdate, InvitationCreate, InvitationResponse,
+    AUTH_RESPONSES, NOT_FOUND_RESPONSE, BaseUrlUpdate, InvitationCreate, InvitationResponse,
     InviteInfoResponse, RegisterWithInviteRequest,
 )
 from app.security import create_access_token, hash_password

--- a/backend/app/modules/nav_router.py
+++ b/backend/app/modules/nav_router.py
@@ -5,7 +5,7 @@ from app.core import cache
 from app.core.deps import current_user
 from app.database import get_db
 from app.models import User, UserNavOrder
-from app.schemas import AUTH_RESPONSES, ErrorResponse, NavOrderResponse, NavOrderUpdate
+from app.schemas import AUTH_RESPONSES, NavOrderResponse, NavOrderUpdate
 from app.core.errors import error_detail, UNKNOWN_NAV_KEYS
 
 router = APIRouter(prefix="/nav", tags=["nav"], responses={**AUTH_RESPONSES})

--- a/backend/app/modules/notifications_router.py
+++ b/backend/app/modules/notifications_router.py
@@ -1,6 +1,4 @@
 import asyncio
-import json
-from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
@@ -11,7 +9,7 @@ from app.core.deps import current_user
 from app.core.push import get_vapid_public_key
 from app.database import get_db
 from app.models import Notification, NotificationPreference, PushSubscription, User
-from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, ErrorResponse, NotificationPreferenceResponse, NotificationPreferenceUpdate, NotificationResponse, PushSubscriptionCreate, PushUnsubscribe
+from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, NotificationPreferenceResponse, NotificationPreferenceUpdate, NotificationResponse, PushSubscriptionCreate, PushUnsubscribe
 from app.core.errors import error_detail, NOTIFICATION_NOT_FOUND
 
 router = APIRouter(prefix="/notifications", tags=["notifications"], responses={**AUTH_RESPONSES})

--- a/backend/app/modules/rewards_router.py
+++ b/backend/app/modules/rewards_router.py
@@ -38,7 +38,6 @@ def _get_currency_or_404(db: Session, family_id: int) -> RewardCurrency:
 
 def _compute_balance(db: Session, family_id: int, user_id: int, include_pending_redeems: bool = False) -> int:
     """Compute token balance. If include_pending_redeems=True, also subtract pending redemptions."""
-    statuses = ["confirmed"]
     if include_pending_redeems:
         # Include pending redeems so they count against available balance
         result = db.query(

--- a/backend/app/modules/setup_router.py
+++ b/backend/app/modules/setup_router.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.core.backup import restore_backup, validate_backup
 from app.database import get_db, engine
 from app.models import User
-from app.schemas import CONFLICT_RESPONSE, ErrorResponse, SetupStatusResponse, RestoreResponse
+from app.schemas import CONFLICT_RESPONSE, SetupStatusResponse, RestoreResponse
 from app.core.errors import error_detail, SETUP_ALREADY_COMPLETED, INVALID_FILE_FORMAT, RESTORE_IN_PROGRESS, RESTORE_FAILED
 
 router = APIRouter(prefix="/setup", tags=["setup"])

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 
 from app.core.utils import utcnow
 
@@ -20,7 +19,6 @@ from app.core.ws_broadcast import (
 from app.schemas import (
     AUTH_RESPONSES,
     NOT_FOUND_RESPONSE,
-    ErrorResponse,
     ShoppingItemCreate,
     ShoppingItemResponse,
     ShoppingItemUpdate,

--- a/backend/app/modules/tasks_router.py
+++ b/backend/app/modules/tasks_router.py
@@ -11,7 +11,7 @@ from app.core.deps import current_user, ensure_adult, ensure_family_membership, 
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import Membership, Task, User
-from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, ErrorResponse, PaginatedTasks, TaskCreate, TaskResponse, TaskUpdate
+from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, PaginatedTasks, TaskCreate, TaskResponse, TaskUpdate
 from app.core.errors import error_detail, TASK_NOT_FOUND, INVALID_STATUS, INVALID_PRIORITY, INVALID_RECURRENCE, ASSIGNEE_NOT_FAMILY_MEMBER, ADULT_REQUIRED
 
 router = APIRouter(prefix="/tasks", tags=["tasks"], responses={**AUTH_RESPONSES})

--- a/backend/app/modules/tokens_router.py
+++ b/backend/app/modules/tokens_router.py
@@ -5,7 +5,7 @@ from app.core.deps import current_user
 from app.core.scopes import VALID_SCOPES, require_scope
 from app.database import get_db
 from app.models import Membership, PersonalAccessToken, User
-from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, ErrorResponse, PATCreate, PATCreatedResponse, PATResponse
+from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, PATCreate, PATCreatedResponse, PATResponse
 from app.core.errors import error_detail, ADULT_REQUIRED, INVALID_SCOPES, TOKEN_LIMIT_REACHED, API_TOKEN_NOT_FOUND, API_TOKEN_NO_ACCESS
 from app.security import generate_pat
 

--- a/backend/tests/test_ics_utils.py
+++ b/backend/tests/test_ics_utils.py
@@ -1,9 +1,8 @@
 """Tests for ICS import/export utilities."""
 
-from datetime import datetime, date
+from datetime import datetime
 from types import SimpleNamespace
 
-import pytest
 
 from app.core.ics_utils import events_to_ics, ics_to_event_dicts
 

--- a/backend/tests/test_recurrence.py
+++ b/backend/tests/test_recurrence.py
@@ -3,7 +3,6 @@
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
-import pytest
 
 from app.core.recurrence import _next_occurrence, expand_event
 

--- a/frontend/e2e/helpers/auth.js
+++ b/frontend/e2e/helpers/auth.js
@@ -15,33 +15,4 @@ function createTestUser() {
   };
 }
 
-/**
- * Register & log in a test user via API, then navigate to the dashboard.
- * Uses page.request so the auth cookie lands in the browser context.
- */
-async function loginAsUser(page, user) {
-  const res = await page.request.post('/api/auth/register', {
-    data: {
-      email: user.email,
-      password: user.password,
-      display_name: user.displayName,
-      family_name: user.familyName,
-    },
-  });
-
-  if (!res.ok()) {
-    // User might already exist — try login instead
-    const loginRes = await page.request.post('/api/auth/login', {
-      data: { email: user.email, password: user.password },
-    });
-    if (!loginRes.ok()) {
-      throw new Error(`Auth failed for ${user.email}: ${loginRes.status()}`);
-    }
-  }
-
-  await page.goto('/');
-  await page.locator('#main-content').waitFor({ timeout: 15000 });
-  await page.waitForTimeout(500);
-}
-
-module.exports = { createTestUser, loginAsUser };
+module.exports = { createTestUser };

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -439,15 +439,11 @@ export function apiSetMemberBirthdate(familyId, userId, dateOfBirth) {
 
 export function apiGetRewardCurrency(familyId) { return request(`/rewards/currency?family_id=${familyId}`); }
 export function apiCreateRewardCurrency(payload) { return post('/rewards/currency', payload); }
-export function apiUpdateRewardCurrency(id, payload) { return patch(`/rewards/currency/${id}`, payload); }
-export function apiDeleteRewardCurrency(id) { return del(`/rewards/currency/${id}`); }
 export function apiGetEarningRules(familyId) { return request(`/rewards/rules?family_id=${familyId}`); }
 export function apiCreateEarningRule(payload) { return post('/rewards/rules', payload); }
-export function apiUpdateEarningRule(id, payload) { return patch(`/rewards/rules/${id}`, payload); }
 export function apiDeleteEarningRule(id) { return del(`/rewards/rules/${id}`); }
 export function apiGetRewardCatalog(familyId) { return request(`/rewards/catalog?family_id=${familyId}`); }
 export function apiCreateReward(payload) { return post('/rewards/catalog', payload); }
-export function apiUpdateReward(id, payload) { return patch(`/rewards/catalog/${id}`, payload); }
 export function apiDeleteReward(id) { return del(`/rewards/catalog/${id}`); }
 export function apiGetRewardTransactions(familyId, userId, limit = 50, offset = 0) {
   let url = `/rewards/transactions?family_id=${familyId}&limit=${limit}&offset=${offset}`;

--- a/frontend/lib/member-colors.js
+++ b/frontend/lib/member-colors.js
@@ -5,7 +5,7 @@ export const COLOR_PALETTE = [
   '#14b8a6', '#f97316', '#6366f1',
 ];
 
-export const MEMBER_COLORS = ['var(--member-1)', 'var(--member-2)', 'var(--member-3)', 'var(--member-4)'];
+const MEMBER_COLORS = ['var(--member-1)', 'var(--member-2)', 'var(--member-3)', 'var(--member-4)'];
 
 export function getMemberColor(member, index) {
   if (member?.color) return member.color;

--- a/frontend/lib/styles.js
+++ b/frontend/lib/styles.js
@@ -1,4 +1,4 @@
-export const styles = {
+const styles = {
   page: { minHeight: '100vh', padding: 12 },
   hero: { background: 'linear-gradient(135deg, #111827 0%, #4c1d95 100%)', color: '#fff', padding: 20, borderRadius: 14, maxWidth: 900, margin: '0 auto' },
   cardNarrow: { background: '#fff', border: '1px solid #e5e7eb', borderRadius: 14, padding: 14, maxWidth: 420, width: '100%', boxSizing: 'border-box', margin: '12px auto' },
@@ -14,20 +14,6 @@ export const styles = {
   grid2: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginTop: 12 },
 };
 
-export function navBtn(active, tokens) {
-  return {
-    border: active ? `1px solid ${tokens.primary}` : `1px solid ${tokens.border}`,
-    background: active ? tokens.sidebarActive : tokens.sidebar,
-    color: tokens.text,
-    borderRadius: 10,
-    padding: '10px 12px',
-    cursor: 'pointer',
-    textAlign: 'left',
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: 8,
-  };
-}
 
 export function buildUi(tokens) {
   return {


### PR DESCRIPTION
## Summary
- **Backend (22 files):** Remove 37 unused imports (F401) and 1 unused variable `statuses` (F841) detected by ruff and vulture
- **Frontend (4 files):** Remove 4 unused API wrapper functions, unused `navBtn` function, un-export `styles` and `MEMBER_COLORS` (only used internally), remove unused `loginAsUser` e2e helper

## Verification
- `ruff check --select F401,F841` passes clean
- `vulture --min-confidence 80` only reports Pydantic `cls` false positives
- All removals confirmed via grep - no behavioral changes