### PR TITLE
docs: sharpen README visual story and add MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Tribu</h1>
 
 <p align="center">
-  <strong>The private family organizer for real everyday life.</strong><br>
-  Shared calendar, tasks, shopping lists, contacts, birthdays, and reminders in one calm home. Self-hosted, bilingual, and built for real family workflows.
+  <strong>Self-hosted family organizer for real everyday life.</strong><br>
+  Calendars, tasks, shopping lists, contacts, birthdays, and reminders — one place, your server, your data.
 </p>
 
 <p align="center">
@@ -27,47 +27,55 @@
 ---
 
 <p align="center">
-  <img src="docs/assets/screenshot-hero-mobile.png" alt="Tribu mobile hero" width="100%" />
+  <img src="docs/assets/screenshot-mobile.png" alt="Mobile family dashboard" width="320" />
 </p>
 
 <p align="center">
-  <em>Tribu on mobile - a private family organizer for everyday life</em>
+  <em>Shared family dashboard on your phone — events, tasks, shopping, and household context in one calm view</em>
+</p>
+
+<p align="center">
+  <img src="docs/assets/screenshot-light.png" alt="Desktop family dashboard - Morning Mist theme" width="100%" />
+</p>
+
+<p align="center">
+  <em>Then scale up to a full desktop home base with upcoming events, open tasks, birthdays, and quick actions</em>
 </p>
 
 <details>
-<summary><strong>More screenshots</strong></summary>
+<summary><strong>Product tour screenshots</strong></summary>
 
 <br>
 
-**Desktop dashboard**
-
-<img src="docs/assets/screenshot-light.png" alt="Dashboard - Morning Mist theme" width="100%" />
-
-**Tablet calendar**
-
-<img src="docs/assets/screenshot-calendar.png" alt="Calendar view" width="100%" />
-
-**Desktop tasks**
-
-<img src="docs/assets/screenshot-tasks.png" alt="Tasks view" width="100%" />
-
-**Desktop shopping**
-
-<img src="docs/assets/screenshot-shopping.png" alt="Shopping view" width="100%" />
-
-**Desktop rewards**
-
-<img src="docs/assets/screenshot-rewards.png" alt="Rewards view" width="100%" />
-
-**Sign-in experience**
-
-<img src="docs/assets/screenshot-auth.png" alt="Login page" width="100%" />
-
-**Mobile (390px)**
+**1. Shared family dashboard on mobile**
 
 <p align="center">
   <img src="docs/assets/screenshot-mobile.png" alt="Mobile dashboard" width="320" />
 </p>
+
+**2. Full household overview on desktop**
+
+<img src="docs/assets/screenshot-light.png" alt="Dashboard - Morning Mist theme" width="100%" />
+
+**3. Shared calendar for appointments, school events, and routines**
+
+<img src="docs/assets/screenshot-calendar.png" alt="Calendar view" width="100%" />
+
+**4. Shopping lists that stay synced across the household**
+
+<img src="docs/assets/screenshot-shopping.png" alt="Shopping view" width="100%" />
+
+**5. Tasks with priorities, due dates, and ownership**
+
+<img src="docs/assets/screenshot-tasks.png" alt="Tasks view" width="100%" />
+
+**6. Rewards for family routines and motivation**
+
+<img src="docs/assets/screenshot-rewards.png" alt="Rewards view" width="100%" />
+
+**7. Clean sign-in and onboarding experience**
+
+<img src="docs/assets/screenshot-auth.png" alt="Login page" width="100%" />
 
 See the [Wiki](https://github.com/itsDNNS/tribu/wiki) for screenshots of every view and theme.
 
@@ -77,21 +85,14 @@ See the [Wiki](https://github.com/itsDNNS/tribu/wiki) for screenshots of every v
 
 ## Why Tribu?
 
-Most family organizer apps lock your data in their cloud. The privacy-friendly alternatives often make you stitch together separate tools for calendars, lists, contacts, and reminders. Tribu gives your household one shared home for everyday coordination, on your own server and under your control.
+Most family organizer apps lock your data in their cloud, split everyday planning across too many tools, and charge monthly fees on top. Tribu runs on your own hardware, keeps your household data under your control, and gives your family one place to stay coordinated.
 
-- **One calm shared home** - calendar, tasks, shopping, contacts, birthdays, and reminders in one place
-- **Private by default** - no mandatory cloud, no third-party SaaS dependency, your data stays on your hardware
-- **Built for actual family workflows** - shared planning for routines, errands, school life, household tasks, and family events
-- **Works today on desktop and mobile** - responsive interface plus CalDAV/CardDAV phone sync
-- **Try before you install** - interactive demo mode with realistic sample data, no backend required
-- **Bilingual out of the box** - German and English, lazy-loaded per module
-
-## Why families switch to Tribu
-
-- **Less app patchwork** - replace the usual mix of calendar apps, reminder apps, shopping lists, notes, and chat workarounds
-- **More family-native than generic productivity tools** - household members, shared context, birthdays, contacts, and routines belong together
-- **More private than cloud-first family apps** - your household data stays under your control
-- **More cohesive than DIY stacks** - less glue, less context switching, less setup friction
+- **Your data stays at home** — no mandatory cloud, no third-party SaaS dependency
+- **Built for actual family workflows** — calendars, tasks, shopping, contacts, birthdays, and reminders in one place
+- **Works on desktop and mobile** — responsive interface with a clean, content-first layout
+- **Try before you install** — interactive demo mode with realistic sample data, no backend required
+- **Bilingual out of the box** — German and English, lazy-loaded per module
+- **Extensible when you need more** — modular plugin architecture for features, themes, and languages
 
 ## What Tribu helps with
 
@@ -141,7 +142,7 @@ After setup, open **Settings → Phone sync** in Tribu to copy the CalDAV and Ca
 | **Themes** | Morning Mist (light) and Dark |
 | **i18n** | English and German out of the box, lazy-loaded per module |
 | **Demo mode** | Try the full UI with realistic sample data, no server setup required |
-| **Security** | httpOnly cookies, OIDC / SSO, rate limiting, scoped PATs, and non-root containers |
+| **Security** | httpOnly cookies, rate limiting, scoped PATs, and non-root containers |
 
 ## Quick Start
 
@@ -259,7 +260,7 @@ If Tribu helps your family stay organized, consider supporting development:
 
 Tribu is released under the **MIT License**.
 
-That means you can use, modify, and redistribute the project with very few restrictions. See [LICENSE](LICENSE) for the full text.
+See [LICENSE](LICENSE) for the full text.
 
 ---
 


### PR DESCRIPTION
## Summary
- lead with a clearer mobile-first README hero
- reorder screenshots into a stronger product story
- add the MIT license file and update the README license section

## Test Plan
- [x] reviewed README diff
- [x] verified referenced assets exist
