### PR TITLE
Improve code quality and consolidate shared helpers

### DIFF
--- a/backend/app/core/backup.py
+++ b/backend/app/core/backup.py
@@ -38,7 +38,7 @@ def _get_alembic_revision(db_params: dict) -> str:
             capture_output=True, text=True, timeout=10, env=env,
         )
         return result.stdout.strip() if result.returncode == 0 else "unknown"
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return "unknown"
 
 
@@ -55,7 +55,7 @@ def _get_pg_version(db_params: dict) -> str:
             capture_output=True, text=True, timeout=10, env=env,
         )
         return result.stdout.strip() if result.returncode == 0 else "unknown"
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return "unknown"
 
 
@@ -110,7 +110,7 @@ def _read_metadata(archive_path: str) -> dict:
             f = tar.extractfile(member)
             if f:
                 return json.load(f)
-    except Exception:
+    except (OSError, KeyError, tarfile.TarError, json.JSONDecodeError):
         pass
     return {}
 

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,13 +1,14 @@
 import json
 import logging
 import os
-from typing import Any, Callable
+from typing import Callable, TypeVar, cast
 
 logger = logging.getLogger(__name__)
 
 REDIS_URL = os.getenv("REDIS_URL")
 
 _client = None
+T = TypeVar("T")
 
 
 def _get_client():
@@ -40,13 +41,13 @@ def ping() -> bool:
         return False
 
 
-def get_or_set(key: str, ttl: int, loader: Callable[[], Any]) -> Any:
+def get_or_set(key: str, ttl: int, loader: Callable[[], T]) -> T:
     client = _get_client()
     if client:
         try:
             cached = client.get(key)
             if cached is not None:
-                return json.loads(cached)
+                return cast(T, json.loads(cached))
         except Exception as e:
             logger.debug("Cache get failed for %s: %s", key, e)
 

--- a/backend/app/core/compat.py
+++ b/backend/app/core/compat.py
@@ -1,0 +1,14 @@
+import asyncio
+from inspect import iscoroutinefunction
+
+
+def patch_asyncio_iscoroutinefunction() -> None:
+    """Provide a non-deprecated coroutine checker for dependencies.
+
+    slowapi still calls ``asyncio.iscoroutinefunction`` which emits a
+    deprecation warning on Python 3.14+ and is scheduled for removal.
+    Rebinding it to ``inspect.iscoroutinefunction`` preserves behavior
+    while keeping test and runtime logs clean.
+    """
+    if getattr(asyncio, "iscoroutinefunction", None) is not iscoroutinefunction:
+        asyncio.iscoroutinefunction = iscoroutinefunction

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,4 +1,5 @@
 from datetime import UTC, date
+import jwt
 
 from app.core.utils import utcnow
 from typing import Optional
@@ -79,7 +80,7 @@ def _resolve_user(request: Request, token_str: str, db: Session) -> User:
     try:
         payload = decode_token(token_str)
         user_id = int(payload.get("sub"))
-    except Exception:
+    except (jwt.PyJWTError, KeyError, TypeError, ValueError):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=error_detail(INVALID_TOKEN))
 
     user = db.query(User).filter(User.id == user_id).first()

--- a/backend/app/core/ws_broadcast.py
+++ b/backend/app/core/ws_broadcast.py
@@ -7,6 +7,8 @@ event loop reference at startup and use `asyncio.run_coroutine_threadsafe`.
 
 import asyncio
 import logging
+from collections.abc import Callable
+from typing import Any
 
 from app.core.ws_manager import manager
 
@@ -20,33 +22,33 @@ def set_event_loop(loop: asyncio.AbstractEventLoop):
     _loop = loop
 
 
-def _fire(coro):
+def _fire(coro_factory: Callable[[], Any]):
     """Schedule a coroutine on the captured event loop (fire-and-forget)."""
     if _loop is None:
         logger.debug("WS broadcast skipped: no event loop set")
         return
-    asyncio.run_coroutine_threadsafe(coro, _loop)
+    asyncio.run_coroutine_threadsafe(coro_factory(), _loop)
 
 
 def broadcast_item_added(list_id: int, item: dict):
-    _fire(manager.broadcast(list_id, {"type": "item_added", "item": item}))
+    _fire(lambda: manager.broadcast(list_id, {"type": "item_added", "item": item}))
 
 
 def broadcast_item_updated(list_id: int, item: dict):
-    _fire(manager.broadcast(list_id, {"type": "item_updated", "item": item}))
+    _fire(lambda: manager.broadcast(list_id, {"type": "item_updated", "item": item}))
 
 
 def broadcast_item_deleted(list_id: int, item_id: int):
-    _fire(manager.broadcast(list_id, {"type": "item_deleted", "item_id": item_id}))
+    _fire(lambda: manager.broadcast(list_id, {"type": "item_deleted", "item_id": item_id}))
 
 
 def broadcast_items_cleared(list_id: int, deleted_count: int):
-    _fire(manager.broadcast(list_id, {"type": "items_cleared", "list_id": list_id, "deleted_count": deleted_count}))
+    _fire(lambda: manager.broadcast(list_id, {"type": "items_cleared", "list_id": list_id, "deleted_count": deleted_count}))
 
 
 def broadcast_list_created(family_id: int, list_data: dict):
-    _fire(manager.broadcast_to_family(family_id, {"type": "list_created", "list": list_data}))
+    _fire(lambda: manager.broadcast_to_family(family_id, {"type": "list_created", "list": list_data}))
 
 
 def broadcast_list_deleted(family_id: int, list_id: int):
-    _fire(manager.broadcast_to_family(family_id, {"type": "list_deleted", "list_id": list_id}))
+    _fire(lambda: manager.broadcast_to_family(family_id, {"type": "list_deleted", "list_id": list_id}))

--- a/backend/app/dav/auth_plugin.py
+++ b/backend/app/dav/auth_plugin.py
@@ -20,9 +20,9 @@ from radicale.log import logger
 from app.core.clock import utcnow
 from app.core.scopes import has_scope, parse_scopes
 from app.database import SessionLocal
-from app.dav import rights_plugin
 from app.models import PersonalAccessToken, User
 from app.security import PAT_PREFIX, hash_pat, pat_lookup_key, verify_pat
+from .rights_plugin import remember_scopes
 
 
 DAV_SCOPES = ("calendar:read", "calendar:write", "contacts:read", "contacts:write")
@@ -84,7 +84,7 @@ class Auth(BaseAuth):
             # run back-to-back on the same thread per request, so a
             # threading.local context is the narrowest handoff that
             # does not require patching Radicale's plugin contract.
-            rights_plugin.remember_scopes(user.email, user.id, granted)
+            remember_scopes(user.email, user.id, granted)
             return user.email
 
 

--- a/backend/app/dav/caldav_storage.py
+++ b/backend/app/dav/caldav_storage.py
@@ -25,8 +25,8 @@ from sqlalchemy.exc import IntegrityError
 from app.core.ics_utils import events_to_ics, ics_to_event_dicts
 from app.core.vcard_utils import contact_to_vcard, contacts_to_vcards, vcard_to_contact_dict
 from app.database import SessionLocal
-from app.dav import rights_plugin
 from app.models import CalendarEvent, Contact, Family, Membership, User
+from .rights_plugin import current_user_id
 
 
 def _db():
@@ -217,7 +217,7 @@ class CalendarCollection(BaseCollection):
         """
         ics_text = getattr(item, "text", None) or item.serialize()
         uid = getattr(item, "uid", None) or ""
-        valid, errors = ics_to_event_dicts(ics_text, self._family_id, rights_plugin.current_user_id())
+        valid, errors = ics_to_event_dicts(ics_text, self._family_id, current_user_id())
         if not valid:
             reason = errors[0]["error"] if errors else "no VEVENT"
             raise ValueError(f"VEVENT rejected: {reason}")
@@ -261,7 +261,7 @@ class CalendarCollection(BaseCollection):
             else:
                 row = CalendarEvent(
                     family_id=self._family_id,
-                    created_by_user_id=rights_plugin.current_user_id(),
+                    created_by_user_id=current_user_id(),
                     ical_uid=uid,
                     dav_href=href,
                 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,10 +2,14 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 
+from app.core.compat import patch_asyncio_iscoroutinefunction
 from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
+
+patch_asyncio_iscoroutinefunction()
+
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import _rate_limit_exceeded_handler

--- a/backend/app/modules/gifts_router.py
+++ b/backend/app/modules/gifts_router.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from app.core.deps import current_user, ensure_adult, ensure_family_membership
+from app.core.deps import current_user, ensure_family_membership
 from app.core.errors import (
     ADULT_REQUIRED,
     GIFT_NOT_FOUND,

--- a/backend/app/modules/invitations_router.py
+++ b/backend/app/modules/invitations_router.py
@@ -2,10 +2,14 @@ import os
 import secrets
 from datetime import timedelta
 
+from app.core.compat import patch_asyncio_iscoroutinefunction
 from app.core.utils import utcnow, audit_log as _audit, ensure_any_admin, get_setting, set_setting
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
+
+patch_asyncio_iscoroutinefunction()
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 

--- a/backend/app/modules/meal_plans_router.py
+++ b/backend/app/modules/meal_plans_router.py
@@ -8,8 +8,9 @@ distinct previously-used ingredient names for frontend autocomplete.
 A push-to-shopping endpoint turns selected ingredients into shopping
 items, formatted as "{amount} {unit}" in the item's spec column.
 """
+from collections.abc import Mapping
 from datetime import date
-from typing import Any, Optional
+from typing import Optional, TypeAlias, TypedDict
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.exc import IntegrityError
@@ -49,6 +50,15 @@ VALID_SLOTS = set(MEAL_SLOTS)
 
 MAX_RANGE_DAYS = 370
 
+IngredientFieldValue: TypeAlias = str | int | float | None
+RawIngredient: TypeAlias = str | IngredientItem | Mapping[str, IngredientFieldValue]
+
+
+class NormalizedIngredient(TypedDict):
+    name: str
+    amount: float | None
+    unit: str | None
+
 
 def _validate_slot(slot: Optional[str]) -> None:
     if slot is None:
@@ -74,7 +84,22 @@ def _load_for_caller(db: Session, user: User, plan_id: int) -> MealPlan:
     return plan
 
 
-def _normalize_stored_ingredients(raw: Optional[list[Any]]) -> list[dict]:
+def _normalize_amount(value: IngredientFieldValue) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _normalize_unit(value: IngredientFieldValue) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _normalize_stored_ingredients(raw: Optional[list[RawIngredient]]) -> list[NormalizedIngredient]:
     """Accept legacy list[str] payloads or the new list[dict] shape.
 
     Always returns a list of ``{"name", "amount", "unit"}`` dicts. This
@@ -85,21 +110,21 @@ def _normalize_stored_ingredients(raw: Optional[list[Any]]) -> list[dict]:
     """
     if not raw:
         return []
-    normalized: list[dict] = []
+    normalized: list[NormalizedIngredient] = []
     for entry in raw:
         if isinstance(entry, str):
             stripped = entry.strip()
             if not stripped:
                 continue
             normalized.append({"name": stripped, "amount": None, "unit": None})
-        elif isinstance(entry, dict):
+        elif isinstance(entry, Mapping):
             name = entry.get("name")
             if not isinstance(name, str) or not name.strip():
                 continue
             normalized.append({
                 "name": name.strip(),
-                "amount": entry.get("amount"),
-                "unit": (entry.get("unit") or None) if isinstance(entry.get("unit"), str) else entry.get("unit"),
+                "amount": _normalize_amount(entry.get("amount")),
+                "unit": _normalize_unit(entry.get("unit")),
             })
     return normalized
 
@@ -126,7 +151,7 @@ def _serialize(plan: MealPlan) -> MealPlanResponse:
     })
 
 
-def _sanitize_ingredients(raw: Optional[list[Any]]) -> list[dict]:
+def _sanitize_ingredients(raw: Optional[list[RawIngredient]]) -> list[NormalizedIngredient]:
     """Normalize a list of ingredient items.
 
     Strips whitespace on name and unit, drops empty names, and
@@ -138,15 +163,15 @@ def _sanitize_ingredients(raw: Optional[list[Any]]) -> list[dict]:
     if not raw:
         return []
     seen: set[str] = set()
-    cleaned: list[dict] = []
+    cleaned: list[NormalizedIngredient] = []
     for item in raw:
         if isinstance(item, IngredientItem):
             name = item.name
             amount = item.amount
             unit = item.unit
-        elif isinstance(item, dict):
+        elif isinstance(item, Mapping):
             name = item.get("name")
-            amount = item.get("amount")
+            amount = _normalize_amount(item.get("amount"))
             unit = item.get("unit")
         else:
             continue
@@ -159,10 +184,7 @@ def _sanitize_ingredients(raw: Optional[list[Any]]) -> list[dict]:
         if key in seen:
             continue
         seen.add(key)
-        unit_clean: Optional[str] = None
-        if isinstance(unit, str):
-            u = unit.strip()
-            unit_clean = u if u else None
+        unit_clean = _normalize_unit(unit)
         cleaned.append({
             "name": name,
             "amount": amount,
@@ -390,7 +412,7 @@ def add_ingredients_to_shopping(
         raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
 
     meal_ingredients = _normalize_stored_ingredients(plan.ingredients)
-    by_name: dict[str, dict] = {
+    by_name: dict[str, NormalizedIngredient] = {
         entry["name"].strip().lower(): entry for entry in meal_ingredients
     }
 
@@ -416,13 +438,10 @@ def add_ingredients_to_shopping(
 
     created: list[ShoppingItem] = []
     for entry in selected:
-        name = entry.get("name")
-        if not isinstance(name, str) or not name.strip():
-            continue
         item = ShoppingItem(
             list_id=shopping_list.id,
-            name=name.strip(),
-            spec=_format_spec(entry.get("amount"), entry.get("unit")),
+            name=entry["name"].strip(),
+            spec=_format_spec(entry["amount"], entry["unit"]),
             added_by_user_id=user.id,
         )
         db.add(item)

--- a/backend/app/modules/shopping_ws.py
+++ b/backend/app/modules/shopping_ws.py
@@ -11,6 +11,7 @@ with ``{"type": "pong"}``.
 import logging
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import jwt
 from sqlalchemy.orm import Session
 
 from app.core.ws_manager import manager
@@ -35,7 +36,7 @@ def _auth_and_check(ws: WebSocket, list_id: int) -> tuple[int, int] | None:
     try:
         payload = decode_token(token)
         user_id = int(payload["sub"])
-    except Exception:
+    except (jwt.PyJWTError, KeyError, TypeError, ValueError):
         return None
 
     db: Session = SessionLocal()

--- a/backend/app/modules/tokens_router.py
+++ b/backend/app/modules/tokens_router.py
@@ -5,7 +5,7 @@ from app.core.deps import current_user
 from app.core.scopes import VALID_SCOPES, require_scope
 from app.core.utils import ensure_any_admin, ensure_any_adult
 from app.database import get_db
-from app.models import Membership, PersonalAccessToken, User
+from app.models import PersonalAccessToken, User
 from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, PATCreate, PATCreatedResponse, PATResponse
 from app.core.errors import error_detail, INVALID_SCOPES, TOKEN_LIMIT_REACHED, API_TOKEN_NOT_FOUND, API_TOKEN_NO_ACCESS
 from app.security import generate_pat

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 from typing import Optional, Union
 
+import binascii
 import re
 
 from enum import Enum
@@ -117,7 +118,7 @@ class ProfileImageUpdate(BaseModel):
 
         try:
             decoded = base64.b64decode(b64_data, validate=True)
-        except Exception:
+        except (binascii.Error, ValueError):
             raise ValueError("Invalid base64 data")
 
         if len(decoded) > _PROFILE_IMAGE_MAX_BYTES:

--- a/backend/tests/test_dav_auth.py
+++ b/backend/tests/test_dav_auth.py
@@ -10,7 +10,6 @@ import base64
 import hashlib
 import os
 import tempfile
-from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient

--- a/backend/tests/test_dav_caldav_read.py
+++ b/backend/tests/test_dav_caldav_read.py
@@ -42,7 +42,7 @@ def app_under_test(dav_storage_folder):
 
 @pytest.fixture
 def seeded(app_under_test):
-    from datetime import datetime, timedelta
+    from datetime import datetime
 
     db = SessionLocal()
     try:
@@ -169,7 +169,6 @@ class TestCalDAVRead:
         that poll CS:getctag before refetching notice the change."""
         import re
         import time
-        from datetime import datetime
 
         token, family_id = seeded
         client = TestClient(app_under_test)
@@ -322,10 +321,8 @@ class TestCalDAVRead:
         surfaces as a deterministic 4xx from the unique-constraint
         fallback path."""
         import concurrent.futures
-        import itertools
 
         token, family_id = seeded
-        base_client = TestClient(app_under_test)
         headers = {
             "Authorization": _basic(EMAIL, token),
             "Content-Type": "text/calendar",

--- a/backend/tests/test_invitation_security.py
+++ b/backend/tests/test_invitation_security.py
@@ -5,7 +5,6 @@ The critical test is that admin+non-adult combinations are rejected at creation 
 and defensively demoted at registration time.
 """
 
-from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 

--- a/backend/tests/test_pat_hash_migration.py
+++ b/backend/tests/test_pat_hash_migration.py
@@ -8,7 +8,6 @@ now via the new path.
 from __future__ import annotations
 
 import base64
-import hashlib
 import os
 import tempfile
 

--- a/frontend/__tests__/components/GiftsView.test.js
+++ b/frontend/__tests__/components/GiftsView.test.js
@@ -17,7 +17,6 @@ jest.mock('../../lib/api', () => ({
   apiCreateGift: jest.fn(),
   apiUpdateGift: jest.fn(),
   apiDeleteGift: jest.fn(),
-  apiGetGift: jest.fn(),
 }));
 
 const messages = {

--- a/frontend/__tests__/lib/helpers.test.js
+++ b/frontend/__tests__/lib/helpers.test.js
@@ -1,4 +1,4 @@
-import { toIsoOrNull, prettyDate, errorText } from '../../lib/helpers';
+import { toIsoOrNull, prettyDate, errorText, copyTextToClipboard } from '../../lib/helpers';
 
 describe('toIsoOrNull', () => {
   it('returns null for falsy values', () => {
@@ -78,5 +78,29 @@ describe('errorText', () => {
   it('backward compat: 2-arg call still works', () => {
     expect(errorText('direct string', 'fallback')).toBe('direct string');
     expect(errorText(null, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('copyTextToClipboard', () => {
+  afterEach(() => {
+    delete global.navigator;
+    jest.restoreAllMocks();
+  });
+
+  it('returns false when clipboard API is unavailable', async () => {
+    await expect(copyTextToClipboard('abc')).resolves.toBe(false);
+  });
+
+  it('writes text through navigator.clipboard when available', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    global.navigator = { clipboard: { writeText } };
+    await expect(copyTextToClipboard('abc')).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith('abc');
+  });
+
+  it('returns false when clipboard write rejects', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('nope'));
+    global.navigator = { clipboard: { writeText } };
+    await expect(copyTextToClipboard('abc')).resolves.toBe(false);
   });
 });

--- a/frontend/__tests__/lib/i18n.test.js
+++ b/frontend/__tests__/lib/i18n.test.js
@@ -37,7 +37,7 @@ describe('i18n no empty strings', () => {
   ];
 
   it.each(allFiles)('%s has no empty string values', (_name, locale) => {
-    for (const [key, value] of Object.entries(locale)) {
+    for (const [, value] of Object.entries(locale)) {
       expect(value.trim()).not.toBe('');
     }
   });

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -1,14 +1,14 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { Bell, CalendarDays, CheckSquare, Gift, LayoutDashboard, Settings, Shield, BookUser, LogOut, ChevronDown, ChevronLeft, ChevronRight, Users, Menu, ShoppingCart, MoreHorizontal, Search, Sparkles, UtensilsCrossed } from 'lucide-react';
+import { Bell, LogOut, ChevronDown, ChevronLeft, ChevronRight, Users, Menu, MoreHorizontal, Search } from 'lucide-react';
 import SearchOverlay from './SearchOverlay';
 import { useApp } from '../contexts/AppContext';
 import { t } from '../lib/i18n';
 import { announce } from '../lib/announce';
+import { isNavItemVisible, NAV_ITEM_META, PINNED_NAV_KEYS } from '../lib/navigation';
 import MemberAvatar from './MemberAvatar';
 import DashboardView from './DashboardView';
 import CalendarView from './calendar';
 import ContactsView from './ContactsView';
-
 import TasksView from './TasksView';
 import RewardsView from './RewardsView';
 import GiftsView from './GiftsView';
@@ -19,6 +19,7 @@ import AdminView from './admin';
 import NotificationCenter from './NotificationCenter';
 import ForcePasswordChange from './ForcePasswordChange';
 import OnboardingWizard from './OnboardingWizard';
+const MAX_BOTTOM_NAV = 5;
 
 const views = {
   dashboard: DashboardView,
@@ -33,11 +34,6 @@ const views = {
   settings: SettingsView,
   admin: AdminView,
 };
-
-import { getMemberColor } from '../lib/member-colors';
-
-const PINNED_BOTTOM_KEYS = new Set(['settings', 'admin']);
-const MAX_BOTTOM_NAV = 5;
 
 function DashboardSkeleton() {
   return (
@@ -88,30 +84,31 @@ export default function AppShell() {
 
 
   // Item registry: all possible nav items keyed by their route key
-  const itemRegistry = useMemo(() => ({
-    dashboard: { key: 'dashboard', icon: LayoutDashboard, label: t(messages, 'dashboard'), mobileLabel: 'Home' },
-    calendar: { key: 'calendar', icon: CalendarDays, label: t(messages, 'calendar'), mobileLabel: t(messages, 'calendar') },
-    shopping: { key: 'shopping', icon: ShoppingCart, label: t(messages, 'module.shopping.name'), mobileLabel: t(messages, 'module.shopping.name'), badge: totalUnchecked || null },
-    tasks: { key: 'tasks', icon: CheckSquare, label: t(messages, 'module.tasks.name'), mobileLabel: t(messages, 'module.tasks.name'), badge: openTaskCount || null },
-    ...(demoMode ? {} : {
-      meal_plans: { key: 'meal_plans', icon: UtensilsCrossed, label: t(messages, 'module.meal_plans.name'), mobileLabel: t(messages, 'module.meal_plans.name') },
-    }),
-    rewards: { key: 'rewards', icon: Gift, label: t(messages, 'module.rewards.name'), mobileLabel: t(messages, 'module.rewards.name') },
-    ...(isChild || demoMode ? {} : {
-      gifts: { key: 'gifts', icon: Sparkles, label: t(messages, 'module.gifts.name'), mobileLabel: t(messages, 'module.gifts.name') },
-    }),
-    contacts: { key: 'contacts', icon: BookUser, label: t(messages, 'contacts'), mobileLabel: t(messages, 'contacts') },
-    notifications: { key: 'notifications', icon: Bell, label: t(messages, 'notifications'), mobileLabel: t(messages, 'notifications'), badge: unreadCount || null },
-    settings: { key: 'settings', icon: Settings, label: t(messages, 'settings'), mobileLabel: t(messages, 'settings') },
-    admin: { key: 'admin', icon: Shield, label: t(messages, 'admin'), mobileLabel: t(messages, 'admin') },
-  }), [messages, totalUnchecked, openTaskCount, unreadCount, isChild, demoMode]);
+  const itemRegistry = useMemo(() => {
+    const registry = {};
+    for (const [key, meta] of Object.entries(NAV_ITEM_META)) {
+      if (!isNavItemVisible(key, { isAdmin, isChild, demoMode })) continue;
+      const label = t(messages, meta.labelKey);
+      const item = {
+        key,
+        icon: meta.icon,
+        label,
+        mobileLabel: meta.mobileLabel || label,
+      };
+      if (key === 'shopping') item.badge = totalUnchecked || null;
+      if (key === 'tasks') item.badge = openTaskCount || null;
+      if (key === 'notifications') item.badge = unreadCount || null;
+      registry[key] = item;
+    }
+    return registry;
+  }, [messages, totalUnchecked, openTaskCount, unreadCount, isAdmin, isChild, demoMode]);
 
   // Split items: sortable nav items vs pinned bottom items (settings, admin)
   const orderedItems = useMemo(() => {
     return navOrder
-      .filter((key) => key in itemRegistry && !PINNED_BOTTOM_KEYS.has(key) && (key !== 'admin' || isAdmin))
+      .filter((key) => key in itemRegistry && !PINNED_NAV_KEYS.has(key))
       .map((key) => itemRegistry[key]);
-  }, [navOrder, itemRegistry, isAdmin]);
+  }, [navOrder, itemRegistry]);
 
   const pinnedItems = useMemo(() => {
     const items = [];

--- a/frontend/components/AssignedBadges.js
+++ b/frontend/components/AssignedBadges.js
@@ -1,0 +1,23 @@
+import MemberAvatar from './MemberAvatar';
+
+export default function AssignedBadges({ assignedTo, members }) {
+  if (!assignedTo) return null;
+
+  let badgeMembers;
+  if (assignedTo === 'all') {
+    badgeMembers = members;
+  } else if (Array.isArray(assignedTo)) {
+    badgeMembers = members.filter((m) => assignedTo.includes(m.user_id));
+  } else {
+    return null;
+  }
+  if (badgeMembers.length === 0) return null;
+
+  return (
+    <div className="assigned-badges">
+      {badgeMembers.map((m, i) => (
+        <MemberAvatar key={m.user_id} member={m} index={i} size={20} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/ContactsView.js
+++ b/frontend/components/ContactsView.js
@@ -56,7 +56,7 @@ function DeleteButton({ onDelete, label, messages }) {
   );
 }
 
-function FormModal({ id, title, onClose, onSubmit, isEditing, saveKey, deleteButton, messages, children }) {
+function FormModal({ id, title, onClose, onSubmit, saveKey, deleteButton, messages, children }) {
   const overlayRef = useRef(null);
   const panelRef = useRef(null);
   const firstInputRef = useRef(null);

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -3,8 +3,8 @@ import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { getMemberColor } from '../lib/member-colors';
+import AssignedBadges from './AssignedBadges';
 import MemberAvatar from './MemberAvatar';
-import { AssignedBadges } from './calendar/CalendarHelpers';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
 
 function getGreeting(messages) {
@@ -131,7 +131,7 @@ export default function DashboardView() {
                 {!isChild && <button className="bento-empty-action" onClick={() => setActiveView('tasks')}>{t(messages, 'module.dashboard.empty_tasks_action')}</button>}
               </div>
             )}
-            {openTasks.slice(0, 5).map((task, i) => {
+            {openTasks.slice(0, 5).map((task) => {
               const assignee = members.find((m) => m.user_id === task.assigned_to_user_id);
               const priorityColor = task.priority === 'high' ? 'var(--danger)' : task.priority === 'normal' ? 'var(--amethyst)' : 'var(--sapphire)';
               return (

--- a/frontend/components/GiftDialog.js
+++ b/frontend/components/GiftDialog.js
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { X, Cake } from 'lucide-react';
 import { t } from '../lib/i18n';
-import { GIFT_STATUSES, GIFT_OCCASIONS } from '../hooks/useGifts';
+import { GIFT_OCCASIONS, GIFT_STATUSES } from '../lib/gifts';
+import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap';
 
 function statusLabel(messages, status) {
   return t(messages, `module.gifts.status.${status}`);
@@ -26,44 +27,7 @@ export default function GiftDialog({
 }) {
   const dialogRef = useRef(null);
   const firstFieldRef = useRef(null);
-  const previousFocusRef = useRef(null);
-  const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
-
-  useEffect(() => {
-    if (!open) return undefined;
-    previousFocusRef.current = document.activeElement;
-    firstFieldRef.current?.focus();
-    function handleKeyDown(e) {
-      if (e.key === 'Escape') {
-        onCloseRef.current();
-        return;
-      }
-      if (e.key === 'Tab' && dialogRef.current) {
-        const focusable = dialogRef.current.querySelectorAll(
-          'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), a[href]',
-        );
-        if (focusable.length === 0) return;
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      const previous = previousFocusRef.current;
-      if (previous && previous.isConnected && typeof previous.focus === 'function') {
-        previous.focus();
-      }
-    };
-  }, [open]);
+  useDialogFocusTrap({ open, containerRef: dialogRef, initialFocusRef: firstFieldRef, onClose });
 
   if (!open) return null;
 

--- a/frontend/components/GiftsView.js
+++ b/frontend/components/GiftsView.js
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
 import { Sparkles, ExternalLink, Edit2, Trash2, Package, ShoppingBag, Gift as GiftIcon, Plus, Users } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
-import { useGifts, GIFT_STATUSES, GIFT_OCCASIONS, GIFT_SORT_OPTIONS } from '../hooks/useGifts';
+import { useGifts } from '../hooks/useGifts';
+import { GIFT_OCCASIONS, GIFT_SORT_OPTIONS, GIFT_STATUSES } from '../lib/gifts';
 import { t } from '../lib/i18n';
 import MemberAvatar from './MemberAvatar';
 import ConfirmDialog from './ConfirmDialog';

--- a/frontend/components/MealPlanDialog.js
+++ b/frontend/components/MealPlanDialog.js
@@ -1,7 +1,8 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import { X, Plus, Trash2, ShoppingCart } from 'lucide-react';
 import { t } from '../lib/i18n';
-import { MEAL_SLOTS } from '../hooks/useMealPlans';
+import { createEmptyMealIngredient, MEAL_SLOTS } from '../lib/meal-plans';
+import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap';
 
 function slotLabel(messages, slot) {
   return t(messages, `module.meal_plans.slot.${slot}`);
@@ -22,9 +23,6 @@ export default function MealPlanDialog({
 }) {
   const dialogRef = useRef(null);
   const firstFieldRef = useRef(null);
-  const previousFocusRef = useRef(null);
-  const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
   const [submitting, setSubmitting] = useState(false);
   const [pushing, setPushing] = useState(false);
   const [selectedListId, setSelectedListId] = useState('');
@@ -38,40 +36,7 @@ export default function MealPlanDialog({
     }
   }, [open, shoppingLists, selectedListId]);
 
-  useEffect(() => {
-    if (!open) return undefined;
-    previousFocusRef.current = document.activeElement;
-    firstFieldRef.current?.focus();
-    function handleKeyDown(e) {
-      if (e.key === 'Escape') {
-        onCloseRef.current();
-        return;
-      }
-      if (e.key === 'Tab' && dialogRef.current) {
-        const focusable = dialogRef.current.querySelectorAll(
-          'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), a[href]',
-        );
-        if (focusable.length === 0) return;
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      const previous = previousFocusRef.current;
-      if (previous && previous.isConnected && typeof previous.focus === 'function') {
-        previous.focus();
-      }
-    };
-  }, [open]);
+  useDialogFocusTrap({ open, containerRef: dialogRef, initialFocusRef: firstFieldRef, onClose });
 
   if (!open) return null;
 
@@ -86,7 +51,7 @@ export default function MealPlanDialog({
   function addIngredient() {
     setForm((prev) => ({
       ...prev,
-      ingredients: [...prev.ingredients, { name: '', amount: '', unit: '' }],
+      ingredients: [...prev.ingredients, createEmptyMealIngredient()],
     }));
   }
 

--- a/frontend/components/MealPlansView.js
+++ b/frontend/components/MealPlansView.js
@@ -11,7 +11,8 @@ import {
   useDroppable,
 } from '@dnd-kit/core';
 import { useApp } from '../contexts/AppContext';
-import { useMealPlans, MEAL_SLOTS, formatIsoDate, weekDays } from '../hooks/useMealPlans';
+import { useMealPlans, formatIsoDate, weekDays } from '../hooks/useMealPlans';
+import { MEAL_SLOTS } from '../lib/meal-plans';
 import { t } from '../lib/i18n';
 import ConfirmDialog from './ConfirmDialog';
 import MealPlanDialog from './MealPlanDialog';

--- a/frontend/components/MemberAvatar.js
+++ b/frontend/components/MemberAvatar.js
@@ -1,13 +1,22 @@
 import { getMemberColor } from '../lib/member-colors';
 
 /**
+ * @typedef {{
+ *   display_name?: string | null,
+ *   profile_image?: string | null,
+ *   color?: string | null,
+ * }} MemberAvatarMember
+ *
+ * @typedef {{
+ *   member: MemberAvatarMember | null | undefined,
+ *   index?: number,
+ *   size?: number,
+ * }} MemberAvatarProps
+ *
  * Unified member avatar component.
  * Shows profile image if available, falls back to colored circle with initials.
  *
- * @param {object} props
- * @param {object} props.member - Member object with display_name, profile_image, color
- * @param {number} [props.index=0] - Index for color fallback
- * @param {number} [props.size=28] - Size in pixels
+ * @param {MemberAvatarProps} props
  */
 export default function MemberAvatar({ member, index = 0, size = 28 }) {
   if (!member) return null;

--- a/frontend/components/RewardsView.js
+++ b/frontend/components/RewardsView.js
@@ -1,11 +1,10 @@
 import { useState } from 'react';
 import { Gift, Plus, Star, Check, X, Award, ArrowUpCircle, ArrowDownCircle, Gem, Zap, Heart, Trophy, Clock, CheckSquare } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
-import { useToast } from '../contexts/ToastContext';
 import { useRewards } from '../hooks/useRewards';
 import { CurrencyIcon } from '../lib/currency-icons';
 import { t } from '../lib/i18n';
-import { errorText, parseDate } from '../lib/helpers';
+import { parseDate } from '../lib/helpers';
 import MemberAvatar from './MemberAvatar';
 import * as api from '../lib/api';
 
@@ -18,8 +17,7 @@ const CURRENCY_PRESETS = [
 ];
 
 export default function RewardsView() {
-  const { familyId, messages, members, me, isChild, isAdmin, demoMode, tasks, setActiveView, loadTasks } = useApp();
-  const { success: toastSuccess, error: toastError } = useToast();
+  const { messages, members, me, isChild, tasks, loadTasks } = useApp();
   const rw = useRewards();
 
   const [tab, setTab] = useState('overview');
@@ -41,16 +39,6 @@ export default function RewardsView() {
 
   // Tasks with token rewards (open, assigned)
   const rewardTasks = (tasks || []).filter(tk => tk.status === 'open' && tk.token_reward_amount > 0);
-
-  async function handleTaskComplete(task) {
-    const { ok } = await api.apiUpdateTask(task.id, { status: 'done' });
-    if (!ok) return;
-    if (!task.token_require_confirmation && rw.currency) {
-      await rw.earnTokens(task.assigned_to_user_id || me?.user_id, task.token_reward_amount, `Task: ${task.title}`);
-    }
-    setConfirmingTask(null);
-    if (loadTasks) await loadTasks();
-  }
 
   async function handleEarnForTask() {
     if (!confirmingTask || !rw.currency) return;

--- a/frontend/components/SetupWizard.js
+++ b/frontend/components/SetupWizard.js
@@ -3,8 +3,6 @@ import { Users, ShieldCheck, Upload, CheckCircle, Globe, AlertCircle, Play } fro
 import { useApp } from '../contexts/AppContext';
 import { errorText } from '../lib/helpers';
 import { t } from '../lib/i18n';
-import { listThemes } from '../lib/themes';
-import { listLanguages } from '../lib/i18n';
 import * as api from '../lib/api';
 
 const STEPS_FRESH = ['welcome', 'admin', 'family', 'prefs', 'done'];

--- a/frontend/components/TasksView.js
+++ b/frontend/components/TasksView.js
@@ -5,7 +5,6 @@ import { useTasks } from '../hooks/useTasks';
 import { prettyDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import MemberAvatar from './MemberAvatar';
-import { getMemberColor } from '../lib/member-colors';
 import ConfirmDialog from './ConfirmDialog';
 
 export default function TasksView() {

--- a/frontend/components/admin/BackupSection.js
+++ b/frontend/components/admin/BackupSection.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
-import { errorText } from '../../lib/helpers';
+import { downloadBlob, errorText } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 import ConfirmDialog from '../ConfirmDialog';
@@ -68,12 +68,7 @@ export default function BackupSection() {
     const res = await api.apiDownloadBackup(filename);
     if (!res.ok) return;
     const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, filename);
   }
 
   async function handleDelete(filename) {

--- a/frontend/components/admin/InviteSection.js
+++ b/frontend/components/admin/InviteSection.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Check, Copy, X, Link, Trash2 } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
-import { errorText } from '../../lib/helpers';
+import { copyTextToClipboard, errorText } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 import ConfirmDialog from '../ConfirmDialog';
@@ -93,25 +93,11 @@ export default function InviteSection() {
     }
   }
 
-  function handleCopyUrl() {
+  async function handleCopyUrl() {
     if (!createdUrl) return;
-    if (navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(createdUrl).then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      });
-    } else {
-      const ta = document.createElement('textarea');
-      ta.value = createdUrl;
-      ta.style.position = 'fixed';
-      ta.style.opacity = '0';
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand('copy');
-      document.body.removeChild(ta);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+    if (!await copyTextToClipboard(createdUrl)) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
 
   function inviteStatus(inv) {

--- a/frontend/components/admin/index.js
+++ b/frontend/components/admin/index.js
@@ -4,7 +4,7 @@ import { Plus, Check, Copy, X, KeyRound, Shield, ImageIcon } from 'lucide-react'
 import { useApp } from '../../contexts/AppContext';
 import MemberAvatar from '../MemberAvatar';
 import { useToast } from '../../contexts/ToastContext';
-import { errorText } from '../../lib/helpers';
+import { copyTextToClipboard, errorText } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 import ConfirmDialog from '../ConfirmDialog';
@@ -14,7 +14,7 @@ import AuditLogSection from './AuditLogSection';
 
 export default function AdminView() {
   const { familyId, members, messages, loadMembers, me, demoMode, timeFormat, setTimeFormat } = useApp();
-  const { error: toastError, info: toastInfo, success: toastSuccess } = useToast();
+  const { error: toastError, info: toastInfo } = useToast();
   const [showAddMember, setShowAddMember] = useState(false);
   const [newEmail, setNewEmail] = useState('');
   const [newName, setNewName] = useState('');
@@ -123,28 +123,11 @@ export default function AdminView() {
     setPasswordBannerType('reset');
   }
 
-  function handleCopyPassword() {
+  async function handleCopyPassword() {
     if (!createdPassword) return;
-    if (navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(createdPassword).then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      }).catch(fallbackCopy);
-    } else {
-      fallbackCopy();
-    }
-    function fallbackCopy() {
-      const ta = document.createElement('textarea');
-      ta.value = createdPassword;
-      ta.style.position = 'fixed';
-      ta.style.opacity = '0';
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand('copy');
-      document.body.removeChild(ta);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+    if (!await copyTextToClipboard(createdPassword)) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
 
   return (

--- a/frontend/components/calendar/CalendarHelpers.js
+++ b/frontend/components/calendar/CalendarHelpers.js
@@ -3,7 +3,7 @@ import { Cake, Pencil, Repeat, Trash2 } from 'lucide-react';
 import { prettyDate } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import { getMemberColor } from '../../lib/member-colors';
-import MemberAvatar from '../MemberAvatar';
+import AssignedBadges from '../AssignedBadges';
 
 export const RECURRENCE_OPTIONS = [
   { value: '', key: 'module.calendar.no_repeat' },
@@ -92,28 +92,6 @@ export function AssignChips({ members, assignedTo, setAssignedTo, messages }) {
           </button>
         );
       })}
-    </div>
-  );
-}
-
-export function AssignedBadges({ assignedTo, members }) {
-  if (!assignedTo) return null;
-
-  let badgeMembers;
-  if (assignedTo === 'all') {
-    badgeMembers = members;
-  } else if (Array.isArray(assignedTo)) {
-    badgeMembers = members.filter((m) => assignedTo.includes(m.user_id));
-  } else {
-    return null;
-  }
-  if (badgeMembers.length === 0) return null;
-
-  return (
-    <div className="assigned-badges">
-      {badgeMembers.map((m, i) => (
-        <MemberAvatar key={m.user_id} member={m} index={i} size={20} />
-      ))}
     </div>
   );
 }

--- a/frontend/components/calendar/index.js
+++ b/frontend/components/calendar/index.js
@@ -7,7 +7,7 @@ import { getMemberColor } from '../../lib/member-colors';
 import DayDetailPanel from './DayDetailPanel';
 
 export default function CalendarView() {
-  const { familyId, families, messages, isMobile, lang, demoMode, events, switchFamily, loadEvents, loadDashboard, setActiveView, isChild, members, timeFormat } = useApp();
+  const { familyId, families, messages, isMobile, lang, demoMode, events, setActiveView, isChild, members, timeFormat } = useApp();
   const cal = useCalendar();
   const locale = lang === 'de' ? 'de-DE' : 'en-US';
   const weekdays = t(messages, 'module.calendar.weekdays').split(',');

--- a/frontend/components/settings/AccountTab.js
+++ b/frontend/components/settings/AccountTab.js
@@ -3,7 +3,7 @@ import { User, Palette, Globe, Check, AlertTriangle, LogOut, Trash2 } from 'luci
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
 import { t, languageCompleteness } from '../../lib/i18n';
-import { COLOR_PALETTE, getMemberColor } from '../../lib/member-colors';
+import { COLOR_PALETTE } from '../../lib/member-colors';
 import * as api from '../../lib/api';
 
 const THEME_DESCS = {

--- a/frontend/components/settings/ApiTokensTab.js
+++ b/frontend/components/settings/ApiTokensTab.js
@@ -3,6 +3,7 @@ import { Key, Plus, Trash2, Copy, Check, X } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
 import { useFamily } from '../../contexts/FamilyContext';
+import { copyTextToClipboard } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 
@@ -78,9 +79,9 @@ export default function ApiTokensTab() {
     }
   }
 
-  function handleCopy() {
+  async function handleCopy() {
     if (!createdToken) return;
-    navigator.clipboard.writeText(createdToken);
+    if (!await copyTextToClipboard(createdToken)) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }

--- a/frontend/components/settings/DataTab.js
+++ b/frontend/components/settings/DataTab.js
@@ -2,12 +2,12 @@ import { useState } from 'react';
 import { Database, Rss, Download, Upload, ChevronUp, ChevronDown, Plus, Copy, Check } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
-import { downloadBlob } from '../../lib/helpers';
+import { copyTextToClipboard, downloadBlob } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 
 export default function DataTab() {
-  const { messages, familyId, loggedIn, demoMode, loadContacts, loadDashboard } = useApp();
+  const { messages, familyId, loadContacts, loadDashboard } = useApp();
   const { error: toastError } = useToast();
 
   // Data management state
@@ -42,8 +42,8 @@ export default function DataTab() {
     }
   }
 
-  function handleCopySubUrl(url, type) {
-    navigator.clipboard.writeText(url);
+  async function handleCopySubUrl(url, type) {
+    if (!await copyTextToClipboard(url)) return;
     if (type === 'calendar') {
       setSubCopiedCal(true);
       setTimeout(() => setSubCopiedCal(false), 2000);

--- a/frontend/components/settings/NavigationTab.js
+++ b/frontend/components/settings/NavigationTab.js
@@ -1,32 +1,17 @@
 import { useState, useEffect } from 'react';
-import { Navigation, ChevronUp, ChevronDown, Check, CalendarDays, CheckSquare, LayoutDashboard, BookUser, ShoppingCart, Bell, Sparkles, UtensilsCrossed, Gift } from 'lucide-react';
+import { Navigation, ChevronUp, ChevronDown, Check } from 'lucide-react';
 import { useApp, DEFAULT_NAV_ORDER } from '../../contexts/AppContext';
 import { t } from '../../lib/i18n';
+import { isNavItemVisible, NAV_ITEM_META, PINNED_NAV_KEYS } from '../../lib/navigation';
 import * as api from '../../lib/api';
-
-const NAV_ITEM_META = {
-  dashboard: { icon: LayoutDashboard, labelKey: 'dashboard' },
-  calendar: { icon: CalendarDays, labelKey: 'calendar' },
-  shopping: { icon: ShoppingCart, labelKey: 'module.shopping.name' },
-  tasks: { icon: CheckSquare, labelKey: 'module.tasks.name' },
-  meal_plans: { icon: UtensilsCrossed, labelKey: 'module.meal_plans.name', hideInDemo: true },
-  rewards: { icon: Gift, labelKey: 'module.rewards.name' },
-  gifts: { icon: Sparkles, labelKey: 'module.gifts.name', adultOnly: true, hideInDemo: true },
-  contacts: { icon: BookUser, labelKey: 'contacts' },
-  notifications: { icon: Bell, labelKey: 'notifications' },
-};
-
-const PINNED_KEYS = new Set(['settings', 'admin']);
 
 export default function NavigationTab() {
   const { messages, isAdmin, isChild, demoMode, navOrder, setNavOrder } = useApp();
   const filterHidden = (keys) => keys.filter((k) => {
-    if (PINNED_KEYS.has(k)) return false;
+    if (PINNED_NAV_KEYS.has(k)) return false;
     const meta = NAV_ITEM_META[k];
     if (!meta) return true;
-    if (meta.adultOnly && isChild) return false;
-    if (meta.hideInDemo && demoMode) return false;
-    return true;
+    return isNavItemVisible(k, { isAdmin, isChild, demoMode });
   });
   const [localNavOrder, setLocalNavOrder] = useState(() => filterHidden(navOrder));
   const [navSaved, setNavSaved] = useState(false);

--- a/frontend/components/settings/PhoneSyncTab.js
+++ b/frontend/components/settings/PhoneSyncTab.js
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Smartphone, Copy, Check, ExternalLink } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
+import { copyTextToClipboard } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 
 function buildDavUrl(email, familyId, kind) {
@@ -21,13 +22,7 @@ function CopyRow({ label, value, copyAria }) {
         className="btn-sm sync-url-copy"
         aria-label={copyAria}
         onClick={async () => {
-          const write = navigator?.clipboard?.writeText;
-          if (typeof write !== "function") return;
-          try {
-            await write.call(navigator.clipboard, value);
-          } catch {
-            return;
-          }
+          if (!await copyTextToClipboard(value)) return;
           setCopied(true);
           setTimeout(() => setCopied(false), 1500);
         }}

--- a/frontend/contexts/AppContext.js
+++ b/frontend/contexts/AppContext.js
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useRef } from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 import * as api from '../lib/api';
 import { buildDemoData } from '../lib/demo-data';
 import { AuthProvider, useAuth } from './AuthContext';
@@ -20,10 +20,10 @@ function AppOrchestrator({ children }) {
   const data = useData();
   const ui = useUI();
 
-  const { loggedIn, demoMode, me, setMe, setLoggedIn, setDemoMode, setProfileImage, setNeedsSetup } = auth;
+  const { loggedIn, demoMode, setMe, setLoggedIn, setDemoMode, setProfileImage, setNeedsSetup } = auth;
   const { familyId, setFamilyId, families, setFamilies, setMyFamilyRole, setMyFamilyIsAdult, loadMembers, setMembers } = family;
   const { loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadNotifications, resetData, lastEventIdRef, setNotifications, setUnreadCount, setEvents, setTasks, setShoppingLists, setContacts, setBirthdays, setSummary } = data;
-  const { setLoading, setTheme, setLang, setActiveView: setActiveViewUI, restoreView, setIsMobile, setNavOrder, setTimeFormat, lang, messages } = ui;
+  const { setLoading, setTheme, setLang, setActiveView: setActiveViewUI, restoreView, setIsMobile, setNavOrder, setTimeFormat, lang } = ui;
 
   // Wrap data loaders to inject familyId default and skip in demo mode
   const loadDashboardWrapped = useCallback(async (fid = familyId) => {

--- a/frontend/contexts/UIContext.js
+++ b/frontend/contexts/UIContext.js
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { buildMessages, listLanguages } from '../lib/i18n';
 import { getTheme, listThemes } from '../lib/themes';
 import { buildUi } from '../lib/styles';

--- a/frontend/hooks/useCalendar.js
+++ b/frontend/hooks/useCalendar.js
@@ -7,7 +7,7 @@ import { announce } from '../lib/announce';
 import * as api from '../lib/api';
 
 export function useCalendar() {
-  const { events, setEvents, familyId, loadEvents, loadDashboard, demoMode, summary, setSummary, lang, messages, members } = useApp();
+  const { events, setEvents, familyId, loadDashboard, demoMode, setSummary, lang, messages, members } = useApp();
   const { success: toastSuccess, error: toastError } = useToast();
 
   const [calendarView, setCalendarViewRaw] = useState('month');

--- a/frontend/hooks/useDialogFocusTrap.js
+++ b/frontend/hooks/useDialogFocusTrap.js
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+const DEFAULT_FOCUSABLE_SELECTOR = 'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), a[href]';
+
+export function useDialogFocusTrap({
+  open,
+  containerRef,
+  initialFocusRef,
+  onClose,
+  focusableSelector = DEFAULT_FOCUSABLE_SELECTOR,
+}) {
+  const previousFocusRef = useRef(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!open) return undefined;
+    previousFocusRef.current = document.activeElement;
+    initialFocusRef?.current?.focus();
+
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') {
+        onCloseRef.current?.();
+        return;
+      }
+      if (e.key !== 'Tab' || !containerRef.current) return;
+
+      const focusable = containerRef.current.querySelectorAll(focusableSelector);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      const previous = previousFocusRef.current;
+      if (previous && previous.isConnected && typeof previous.focus === 'function') {
+        previous.focus();
+      }
+    };
+  }, [containerRef, focusableSelector, initialFocusRef, open]);
+}

--- a/frontend/hooks/useGifts.js
+++ b/frontend/hooks/useGifts.js
@@ -4,31 +4,8 @@ import { useToast } from '../contexts/ToastContext';
 import { errorText } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { announce } from '../lib/announce';
+import { createEmptyGiftForm } from '../lib/gifts';
 import * as api from '../lib/api';
-
-export const GIFT_STATUSES = ['idea', 'ordered', 'purchased', 'gifted'];
-export const GIFT_OCCASIONS = ['birthday', 'christmas', 'easter', 'other'];
-export const GIFT_SORT_OPTIONS = [
-  'created_desc',
-  'created_asc',
-  'occasion_date_asc',
-  'price_desc',
-  'price_asc',
-  'title_asc',
-];
-
-const EMPTY_FORM = {
-  title: '',
-  description: '',
-  url: '',
-  for_user_id: '',
-  for_person_name: '',
-  occasion: '',
-  occasion_date: '',
-  status: 'idea',
-  notes: '',
-  price_eur: '',
-};
 
 function priceToCents(value) {
   if (value === '' || value === null || value === undefined) return null;
@@ -47,7 +24,7 @@ export function useGifts() {
   const [recipientFilter, setRecipientFilter] = useState('');
   const [includeGifted, setIncludeGifted] = useState(false);
   const [sortOrder, setSortOrder] = useState('created_desc');
-  const [form, setForm] = useState(EMPTY_FORM);
+  const [form, setForm] = useState(() => createEmptyGiftForm());
   const [editingId, setEditingId] = useState(null);
 
   const loadGifts = useCallback(async (fid = familyId) => {
@@ -73,7 +50,7 @@ export function useGifts() {
   const filteredGifts = useMemo(() => gifts, [gifts]);
 
   const resetForm = useCallback(() => {
-    setForm(EMPTY_FORM);
+    setForm(createEmptyGiftForm());
     setEditingId(null);
   }, []);
 

--- a/frontend/hooks/useMealPlans.js
+++ b/frontend/hooks/useMealPlans.js
@@ -4,12 +4,11 @@ import { useToast } from '../contexts/ToastContext';
 import { errorText } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { announce } from '../lib/announce';
+import { createEmptyMealForm } from '../lib/meal-plans';
 import * as api from '../lib/api';
 
-export const MEAL_SLOTS = ['morning', 'noon', 'evening'];
-
 /** Return the Monday of the ISO week for a given date, in local time. */
-export function isoWeekStart(date) {
+function isoWeekStart(date) {
   const d = new Date(date);
   d.setHours(0, 0, 0, 0);
   // getDay: 0 = Sunday. We want Monday as week start.
@@ -25,7 +24,7 @@ export function formatIsoDate(d) {
   return `${y}-${m}-${day}`;
 }
 
-export function addDays(date, days) {
+function addDays(date, days) {
   const d = new Date(date);
   d.setDate(d.getDate() + days);
   return d;
@@ -34,16 +33,6 @@ export function addDays(date, days) {
 export function weekDays(weekStart) {
   return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
 }
-
-const EMPTY_INGREDIENT = { name: '', amount: '', unit: '' };
-
-export const EMPTY_FORM = {
-  plan_date: '',
-  slot: 'noon',
-  meal_name: '',
-  ingredients: [],
-  notes: '',
-};
 
 export function useMealPlans() {
   const { familyId, messages, demoMode } = useApp();
@@ -217,7 +206,7 @@ export function useMealPlans() {
   }
 
   function emptyFormFor(dateIso, slot) {
-    return { ...EMPTY_FORM, plan_date: dateIso, slot };
+    return createEmptyMealForm({ plan_date: dateIso, slot });
   }
 
   return {
@@ -238,6 +227,5 @@ export function useMealPlans() {
     pushToShopping,
     populateFormFromMeal,
     emptyFormFor,
-    EMPTY_INGREDIENT,
   };
 }

--- a/frontend/hooks/useRewards.js
+++ b/frontend/hooks/useRewards.js
@@ -6,7 +6,7 @@ import { errorText } from '../lib/helpers';
 import * as api from '../lib/api';
 
 export function useRewards() {
-  const { familyId, members, me, isChild, demoMode, messages } = useApp();
+  const { familyId, me, demoMode, messages } = useApp();
   const { success: toastSuccess, error: toastError } = useToast();
 
   const [currency, setCurrency] = useState(null);

--- a/frontend/hooks/useShopping.js
+++ b/frontend/hooks/useShopping.js
@@ -7,7 +7,7 @@ import { useWebSocket } from './useWebSocket';
 
 export function useShopping() {
   const {
-    shoppingLists, setShoppingLists, familyId, members, messages,
+    shoppingLists, setShoppingLists, familyId, messages,
     loadShoppingLists, demoMode,
   } = useApp();
   const { error: toastError } = useToast();

--- a/frontend/hooks/useTasks.js
+++ b/frontend/hooks/useTasks.js
@@ -7,7 +7,7 @@ import { announce } from '../lib/announce';
 import * as api from '../lib/api';
 
 export function useTasks() {
-  const { tasks, setTasks, familyId, members, messages, loadTasks, demoMode } = useApp();
+  const { tasks, setTasks, familyId, messages, loadTasks, demoMode } = useApp();
   const { success: toastSuccess, error: toastError } = useToast();
 
   const [taskFilter, setTaskFilter] = useState('open');

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -466,10 +466,6 @@ export function apiGetGifts(familyId, { status = null, forUserId = null, occasio
   return request(`/gifts?${params.toString()}`);
 }
 
-export function apiGetGift(giftId) {
-  return request(`/gifts/${giftId}`);
-}
-
 export function apiCreateGift(payload) {
   return post('/gifts', payload);
 }

--- a/frontend/lib/gifts.js
+++ b/frontend/lib/gifts.js
@@ -1,0 +1,27 @@
+export const GIFT_STATUSES = ['idea', 'ordered', 'purchased', 'gifted'];
+
+export const GIFT_OCCASIONS = ['birthday', 'christmas', 'easter', 'other'];
+
+export const GIFT_SORT_OPTIONS = [
+  'created_desc',
+  'created_asc',
+  'occasion_date_asc',
+  'price_desc',
+  'price_asc',
+  'title_asc',
+];
+
+export function createEmptyGiftForm() {
+  return {
+    title: '',
+    description: '',
+    url: '',
+    for_user_id: '',
+    for_person_name: '',
+    occasion: '',
+    occasion_date: '',
+    status: 'idea',
+    notes: '',
+    price_eur: '',
+  };
+}

--- a/frontend/lib/helpers.js
+++ b/frontend/lib/helpers.js
@@ -40,6 +40,17 @@ export function downloadBlob(blob, filename) {
   URL.revokeObjectURL(url);
 }
 
+export async function copyTextToClipboard(value) {
+  const write = typeof navigator !== 'undefined' ? navigator?.clipboard?.writeText : null;
+  if (typeof write !== 'function') return false;
+  try {
+    await write.call(navigator.clipboard, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function timeAgo(dateStr, lang) {
   const now = new Date();
   const date = new Date(dateStr);

--- a/frontend/lib/meal-plans.js
+++ b/frontend/lib/meal-plans.js
@@ -1,0 +1,16 @@
+export const MEAL_SLOTS = ['morning', 'noon', 'evening'];
+
+export function createEmptyMealIngredient() {
+  return { name: '', amount: '', unit: '' };
+}
+
+export function createEmptyMealForm(overrides = {}) {
+  return {
+    plan_date: '',
+    slot: 'noon',
+    meal_name: '',
+    ingredients: [],
+    notes: '',
+    ...overrides,
+  };
+}

--- a/frontend/lib/navigation.js
+++ b/frontend/lib/navigation.js
@@ -1,0 +1,38 @@
+import {
+  Bell,
+  BookUser,
+  CalendarDays,
+  CheckSquare,
+  Gift,
+  LayoutDashboard,
+  Settings,
+  Shield,
+  ShoppingCart,
+  Sparkles,
+  UtensilsCrossed,
+} from 'lucide-react';
+
+export const PINNED_NAV_KEYS = new Set(['settings', 'admin']);
+
+export const NAV_ITEM_META = {
+  dashboard: { icon: LayoutDashboard, labelKey: 'dashboard', mobileLabel: 'Home' },
+  calendar: { icon: CalendarDays, labelKey: 'calendar' },
+  shopping: { icon: ShoppingCart, labelKey: 'module.shopping.name' },
+  tasks: { icon: CheckSquare, labelKey: 'module.tasks.name' },
+  meal_plans: { icon: UtensilsCrossed, labelKey: 'module.meal_plans.name', hideInDemo: true },
+  rewards: { icon: Gift, labelKey: 'module.rewards.name' },
+  gifts: { icon: Sparkles, labelKey: 'module.gifts.name', adultOnly: true, hideInDemo: true },
+  contacts: { icon: BookUser, labelKey: 'contacts' },
+  notifications: { icon: Bell, labelKey: 'notifications' },
+  settings: { icon: Settings, labelKey: 'settings' },
+  admin: { icon: Shield, labelKey: 'admin', adminOnly: true },
+};
+
+export function isNavItemVisible(key, { isAdmin = false, isChild = false, demoMode = false } = {}) {
+  const meta = NAV_ITEM_META[key];
+  if (!meta) return false;
+  if (meta.adminOnly && !isAdmin) return false;
+  if (meta.adultOnly && isChild) return false;
+  if (meta.hideInDemo && demoMode) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

This PR packages a focused code-quality sweep across the frontend and backend.

It consolidates duplicated UI helpers and constants, tightens backend typing and error handling, removes dead code, and cleans up a few remaining compatibility issues that were surfacing in the test suite.

## What Changed

- extracted shared frontend modules for navigation, gifts, meal-plans, dialog focus management, and assigned badges
- unified clipboard and download helpers across admin and settings flows
- removed unused imports, exports, and stale code paths across frontend and backend
- tightened backend typing in meal-plan ingredient normalization and cache helpers
- narrowed broad exception handling to concrete error classes where appropriate
- simplified DAV imports to avoid unnecessary package-level coupling
- fixed residual backend test warnings by avoiding unawaited websocket broadcast coroutines and adding a small Python 3.14 compatibility shim for slowapi

## Why

Several areas had started to drift in parallel:

- shared UI metadata lived in multiple places
- a number of screens duplicated the same focus-trap and clipboard behavior
- dead imports and unused helpers added noise during review and linting
- some backend paths still relied on broad exception handling or weaker typing than necessary
- the backend test suite still emitted avoidable warnings on Python 3.14

This change reduces that drift without changing product scope.

## Impact

- lower maintenance overhead for shared frontend behaviors
- cleaner lint/test output
- tighter backend contracts around meal-plan ingredient handling and token decoding
- fewer hidden fallback branches in admin/settings copy flows

## Validation

- `npx --yes oxlint -D correctness/no-unused-vars frontend`
- `npm test -- --runInBand __tests__/lib/helpers.test.js __tests__/components/GiftsView.test.js __tests__/lib/i18n.test.js`
- `npm run build`
- `python3 -m compileall backend/app`
- `DATABASE_URL=sqlite:///./test-full.db JWT_SECRET=test-secret .venv/bin/pytest -q`
