### PR TITLE
chore: release Tribu under MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dennis Braun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -257,13 +257,9 @@ If Tribu helps your family stay organized, consider supporting development:
 
 ## License
 
-Tribu is **source-available**, but it is **not open source** at this time.
+Tribu is released under the **MIT License**.
 
-**All rights reserved.**
-
-The repository is public for transparency, feedback, and collaboration, but no open-source license is granted by default.
-
-If you need clarification about usage, redistribution, commercial use, or partnership/licensing options, please contact the maintainer first.
+That means you can use, modify, and redistribute the project with very few restrictions. See [LICENSE](LICENSE) for the full text.
 
 ---
 


### PR DESCRIPTION
## Summary
- add an MIT LICENSE file
- update the README license section to reflect the new open-source status

## Test plan
- [x] Confirm LICENSE file is present
- [x] Confirm README license section links to LICENSE