### PR TITLE
Use stable contact ids for synced birthdays

### DIFF
--- a/backend/alembic/versions/0029_add_birthday_contact_id.py
+++ b/backend/alembic/versions/0029_add_birthday_contact_id.py
@@ -1,0 +1,87 @@
+"""Link family_birthdays to contacts by stable id.
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-04-22
+
+Issue #160. Previously, contact-synced birthdays were located and
+maintained by ``person_name``, which broke on rename and could not
+represent two contacts sharing a name. This migration adds a nullable
+``contact_id`` FK on ``family_birthdays`` plus a partial unique index
+on ``(family_id, contact_id) WHERE contact_id IS NOT NULL``.
+
+Existing rows are backfilled only when name+date matches are
+unambiguous within a family; ambiguous legacy data is left unlinked so
+nothing is silently merged or reassigned. The runtime backfill logic
+lives in ``app.core.contact_birthdays.backfill_contact_id_from_name_match``
+so it is unit-testable.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.core.contact_birthdays import backfill_contact_id_from_name_match
+
+
+revision: str = "0029"
+down_revision: Union[str, None] = "0028"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_column(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    return column in {c["name"] for c in insp.get_columns(table)}
+
+
+def _has_index(table: str, name: str) -> bool:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    return name in {ix["name"] for ix in insp.get_indexes(table)}
+
+
+def upgrade() -> None:
+    if not _has_column("family_birthdays", "contact_id"):
+        # batch_alter_table rebuilds the table under SQLite so the FK is
+        # actually created; it is a no-op wrapper on PostgreSQL.
+        with op.batch_alter_table("family_birthdays") as batch:
+            batch.add_column(sa.Column("contact_id", sa.Integer, nullable=True))
+            batch.create_foreign_key(
+                "fk_family_birthdays_contact_id",
+                "contacts",
+                ["contact_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
+    if not _has_index("family_birthdays", "ix_family_birthdays_contact_id"):
+        op.create_index(
+            "ix_family_birthdays_contact_id",
+            "family_birthdays",
+            ["contact_id"],
+        )
+
+    if not _has_index("family_birthdays", "uq_family_birthdays_family_contact"):
+        op.create_index(
+            "uq_family_birthdays_family_contact",
+            "family_birthdays",
+            ["family_id", "contact_id"],
+            unique=True,
+            sqlite_where=sa.text("contact_id IS NOT NULL"),
+            postgresql_where=sa.text("contact_id IS NOT NULL"),
+        )
+
+    backfill_contact_id_from_name_match(op.get_bind())
+
+
+def downgrade() -> None:
+    if _has_index("family_birthdays", "uq_family_birthdays_family_contact"):
+        op.drop_index("uq_family_birthdays_family_contact", table_name="family_birthdays")
+    if _has_index("family_birthdays", "ix_family_birthdays_contact_id"):
+        op.drop_index("ix_family_birthdays_contact_id", table_name="family_birthdays")
+    if _has_column("family_birthdays", "contact_id"):
+        with op.batch_alter_table("family_birthdays") as batch:
+            batch.drop_constraint("fk_family_birthdays_contact_id", type_="foreignkey")
+            batch.drop_column("contact_id")

--- a/backend/app/core/contact_birthdays.py
+++ b/backend/app/core/contact_birthdays.py
@@ -1,76 +1,152 @@
+"""Sync helpers between Contact rows and their FamilyBirthday row.
+
+Contact-synced birthdays are identified by ``FamilyBirthday.contact_id``
+(stable FK to ``contacts.id``), not by ``person_name``. A rename on the
+contact updates the existing row in place; two contacts with the same
+name each own their own row; deleting one contact only affects its own
+linked row. Manual birthdays keep ``contact_id = NULL`` and are
+unaffected by contact flows.
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session
 
 from app.models import FamilyBirthday
 
 
-def upsert_family_birthday(
+def sync_contact_birthday(
     db: Session,
     family_id: int,
+    contact_id: int,
     person_name: str,
     month: int | None,
     day: int | None,
 ) -> None:
-    if not person_name or not month or not day:
+    """Reconcile the synced birthday row for one contact.
+
+    Creates, updates, or deletes the single ``FamilyBirthday`` row that
+    belongs to ``contact_id`` within ``family_id``. ``person_name`` is
+    stored on the row as the human-readable label; it is *not* used to
+    locate the row.
+
+    The ``year`` column is intentionally not touched here: contacts do
+    not carry a year, and a year the user set manually on the synced row
+    must survive edits/renames on the contact.
+    """
+    if contact_id is None:
         return
+
     existing = (
         db.query(FamilyBirthday)
         .filter(
             FamilyBirthday.family_id == family_id,
-            FamilyBirthday.person_name == person_name,
+            FamilyBirthday.contact_id == contact_id,
         )
         .first()
     )
-    if existing:
-        existing.month = month
-        existing.day = day
+
+    if month and day and person_name:
+        if existing:
+            existing.person_name = person_name
+            existing.month = month
+            existing.day = day
+            return
+        db.add(FamilyBirthday(
+            family_id=family_id,
+            contact_id=contact_id,
+            person_name=person_name,
+            month=month,
+            day=day,
+        ))
         return
-    db.add(FamilyBirthday(family_id=family_id, person_name=person_name, month=month, day=day))
+
+    if existing:
+        db.delete(existing)
 
 
-def delete_family_birthday(db: Session, family_id: int, person_name: str) -> None:
-    if not person_name:
+def delete_synced_birthday_for_contact(
+    db: Session,
+    family_id: int,
+    contact_id: int,
+) -> None:
+    """Remove the synced birthday row for a contact being deleted.
+
+    Only targets the row with matching ``contact_id``, so a manual
+    birthday that happens to share the contact's name/date is left
+    alone, and a second same-name contact's row is unaffected.
+    """
+    if contact_id is None:
         return
     (
         db.query(FamilyBirthday)
         .filter(
             FamilyBirthday.family_id == family_id,
-            FamilyBirthday.person_name == person_name,
+            FamilyBirthday.contact_id == contact_id,
         )
-        .delete()
+        .delete(synchronize_session=False)
     )
 
 
-def sync_contact_birthday(
-    db: Session,
-    family_id: int,
-    old_name: str | None,
-    new_name: str,
-    month: int | None,
-    day: int | None,
-) -> None:
-    existing = None
-    if old_name and old_name != new_name:
-        existing = (
-            db.query(FamilyBirthday)
-            .filter(
-                FamilyBirthday.family_id == family_id,
-                FamilyBirthday.person_name == old_name,
-            )
-            .first()
-        )
-        if existing:
-            existing.person_name = new_name
+def backfill_contact_id_from_name_match(conn: Connection) -> int:
+    """Conservatively link legacy unlinked birthday rows to contacts.
 
-    if existing:
-        if month and day:
-            existing.month = month
-            existing.day = day
-            return
-        db.delete(existing)
-        return
+    A legacy row (``contact_id IS NULL``) is linked to a contact only
+    when, within the same family, the tuple ``(person_name, month, day)``
+    matches *exactly one* contact's ``(full_name, birthday_month,
+    birthday_day)`` AND *exactly one* unlinked birthday row. Any
+    ambiguity (multiple same-name+date contacts, multiple same-name+date
+    birthday rows, a birthday that already links to a different
+    contact) is left untouched so no user data is silently collapsed or
+    reassigned.
 
-    if month and day:
-        upsert_family_birthday(db, family_id, new_name, month, day)
-        return
+    Returns the number of rows updated. Exposed as a plain helper so the
+    alembic migration and unit tests can call it against a live
+    connection.
+    """
+    contact_rows = conn.execute(text(
+        """
+        SELECT family_id, full_name, birthday_month, birthday_day, MIN(id) AS contact_id
+        FROM contacts
+        WHERE birthday_month IS NOT NULL
+          AND birthday_day IS NOT NULL
+          AND full_name IS NOT NULL
+        GROUP BY family_id, full_name, birthday_month, birthday_day
+        HAVING COUNT(*) = 1
+        """
+    )).fetchall()
 
-    delete_family_birthday(db, family_id, new_name)
+    updated = 0
+    for row in contact_rows:
+        params = {
+            "family_id": row[0],
+            "full_name": row[1],
+            "month": row[2],
+            "day": row[3],
+            "contact_id": row[4],
+        }
+        birthday_rows = conn.execute(text(
+            """
+            SELECT id FROM family_birthdays
+            WHERE family_id = :family_id
+              AND person_name = :full_name
+              AND month = :month
+              AND day = :day
+              AND contact_id IS NULL
+            """
+        ), params).fetchall()
+        if len(birthday_rows) != 1:
+            continue
+        # Guard against double-linking the same contact_id (would fail
+        # the partial unique index anyway, but fail early and skip).
+        already_linked = conn.execute(text(
+            "SELECT 1 FROM family_birthdays WHERE family_id = :family_id AND contact_id = :contact_id"
+        ), params).fetchone()
+        if already_linked is not None:
+            continue
+        conn.execute(text(
+            "UPDATE family_birthdays SET contact_id = :contact_id WHERE id = :birthday_id"
+        ), {"contact_id": params["contact_id"], "birthday_id": birthday_rows[0][0]})
+        updated += 1
+    return updated

--- a/backend/app/dav/caldav_storage.py
+++ b/backend/app/dav/caldav_storage.py
@@ -23,7 +23,7 @@ from radicale.storage import BaseStorage, BaseCollection
 from sqlalchemy.exc import IntegrityError
 
 from app.core import cache
-from app.core.contact_birthdays import delete_family_birthday, sync_contact_birthday
+from app.core.contact_birthdays import delete_synced_birthday_for_contact, sync_contact_birthday
 from app.core.ics_utils import events_to_ics, ics_to_event_dicts
 from app.core.vcard_utils import contact_to_vcard, contacts_to_vcards, vcard_to_contact_dict
 from app.database import SessionLocal
@@ -608,7 +608,6 @@ class AddressBookCollection(BaseCollection):
 
             replaced_item: Optional["radicale_item.Item"] = None
             if existing_by_href is not None:
-                old_name = existing_by_href.full_name
                 replaced_item = self._contact_to_item(existing_by_href)
                 _apply_contact_fields(existing_by_href, fields)
                 existing_by_href.vcard_uid = uid
@@ -624,11 +623,11 @@ class AddressBookCollection(BaseCollection):
                 )
                 _apply_contact_fields(row, fields)
                 db.add(row)
-                old_name = None
+                db.flush()
             sync_contact_birthday(
                 db,
                 self._family_id,
-                old_name,
+                row.id,
                 row.full_name,
                 row.birthday_month,
                 row.birthday_day,
@@ -650,7 +649,7 @@ class AddressBookCollection(BaseCollection):
             c = self._find_contact_by_href_scoped(db, href)
             if c is None:
                 raise KeyError(href)
-            delete_family_birthday(db, self._family_id, c.full_name)
+            delete_synced_birthday_for_contact(db, self._family_id, c.id)
             db.delete(c)
             db.commit()
         cache.invalidate_pattern(f"tribu:dashboard:{self._family_id}:*")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 
 from app.core.clock import utcnow
 
-from sqlalchemy import Column, Date, Integer, String, ForeignKey, UniqueConstraint, DateTime, Boolean, func, Text, JSON
+from sqlalchemy import Column, Date, Index, Integer, String, ForeignKey, UniqueConstraint, DateTime, Boolean, func, Text, JSON, text
 from sqlalchemy.orm import relationship
 
 from .database import Base
@@ -103,9 +103,33 @@ class FamilyBirthday(Base):
     month = Column(Integer, nullable=False)
     day = Column(Integer, nullable=False)
     year = Column(Integer, nullable=True)
+    # Nullable link to the originating Contact row. NULL means the
+    # birthday was entered manually; a non-null value means the row is
+    # synced from a contact and must be located and maintained by
+    # contact identity, not by person_name.
+    contact_id = Column(
+        Integer,
+        ForeignKey("contacts.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     created_at = Column(DateTime, nullable=False, default=utcnow)
 
+    __table_args__ = (
+        # At most one synced birthday per (family, contact). Partial so
+        # manual rows (contact_id IS NULL) can coexist freely.
+        Index(
+            "uq_family_birthdays_family_contact",
+            "family_id",
+            "contact_id",
+            unique=True,
+            sqlite_where=text("contact_id IS NOT NULL"),
+            postgresql_where=text("contact_id IS NOT NULL"),
+        ),
+    )
+
     family = relationship("Family", back_populates="birthdays")
+    contact = relationship("Contact", back_populates="birthday_entry")
 
 
 class Task(Base):
@@ -161,6 +185,13 @@ class Contact(Base):
     __table_args__ = (
         UniqueConstraint("family_id", "vcard_uid", name="uq_contacts_family_uid"),
         UniqueConstraint("family_id", "dav_href", name="uq_contacts_family_href"),
+    )
+
+    birthday_entry = relationship(
+        "FamilyBirthday",
+        back_populates="contact",
+        uselist=False,
+        passive_deletes=True,
     )
 
 

--- a/backend/app/modules/contacts_router.py
+++ b/backend/app/modules/contacts_router.py
@@ -6,7 +6,7 @@ from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from app.core import cache
-from app.core.contact_birthdays import delete_family_birthday, sync_contact_birthday, upsert_family_birthday
+from app.core.contact_birthdays import delete_synced_birthday_for_contact, sync_contact_birthday
 from app.core.deps import current_user, current_user_via_token_param, ensure_adult, ensure_family_membership
 from app.core.scopes import require_scope
 from app.core.vcard_utils import contact_channel_values
@@ -75,7 +75,16 @@ def create_contact(
         birthday_day=payload.birthday_day,
     )
     db.add(contact)
-    upsert_family_birthday(db, payload.family_id, payload.full_name, payload.birthday_month, payload.birthday_day)
+    # Flush so the synced birthday row can reference contact.id.
+    db.flush()
+    sync_contact_birthday(
+        db,
+        contact.family_id,
+        contact.id,
+        contact.full_name,
+        contact.birthday_month,
+        contact.birthday_day,
+    )
     db.commit()
     db.refresh(contact)
     cache.invalidate_pattern(f"tribu:dashboard:{payload.family_id}:*")
@@ -102,16 +111,18 @@ def update_contact(
         raise HTTPException(status_code=404, detail=error_detail(CONTACT_NOT_FOUND))
     ensure_adult(db, user.id, contact.family_id)
 
-    old_name = contact.full_name
     update_data = payload.model_dump(exclude_unset=True)
     for key, value in update_data.items():
         setattr(contact, key, value)
 
-    new_name = contact.full_name
-    new_month = contact.birthday_month
-    new_day = contact.birthday_day
-
-    sync_contact_birthday(db, contact.family_id, old_name, new_name, new_month, new_day)
+    sync_contact_birthday(
+        db,
+        contact.family_id,
+        contact.id,
+        contact.full_name,
+        contact.birthday_month,
+        contact.birthday_day,
+    )
 
     db.commit()
     db.refresh(contact)
@@ -137,7 +148,7 @@ def delete_contact(
         raise HTTPException(status_code=404, detail=error_detail(CONTACT_NOT_FOUND))
     ensure_adult(db, user.id, contact.family_id)
 
-    delete_family_birthday(db, contact.family_id, contact.full_name)
+    delete_synced_birthday_for_contact(db, contact.family_id, contact.id)
 
     db.delete(contact)
     db.commit()
@@ -266,7 +277,15 @@ def import_contacts_csv(
             birthday_day=day,
         )
         db.add(contact)
-        upsert_family_birthday(db, payload.family_id, name, month, day)
+        db.flush()
+        sync_contact_birthday(
+            db,
+            contact.family_id,
+            contact.id,
+            contact.full_name,
+            contact.birthday_month,
+            contact.birthday_day,
+        )
         created += 1
 
     db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -536,6 +536,10 @@ class BirthdayResponse(BaseModel):
     month: int = Field(..., description="Month (1-12)")
     day: int = Field(..., description="Day (1-31)")
     year: Optional[int] = Field(None, description="Birth year (null if unknown)")
+    contact_id: Optional[int] = Field(
+        None,
+        description="Contact this birthday is synced from; null for manual entries",
+    )
 
 
 class UpcomingBirthday(BaseModel):

--- a/backend/tests/test_birthdays.py
+++ b/backend/tests/test_birthdays.py
@@ -14,9 +14,10 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 from app.core.clock import utcnow
+from app.core.contact_birthdays import backfill_contact_id_from_name_match
 from app.database import Base, get_db
 from app.main import app
-from app.models import Family, FamilyBirthday, Membership, PersonalAccessToken, User
+from app.models import Contact, Family, FamilyBirthday, Membership, PersonalAccessToken, User
 from app.security import hash_password, PAT_PREFIX
 
 
@@ -204,46 +205,236 @@ def test_patch_without_year_key_leaves_year_untouched():
     assert body["year"] == 1940
 
 
-def test_contact_rename_preserves_existing_birthday_row_and_year():
-    token, family_id = _seed_member(scopes="birthdays:write,contacts:write")
+def test_contact_rename_updates_same_synced_row_without_creating_duplicate():
+    """Renaming a contact must rename its own synced birthday in place.
+
+    Stable identity lives on ``FamilyBirthday.contact_id`` now, so a
+    rename updates the existing row regardless of whether the old name
+    still matches.
+    """
+    token, family_id = _seed_member(scopes="birthdays:read,birthdays:write,contacts:write")
     client = TestClient(app)
 
-    created_birthday = client.post(
-        "/birthdays",
-        json={"family_id": family_id, "person_name": "Alice", "month": 4, "day": 14, "year": 1980},
-        headers=_auth_headers(token),
-    )
-    assert created_birthday.status_code == 200, created_birthday.text
-    birthday_id = created_birthday.json()["id"]
-
-    created_contact = client.post(
+    created = client.post(
         "/contacts",
         json={"family_id": family_id, "full_name": "Alice", "birthday_month": 4, "birthday_day": 14},
         headers=_auth_headers(token),
     )
-    assert created_contact.status_code == 200, created_contact.text
-    contact_id = created_contact.json()["id"]
+    assert created.status_code == 200, created.text
+    contact_id = created.json()["id"]
 
-    renamed_contact = client.patch(
+    before = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    assert len(before) == 1
+    synced_id = before[0]["id"]
+    assert before[0]["contact_id"] == contact_id
+
+    rename = client.patch(
         f"/contacts/{contact_id}",
         json={"full_name": "Alice Smith"},
         headers=_auth_headers(token),
     )
-    assert renamed_contact.status_code == 200, renamed_contact.text
+    assert rename.status_code == 200, rename.text
+
+    after = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    assert len(after) == 1
+    assert after[0]["id"] == synced_id
+    assert after[0]["person_name"] == "Alice Smith"
+    assert after[0]["contact_id"] == contact_id
+    assert after[0]["month"] == 4
+    assert after[0]["day"] == 14
+
+
+def test_contact_birthday_date_change_updates_same_row_in_place():
+    """Changing ``birthday_month``/``birthday_day`` on an existing contact
+    must update the synced row in place — no stale leftover, no new row.
+    """
+    token, family_id = _seed_member(scopes="birthdays:read,birthdays:write,contacts:write")
+    client = TestClient(app)
+
+    created = client.post(
+        "/contacts",
+        json={"family_id": family_id, "full_name": "Alice", "birthday_month": 4, "birthday_day": 14},
+        headers=_auth_headers(token),
+    )
+    assert created.status_code == 200, created.text
+    contact_id = created.json()["id"]
+
+    before = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    assert len(before) == 1
+    synced_id = before[0]["id"]
+    assert before[0]["contact_id"] == contact_id
+    assert (before[0]["month"], before[0]["day"]) == (4, 14)
+
+    patch = client.patch(
+        f"/contacts/{contact_id}",
+        json={"birthday_month": 12, "birthday_day": 25},
+        headers=_auth_headers(token),
+    )
+    assert patch.status_code == 200, patch.text
+
+    after = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    assert len(after) == 1, f"expected exactly one synced row, got {after}"
+    assert after[0]["id"] == synced_id
+    assert after[0]["contact_id"] == contact_id
+    assert (after[0]["month"], after[0]["day"]) == (12, 25)
+    assert after[0]["person_name"] == "Alice"
+
+
+def test_manual_birthday_survives_matching_contact_create_and_delete():
+    """A manual birthday that happens to match a contact must remain safe."""
+    token, family_id = _seed_member(scopes="birthdays:read,birthdays:write,contacts:write")
+    client = TestClient(app)
+
+    manual = client.post(
+        "/birthdays",
+        json={"family_id": family_id, "person_name": "Alice", "month": 4, "day": 14, "year": 1980},
+        headers=_auth_headers(token),
+    ).json()
+    manual_id = manual["id"]
+    assert manual["contact_id"] is None
+
+    contact = client.post(
+        "/contacts",
+        json={"family_id": family_id, "full_name": "Alice", "birthday_month": 4, "birthday_day": 14},
+        headers=_auth_headers(token),
+    ).json()
+    contact_id = contact["id"]
+
+    rows = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    by_id = {r["id"]: r for r in rows}
+    assert manual_id in by_id
+    assert by_id[manual_id]["contact_id"] is None
+    assert by_id[manual_id]["year"] == 1980
+    synced = [r for r in rows if r["contact_id"] == contact_id]
+    assert len(synced) == 1
+    assert synced[0]["id"] != manual_id
+
+    delete = client.delete(
+        f"/contacts/{contact_id}", headers=_auth_headers(token),
+    )
+    assert delete.status_code == 200, delete.text
+
+    remaining = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    assert [r["id"] for r in remaining] == [manual_id]
+    assert remaining[0]["year"] == 1980
+
+
+def test_two_contacts_same_name_each_own_a_birthday_row():
+    token, family_id = _seed_member(scopes="birthdays:read,birthdays:write,contacts:write")
+    client = TestClient(app)
+
+    a = client.post(
+        "/contacts",
+        json={"family_id": family_id, "full_name": "Max", "birthday_month": 9, "birthday_day": 3},
+        headers=_auth_headers(token),
+    ).json()
+    b = client.post(
+        "/contacts",
+        json={"family_id": family_id, "full_name": "Max", "birthday_month": 9, "birthday_day": 3},
+        headers=_auth_headers(token),
+    ).json()
+    assert a["id"] != b["id"]
+
+    rows = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    assert {r["contact_id"] for r in rows} == {a["id"], b["id"]}
+    assert len(rows) == 2
+
+
+def test_deleting_one_duplicate_name_contact_only_removes_its_own_row():
+    token, family_id = _seed_member(scopes="birthdays:read,birthdays:write,contacts:write")
+    client = TestClient(app)
+
+    a = client.post(
+        "/contacts",
+        json={"family_id": family_id, "full_name": "Max", "birthday_month": 9, "birthday_day": 3},
+        headers=_auth_headers(token),
+    ).json()
+    b = client.post(
+        "/contacts",
+        json={"family_id": family_id, "full_name": "Max", "birthday_month": 9, "birthday_day": 3},
+        headers=_auth_headers(token),
+    ).json()
+
+    client.delete(f"/contacts/{a['id']}", headers=_auth_headers(token))
+
+    remaining = client.get(
+        "/birthdays", params={"family_id": family_id}, headers=_auth_headers(token),
+    ).json()
+    assert len(remaining) == 1
+    assert remaining[0]["contact_id"] == b["id"]
+
+
+def test_backfill_is_conservative_with_ambiguous_legacy_data():
+    """Simulate a legacy DB: contacts + unlinked birthday rows with
+    matching names and dates. The backfill must link only unambiguous
+    pairs and leave ambiguous ones as ``contact_id IS NULL``.
+    """
+    db = TestSession()
+    try:
+        family = Family(name="Legacy Family")
+        db.add(family)
+        db.flush()
+        fid = family.id
+
+        # Unambiguous pair: one contact + one birthday with the same name/date.
+        solo_contact = Contact(
+            family_id=fid, full_name="Anna", birthday_month=3, birthday_day=1,
+        )
+        db.add(solo_contact)
+        solo_row = FamilyBirthday(family_id=fid, person_name="Anna", month=3, day=1)
+        db.add(solo_row)
+
+        # Ambiguous: two contacts with identical name+date.
+        db.add(Contact(family_id=fid, full_name="Max", birthday_month=9, birthday_day=3))
+        db.add(Contact(family_id=fid, full_name="Max", birthday_month=9, birthday_day=3))
+        ambiguous_row = FamilyBirthday(family_id=fid, person_name="Max", month=9, day=3)
+        db.add(ambiguous_row)
+
+        # Ambiguous: one contact but two candidate birthday rows.
+        db.add(Contact(family_id=fid, full_name="Lena", birthday_month=6, birthday_day=10))
+        dup_a = FamilyBirthday(family_id=fid, person_name="Lena", month=6, day=10)
+        dup_b = FamilyBirthday(family_id=fid, person_name="Lena", month=6, day=10, year=1970)
+        db.add(dup_a)
+        db.add(dup_b)
+
+        db.commit()
+        solo_contact_id = solo_contact.id
+        solo_row_id = solo_row.id
+        ambiguous_row_id = ambiguous_row.id
+        dup_a_id, dup_b_id = dup_a.id, dup_b.id
+    finally:
+        db.close()
+
+    with engine.connect() as conn:
+        with conn.begin():
+            updated = backfill_contact_id_from_name_match(conn)
+
+    assert updated == 1
 
     db = TestSession()
     try:
-        birthdays = (
-            db.query(FamilyBirthday)
-            .filter(FamilyBirthday.family_id == family_id)
-            .order_by(FamilyBirthday.id.asc())
-            .all()
-        )
-        assert len(birthdays) == 1
-        assert birthdays[0].id == birthday_id
-        assert birthdays[0].person_name == "Alice Smith"
-        assert birthdays[0].month == 4
-        assert birthdays[0].day == 14
-        assert birthdays[0].year == 1980
+        linked = db.query(FamilyBirthday).filter(FamilyBirthday.id == solo_row_id).one()
+        assert linked.contact_id == solo_contact_id
+
+        untouched_ambiguous = db.query(FamilyBirthday).filter(FamilyBirthday.id == ambiguous_row_id).one()
+        assert untouched_ambiguous.contact_id is None
+
+        for rid in (dup_a_id, dup_b_id):
+            row = db.query(FamilyBirthday).filter(FamilyBirthday.id == rid).one()
+            assert row.contact_id is None
     finally:
         db.close()

--- a/backend/tests/test_dav_carddav.py
+++ b/backend/tests/test_dav_carddav.py
@@ -244,6 +244,94 @@ class TestCardDAV:
         finally:
             db.close()
 
+    def test_put_updates_synced_birthday_in_place(self, app_under_test, seeded):
+        """A CardDAV update changing BDAY must update the linked birthday
+        row in place — same id, new month/day, no duplicates.
+        """
+        token, family_id = seeded
+        client = TestClient(app_under_test)
+        auth = {"Authorization": _basic(EMAIL, token), "Content-Type": "text/vcard"}
+        original = (
+            "BEGIN:VCARD\r\nVERSION:3.0\r\n"
+            "UID:bday-update@example.com\r\n"
+            "FN:Birthday Shift\r\nN:Shift;Birthday;;;\r\n"
+            "BDAY:--04-14\r\n"
+            "END:VCARD\r\n"
+        )
+        put = client.put(
+            f"/dav/{EMAIL}/book-{family_id}/birthday-shift.vcf",
+            headers=auth,
+            content=original,
+        )
+        assert put.status_code in (201, 204), put.text
+
+        db = SessionLocal()
+        try:
+            contact = (
+                db.query(Contact)
+                .filter(Contact.family_id == family_id, Contact.full_name == "Birthday Shift")
+                .first()
+            )
+            assert contact is not None
+            contact_id = contact.id
+            initial_rows = (
+                db.query(FamilyBirthday)
+                .filter(
+                    FamilyBirthday.family_id == family_id,
+                    FamilyBirthday.contact_id == contact_id,
+                )
+                .all()
+            )
+            assert len(initial_rows) == 1
+            synced_id = initial_rows[0].id
+            assert (initial_rows[0].month, initial_rows[0].day) == (4, 14)
+        finally:
+            db.close()
+
+        updated = (
+            "BEGIN:VCARD\r\nVERSION:3.0\r\n"
+            "UID:bday-update@example.com\r\n"
+            "FN:Birthday Shift\r\nN:Shift;Birthday;;;\r\n"
+            "BDAY:--12-25\r\n"
+            "END:VCARD\r\n"
+        )
+        put2 = client.put(
+            f"/dav/{EMAIL}/book-{family_id}/birthday-shift.vcf",
+            headers=auth,
+            content=updated,
+        )
+        assert put2.status_code in (201, 204), put2.text
+
+        db = SessionLocal()
+        try:
+            rows = (
+                db.query(FamilyBirthday)
+                .filter(
+                    FamilyBirthday.family_id == family_id,
+                    FamilyBirthday.contact_id == contact_id,
+                )
+                .all()
+            )
+            assert len(rows) == 1, f"expected in-place update, got {rows}"
+            assert rows[0].id == synced_id
+            assert (rows[0].month, rows[0].day) == (12, 25)
+            assert rows[0].person_name == "Birthday Shift"
+
+            # Nothing should have been left behind at the old date.
+            stale = (
+                db.query(FamilyBirthday)
+                .filter(
+                    FamilyBirthday.family_id == family_id,
+                    FamilyBirthday.person_name == "Birthday Shift",
+                    FamilyBirthday.month == 4,
+                    FamilyBirthday.day == 14,
+                )
+                .all()
+            )
+            assert stale == []
+        finally:
+            db.close()
+
     def test_put_preserves_multiple_channel_values_in_contact_response(self, app_under_test, seeded):
         token, family_id = seeded
         client = TestClient(app_under_test)

--- a/frontend/__tests__/hooks/useCalendar.test.js
+++ b/frontend/__tests__/hooks/useCalendar.test.js
@@ -44,6 +44,22 @@ describe('buildBirthdayEvents', () => {
     expect(events).toHaveLength(1);
     expect(events[0].title).toBe('Max (11)');
   });
+
+  it('keeps two contact-synced same-name same-date birthdays separate', () => {
+    const { buildBirthdayEvents } = require('../../hooks/useCalendar');
+    const events = buildBirthdayEvents({
+      viewYear: 2026,
+      birthdays: [
+        { id: 1, contact_id: 11, person_name: 'Max', month: 9, day: 3 },
+        { id: 2, contact_id: 12, person_name: 'Max', month: 9, day: 3 },
+      ],
+      members: [],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.title)).toEqual(['Max', 'Max']);
+    expect(new Set(events.map((event) => event.id)).size).toBe(2);
+  });
 });
 
 describe('useCalendar edit flow', () => {

--- a/frontend/e2e/tests/calendar-birthday-identity.spec.js
+++ b/frontend/e2e/tests/calendar-birthday-identity.spec.js
@@ -1,0 +1,60 @@
+const { test, expect } = require('../helpers/fixtures');
+const { getFamilyId } = require('../helpers/api-setup');
+const { navigateTo } = require('../helpers/navigation');
+
+async function seedContact(request, familyId, fullName, month, day) {
+  const res = await request.post('/api/contacts', {
+    data: {
+      family_id: familyId,
+      full_name: fullName,
+      birthday_month: month,
+      birthday_day: day,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/contacts failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
+test.describe('Birthday identity regression', () => {
+  test('calendar keeps duplicate-name contact birthdays separate and tracks rename/delete correctly', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    const name = `E2E Twin ${Date.now()}`;
+    const month = new Date().getMonth() + 1;
+    const day = 3;
+
+    const first = await seedContact(apiCtx, familyId, name, month, day);
+    const second = await seedContact(apiCtx, familyId, name, month, day);
+
+    await page.reload();
+    await navigateTo(page, 'Calendar');
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+    await page.locator('.calendar-day:not(.other-month)', { hasText: /^3$/ }).first().click();
+
+    await expect(page.locator('.day-detail-events .event-card-title', { hasText: name })).toHaveCount(2);
+
+    const renamed = `Renamed Twin ${Date.now()}`;
+    const renameRes = await apiCtx.patch(`/api/contacts/${second.id}`, {
+      data: { full_name: renamed },
+    });
+    expect(renameRes.ok()).toBeTruthy();
+
+    await page.reload();
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+    await page.locator('.calendar-day:not(.other-month)', { hasText: /^3$/ }).first().click();
+
+    await expect(page.locator('.day-detail-events .event-card-title', { hasText: name })).toHaveCount(1);
+    await expect(page.locator('.day-detail-events .event-card-title', { hasText: renamed })).toHaveCount(1);
+
+    const deleteRes = await apiCtx.delete(`/api/contacts/${first.id}`);
+    expect(deleteRes.ok()).toBeTruthy();
+
+    await page.reload();
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+    await page.locator('.calendar-day:not(.other-month)', { hasText: /^3$/ }).first().click();
+
+    await expect(page.locator('.day-detail-events .event-card-title', { hasText: name })).toHaveCount(0);
+    await expect(page.locator('.day-detail-events .event-card-title', { hasText: renamed })).toHaveCount(1);
+  });
+});

--- a/frontend/hooks/useCalendar.js
+++ b/frontend/hooks/useCalendar.js
@@ -409,14 +409,23 @@ export function useCalendar() {
 }
 
 export function buildBirthdayEvents({ birthdays = [], members = [], viewYear }) {
+  // Contact-synced birthdays (contact_id != null) are keyed by their
+  // stable contact id so two contacts that happen to share a name and
+  // date still show up as distinct calendar entries. Manual birthdays
+  // (contact_id == null) still collapse with a member's own
+  // date_of_birth when the name and date match, since that historically
+  // covers admins who manually added a row for their own family member.
   const deduped = new Map();
 
   for (const birthday of birthdays) {
     if (!birthday?.person_name || !birthday?.month || !birthday?.day) continue;
     const startsAt = new Date(viewYear, birthday.month - 1, birthday.day, 0, 0, 0).toISOString();
-    const key = `${birthday.person_name.toLowerCase()}|${birthday.month}|${birthday.day}`;
+    const key = birthday.contact_id != null
+      ? `contact-${birthday.contact_id}`
+      : `${birthday.person_name.toLowerCase()}|${birthday.month}|${birthday.day}`;
+    const stableIdPart = birthday.id ?? `${birthday.person_name}-${birthday.month}-${birthday.day}`;
     deduped.set(key, {
-      id: `birthday-${birthday.person_name}-${birthday.month}-${birthday.day}-${viewYear}`,
+      id: `birthday-${stableIdPart}-${viewYear}`,
       title: birthday.person_name,
       starts_at: startsAt,
       ends_at: null,


### PR DESCRIPTION
## Summary
- add `family_birthdays.contact_id` as a stable link to contacts
- sync contact birthdays by `contact_id` instead of `person_name`
- keep manual birthdays unlinked and untouched
- fix calendar dedupe for same-name same-date contacts
- add regression coverage for rename, date changes, delete, CardDAV updates, and local calendar behavior

## Verification
- `cd backend && . .venv/bin/activate && DATABASE_URL=sqlite:////tmp/tribu-review.db JWT_SECRET=test-secret pytest tests/test_birthdays.py tests/test_dav_carddav.py -q`
- `cd frontend && npm test -- --runInBand __tests__/hooks/useCalendar.test.js`
- local Playwright verification on demo instance via `frontend/e2e/tests/calendar-birthday-identity.spec.js`

## Notes
- migration backfills only unambiguous legacy matches inside the same family
- ambiguous legacy birthday rows remain unlinked
- manual birthdays remain separate from contact-synced rows

Closes #160
