### PR TITLE
fix: preserve synced birthday row on contact rename

### DIFF
--- a/backend/app/core/contact_birthdays.py
+++ b/backend/app/core/contact_birthdays.py
@@ -48,6 +48,7 @@ def sync_contact_birthday(
     month: int | None,
     day: int | None,
 ) -> None:
+    existing = None
     if old_name and old_name != new_name:
         existing = (
             db.query(FamilyBirthday)
@@ -59,6 +60,14 @@ def sync_contact_birthday(
         )
         if existing:
             existing.person_name = new_name
+
+    if existing:
+        if month and day:
+            existing.month = month
+            existing.day = day
+            return
+        db.delete(existing)
+        return
 
     if month and day:
         upsert_family_birthday(db, family_id, new_name, month, day)

--- a/backend/tests/test_birthdays.py
+++ b/backend/tests/test_birthdays.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import sessionmaker
 from app.core.clock import utcnow
 from app.database import Base, get_db
 from app.main import app
-from app.models import Family, Membership, PersonalAccessToken, User
+from app.models import Family, FamilyBirthday, Membership, PersonalAccessToken, User
 from app.security import hash_password, PAT_PREFIX
 
 
@@ -24,7 +24,7 @@ engine = create_engine(
     "sqlite:///./test-birthdays.db",
     connect_args={"check_same_thread": False},
 )
-TestSession = sessionmaker(bind=engine)
+TestSession = sessionmaker(bind=engine, autoflush=False)
 
 
 @event.listens_for(engine, "connect")
@@ -202,3 +202,48 @@ def test_patch_without_year_key_leaves_year_untouched():
     body = resp.json()
     assert body["person_name"] == "Grandpa"
     assert body["year"] == 1940
+
+
+def test_contact_rename_preserves_existing_birthday_row_and_year():
+    token, family_id = _seed_member(scopes="birthdays:write,contacts:write")
+    client = TestClient(app)
+
+    created_birthday = client.post(
+        "/birthdays",
+        json={"family_id": family_id, "person_name": "Alice", "month": 4, "day": 14, "year": 1980},
+        headers=_auth_headers(token),
+    )
+    assert created_birthday.status_code == 200, created_birthday.text
+    birthday_id = created_birthday.json()["id"]
+
+    created_contact = client.post(
+        "/contacts",
+        json={"family_id": family_id, "full_name": "Alice", "birthday_month": 4, "birthday_day": 14},
+        headers=_auth_headers(token),
+    )
+    assert created_contact.status_code == 200, created_contact.text
+    contact_id = created_contact.json()["id"]
+
+    renamed_contact = client.patch(
+        f"/contacts/{contact_id}",
+        json={"full_name": "Alice Smith"},
+        headers=_auth_headers(token),
+    )
+    assert renamed_contact.status_code == 200, renamed_contact.text
+
+    db = TestSession()
+    try:
+        birthdays = (
+            db.query(FamilyBirthday)
+            .filter(FamilyBirthday.family_id == family_id)
+            .order_by(FamilyBirthday.id.asc())
+            .all()
+        )
+        assert len(birthdays) == 1
+        assert birthdays[0].id == birthday_id
+        assert birthdays[0].person_name == "Alice Smith"
+        assert birthdays[0].month == 4
+        assert birthdays[0].day == 14
+        assert birthdays[0].year == 1980
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- preserve the existing synced birthday row when a contact is renamed
- avoid the rename-then-upsert path that could create a duplicate birthday entry under `autoflush=False`
- add a regression test that verifies the original birthday row and stored year survive the rename flow

## Testing
- `python3 -m py_compile backend/app/core/contact_birthdays.py backend/tests/test_birthdays.py`
- `cd backend && . .venv/bin/activate && DATABASE_URL=sqlite:///./test-app.db JWT_SECRET=test-secret pytest tests/test_birthdays.py -q`

## Context
- fixes the regression discussed in #158
- long-term follow-up for stable ID-based linkage is tracked in #160
