### PR TITLE
docs: fix reverse proxy examples

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -61,7 +61,7 @@ These variables are constructed in `docker-compose.yml` and normally don't need 
 
 Running behind a reverse proxy gives you TLS (HTTPS), a clean domain, and is **required** for secure cookies. Set `SECURE_COOKIES=true` in your `.env` when using any of these.
 
-> All examples assume Tribu runs on the same host with the default ports (backend: 8000, frontend: 3000). WebSocket support is needed for real-time shopping list sync.
+> All examples assume Tribu runs on the same host with the default ports (backend: 8000, frontend: 3000). `/api` must be forwarded to the backend **without** the `/api` prefix, while `/ws`, `/dav`, and `/.well-known/{caldav,carddav}` must reach the backend unchanged.
 
 ### Caddy (recommended)
 
@@ -69,10 +69,19 @@ Caddy handles TLS certificates automatically via Let's Encrypt.
 
 ```
 tribu.example.com {
-	handle /api/* {
+	handle_path /api/* {
 		reverse_proxy localhost:8000
 	}
 	handle /ws/* {
+		reverse_proxy localhost:8000
+	}
+	handle /dav* {
+		reverse_proxy localhost:8000
+	}
+	handle /.well-known/caldav {
+		reverse_proxy localhost:8000
+	}
+	handle /.well-known/carddav {
 		reverse_proxy localhost:8000
 	}
 	handle {
@@ -85,14 +94,16 @@ tribu.example.com {
 
 ```nginx
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name tribu.example.com;
 
     ssl_certificate     /etc/letsencrypt/live/tribu.example.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/tribu.example.com/privkey.pem;
+    client_max_body_size 10M;
 
     location /api/ {
-        proxy_pass http://127.0.0.1:8000;
+        proxy_pass http://127.0.0.1:8000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -104,6 +115,38 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /dav {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /dav/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /.well-known/caldav {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /.well-known/carddav {
+        proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -140,9 +183,17 @@ And for the `backend` service:
 backend:
   labels:
     - "traefik.enable=true"
-    - "traefik.http.routers.tribu-api.rule=Host(`tribu.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/ws`))"
+    - "traefik.http.middlewares.tribu-api-strip.stripprefix.prefixes=/api"
+    - "traefik.http.routers.tribu-api.rule=Host(`tribu.example.com`) && PathPrefix(`/api`)"
     - "traefik.http.routers.tribu-api.entrypoints=websecure"
     - "traefik.http.routers.tribu-api.tls.certresolver=letsencrypt"
+    - "traefik.http.routers.tribu-api.middlewares=tribu-api-strip"
+    - "traefik.http.routers.tribu-ws.rule=Host(`tribu.example.com`) && PathPrefix(`/ws`)"
+    - "traefik.http.routers.tribu-ws.entrypoints=websecure"
+    - "traefik.http.routers.tribu-ws.tls.certresolver=letsencrypt"
+    - "traefik.http.routers.tribu-dav.rule=Host(`tribu.example.com`) && (PathPrefix(`/dav`) || Path(`/.well-known/caldav`) || Path(`/.well-known/carddav`))"
+    - "traefik.http.routers.tribu-dav.entrypoints=websecure"
+    - "traefik.http.routers.tribu-dav.tls.certresolver=letsencrypt"
     - "traefik.http.services.tribu-api.loadbalancer.server.port=8000"
 ```
 


### PR DESCRIPTION
## Summary
- fix the documented reverse proxy examples so `/api` is forwarded without the `/api` prefix
- add the missing `/dav` and `/.well-known/{caldav,carddav}` backend routes to the proxy examples
- keep `/ws` routed directly to the backend and modernize the nginx example

## Root cause
The frontend rewrites `/api/:path*` to the backend without the `/api` prefix, but the documented reverse proxy examples forwarded `/api/...` to the backend unchanged. That broke auth and other REST calls when following the docs literally.

## Validation
- reviewed `frontend/next.config.js` for the actual rewrite behavior
- reviewed `backend/app/main.py` and `backend/app/modules/shopping_ws.py` for `/dav`, `/.well-known/*`, and `/ws/shopping/{list_id}`
- inspected the resulting `docs/self-hosting.md` diff
