### PR TITLE
docs: clarify nginx reverse proxy options

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,6 +97,45 @@ tribu.example.com {
 
 ### Nginx
 
+If you want the simplest setup, proxy everything to the frontend on port `3000`. Tribu's frontend already rewrites `/api/*`, `/dav*`, and `/.well-known/{caldav,carddav}` to the backend.
+
+```nginx
+upstream tribu-app {
+    zone tribu-app 64k;
+    server 127.0.0.1:3000;
+    keepalive 2;
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      "";
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name tribu.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/tribu.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/tribu.example.com/privkey.pem;
+    client_max_body_size 10M;
+
+    location / {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://tribu-app;
+        proxy_read_timeout 180s;
+    }
+}
+```
+
+If you prefer handling backend routes directly in nginx, this split setup also works. Keep the trailing slash on `proxy_pass http://127.0.0.1:8000/;` inside `location /api/` so nginx strips the `/api` prefix before forwarding to the backend.
+
 ```nginx
 server {
     listen 443 ssl;


### PR DESCRIPTION
## Summary
- add a simple nginx example that proxies everything to the frontend
- keep the split nginx example and explain the required trailing slash on `/api/`
- make it clearer when each option is appropriate

Refs: discussion #159