### PR TITLE
Show rewards in navigation settings tree (fixes #149)

### DIFF
--- a/frontend/__tests__/components/NavigationTab.test.js
+++ b/frontend/__tests__/components/NavigationTab.test.js
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NavigationTab from '../../components/settings/NavigationTab';
+import { DEFAULT_NAV_ORDER } from '../../contexts/UIContext';
+
+let mockAppState = {};
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+  DEFAULT_NAV_ORDER: jest.requireActual('../../contexts/UIContext').DEFAULT_NAV_ORDER,
+}));
+
+jest.mock('../../lib/api', () => ({
+  apiUpdateNavOrder: jest.fn(),
+}));
+
+const messages = {
+  nav_order_title: 'Navigation',
+  nav_order_desc: 'Sort the nav.',
+  nav_visible: 'sichtbar',
+  nav_overflow: 'mehr',
+  nav_save: 'Speichern',
+  nav_saved: 'Gespeichert',
+  nav_reset: 'Zuruecksetzen',
+  dashboard: 'Dashboard',
+  calendar: 'Kalender',
+  contacts: 'Kontakte',
+  notifications: 'Benachrichtigungen',
+  'module.shopping.name': 'Einkauf',
+  'module.tasks.name': 'Aufgaben',
+  'module.meal_plans.name': 'Essensplan',
+  'module.rewards.name': 'Belohnungen',
+  'module.gifts.name': 'Geschenke',
+};
+
+function baseState(overrides) {
+  return {
+    messages,
+    isAdmin: false,
+    isChild: false,
+    demoMode: false,
+    navOrder: DEFAULT_NAV_ORDER,
+    setNavOrder: jest.fn(),
+    ...overrides,
+  };
+}
+
+const LABEL_BY_KEY = {
+  dashboard: 'Dashboard',
+  calendar: 'Kalender',
+  shopping: 'Einkauf',
+  tasks: 'Aufgaben',
+  meal_plans: 'Essensplan',
+  rewards: 'Belohnungen',
+  gifts: 'Geschenke',
+  contacts: 'Kontakte',
+  notifications: 'Benachrichtigungen',
+};
+const PINNED_KEYS = new Set(['settings', 'admin']);
+const SORTABLE_KEYS = DEFAULT_NAV_ORDER.filter((k) => !PINNED_KEYS.has(k));
+
+describe('NavigationTab', () => {
+  test('renders a row for every sortable key in DEFAULT_NAV_ORDER (drift guard)', () => {
+    mockAppState = baseState();
+    render(<NavigationTab />);
+    // If a new key lands in DEFAULT_NAV_ORDER without a matching NAV_ITEM_META entry,
+    // NavigationTab silently drops it, reproducing the issue #149 bug. Iterating the
+    // actual default keeps this test load-bearing against that drift.
+    for (const key of SORTABLE_KEYS) {
+      const label = LABEL_BY_KEY[key];
+      expect(label).toBeDefined();
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  test('includes rewards entry (regression for #149)', () => {
+    mockAppState = baseState();
+    render(<NavigationTab />);
+    expect(screen.getByText('Belohnungen')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /move belohnungen up/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /move belohnungen down/i })).toBeInTheDocument();
+  });
+
+  test('hides adult-only items for children but still shows rewards', () => {
+    mockAppState = baseState({ isChild: true });
+    render(<NavigationTab />);
+    expect(screen.queryByText('Geschenke')).not.toBeInTheDocument();
+    expect(screen.getByText('Belohnungen')).toBeInTheDocument();
+  });
+
+  test('hides demo-blocked items in demo mode but still shows rewards', () => {
+    mockAppState = baseState({ demoMode: true });
+    render(<NavigationTab />);
+    expect(screen.queryByText('Essensplan')).not.toBeInTheDocument();
+    expect(screen.queryByText('Geschenke')).not.toBeInTheDocument();
+    expect(screen.getByText('Belohnungen')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/settings/NavigationTab.js
+++ b/frontend/components/settings/NavigationTab.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Navigation, ChevronUp, ChevronDown, Check, CalendarDays, CheckSquare, LayoutDashboard, BookUser, ShoppingCart, Bell, Sparkles, UtensilsCrossed } from 'lucide-react';
+import { Navigation, ChevronUp, ChevronDown, Check, CalendarDays, CheckSquare, LayoutDashboard, BookUser, ShoppingCart, Bell, Sparkles, UtensilsCrossed, Gift } from 'lucide-react';
 import { useApp, DEFAULT_NAV_ORDER } from '../../contexts/AppContext';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
@@ -10,6 +10,7 @@ const NAV_ITEM_META = {
   shopping: { icon: ShoppingCart, labelKey: 'module.shopping.name' },
   tasks: { icon: CheckSquare, labelKey: 'module.tasks.name' },
   meal_plans: { icon: UtensilsCrossed, labelKey: 'module.meal_plans.name', hideInDemo: true },
+  rewards: { icon: Gift, labelKey: 'module.rewards.name' },
   gifts: { icon: Sparkles, labelKey: 'module.gifts.name', adultOnly: true, hideInDemo: true },
   contacts: { icon: BookUser, labelKey: 'contacts' },
   notifications: { icon: Bell, labelKey: 'notifications' },


### PR DESCRIPTION
## Summary
- Adds `rewards` to `NAV_ITEM_META` in `NavigationTab.js`, using the same `Gift` icon and `module.rewards.name` label as `AppShell` already does.
- Since rewards have a child flow and are shown in `AppShell` for children and in demo mode, no `adultOnly` or `hideInDemo` gate is applied here either.
- Adds a regression test that iterates `DEFAULT_NAV_ORDER` programmatically so any future key added without a `NAV_ITEM_META` entry turns the suite red instead of silently dropping from the settings tree.

## Why it was broken
`NavigationTab` renders by looking up each key in `NAV_ITEM_META`. Keys without a matching entry are silently returned as `null`. `rewards` has been in `DEFAULT_NAV_ORDER`, in the backend's `KNOWN_KEYS`, and in `AppShell`'s item registry all along, but the settings tab's registry was missing it - so the row, including its reorder buttons, never appeared in the settings UI.

## Test plan
- [x] `npx jest` - 83/83 green (4 new + 79 pre-existing).
- [x] New `__tests__/components/NavigationTab.test.js` covers: every sortable key from `DEFAULT_NAV_ORDER` renders, rewards specifically has its move-up/down controls, child mode hides gifts but keeps rewards, demo mode hides meal_plans and gifts but keeps rewards.
- [ ] Open the app, go to Settings > Navigation, confirm the Rewards row appears and can be reordered.

Fixes #149