### PR TITLE
docs: add repo-local contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,209 @@
+# Contributing to Tribu
+
+Thanks for your interest in contributing to Tribu.
+
+This file is the fastest repo-local guide for contributors. Use it to understand how to propose work, run the app locally, verify changes, and decide where code should live.
+
+For deeper references, also see:
+
+- [Architecture](https://github.com/itsDNNS/tribu/wiki/Architecture)
+- [Plugin Manifest](https://github.com/itsDNNS/tribu/wiki/Plugin-Manifest)
+- [Roadmap](https://github.com/itsDNNS/tribu/wiki/Roadmap)
+- [Self-Hosting Guide](docs/self-hosting.md)
+- [Security Policy](SECURITY.md)
+
+## Before you start
+
+- Open an issue before starting significant work so the approach can be aligned early.
+- Small fixes like typos, narrow bug fixes, and doc improvements can usually go straight to a PR.
+- Keep changes scoped. Tribu is easier to review when one PR solves one clear problem.
+
+## Engineering principles
+
+### 1. Architecture first
+
+Before changing code, read the relevant architecture and module context first.
+
+Do not start by scattering changes across the repo. First decide:
+
+- which layer should own the change
+- which files are the right home for it
+- whether it belongs in core product code, an existing module, docs, or plugin-related surfaces
+
+A good PR explains file placement clearly before or alongside the implementation.
+
+### 2. Keep boundaries clean
+
+Prefer small, typed, production-ready changes over broad rewrites.
+
+Examples:
+
+- backend API logic belongs in backend modules and supporting backend layers, not in frontend helpers
+- frontend view behavior belongs in components, hooks, or lib utilities that already own that concern
+- docs changes should update the canonical doc instead of duplicating conflicting instructions in multiple places
+
+### 3. Do not hide uncertainty
+
+If a change conflicts with existing architecture, product direction, or documentation, raise it in the issue or PR instead of guessing.
+
+## Repo map
+
+A simplified map of the main areas:
+
+```text
+tribu/
+├── backend/              # FastAPI app, models, routers, tests, migrations
+├── frontend/             # Next.js app, components, hooks, tests, e2e
+├── docker/               # Compose stack and env template
+├── docs/                 # Repo-local documentation and assets
+├── scripts/              # Backup and restore helpers
+├── README.md             # Public product-facing entry page
+├── CONTRIBUTING.md       # Repo-local contributor guide
+└── SECURITY.md           # Security disclosure policy
+```
+
+## Development setup
+
+## Option A: Full stack with Docker Compose
+
+This is the easiest way to boot the whole app locally.
+
+```bash
+git clone https://github.com/itsDNNS/tribu.git
+cd tribu
+cp docker/.env.example docker/.env
+# Fill in JWT_SECRET and POSTGRES_PASSWORD
+cd docker
+docker compose up --build
+```
+
+Then open `http://localhost:3000`.
+
+The first registered user becomes the family admin.
+
+## Option B: Local frontend + local backend
+
+### Prerequisites
+
+- Python 3.13+
+- Node.js 20+
+- Docker with Compose v2 for PostgreSQL/Valkey or for full-stack runs
+
+### Backend
+
+Create and activate a virtual environment inside `backend/`, install dependencies, set required environment variables, and run the API:
+
+```bash
+cd backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install pytest
+export DATABASE_URL="postgresql://tribu:password@localhost:5432/tribu"
+export JWT_SECRET="<random-64-char-hex>"  # generate with: openssl rand -hex 32
+uvicorn app.main:app --reload --port 8000
+```
+
+Required backend environment variables:
+
+- `DATABASE_URL`
+- `JWT_SECRET`
+
+If you want a ready database/cache quickly, start the supporting services from the compose stack and point your local backend at them.
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend expects the app at `http://localhost:3000` and the backend at `http://localhost:8000`.
+
+## Testing before you open a PR
+
+Run the narrowest relevant checks for your change, then broaden if needed.
+
+### Frontend
+
+```bash
+cd frontend
+npm test
+npm run build
+```
+
+For browser coverage:
+
+```bash
+cd frontend
+npm run e2e
+```
+
+### Backend
+
+```bash
+cd backend
+source .venv/bin/activate
+pytest
+```
+
+If your change touches authentication, DAV, invitations, admin flows, or data integrity, prefer adding or updating backend tests near the affected area.
+
+## Where changes should go
+
+### Product and feature changes
+
+- backend routes and domain logic: `backend/app/`
+- backend tests: `backend/tests/`
+- frontend screens and UI behavior: `frontend/components/`, `frontend/hooks/`, `frontend/lib/`
+- frontend unit tests: `frontend/__tests__/`
+- frontend end-to-end coverage: `frontend/e2e/tests/`
+
+### Docs and positioning
+
+- public first impression and product story: `README.md`
+- contributor workflow: `CONTRIBUTING.md`
+- self-hosting and operations: `docs/self-hosting.md`
+- security disclosure process: `SECURITY.md`
+- deeper architecture, roadmap, changelog, and plugin details: wiki pages linked from the README
+
+## PR expectations
+
+A good PR should:
+
+- explain the problem being solved
+- explain why the chosen file placement is correct
+- keep unrelated changes out of scope
+- include tests or a clear reason they were not needed
+- update docs when behavior, setup, or contributor expectations changed
+
+Recommended PR structure:
+
+1. Summary
+2. File placement / architecture notes
+3. Test plan
+4. Screenshots or recordings for meaningful UI changes
+
+## Documentation updates are part of the job
+
+When you change setup steps, developer workflow, behavior, architecture assumptions, or user-facing flows, update the relevant docs in the same PR.
+
+Do not leave the README, self-hosting guide, and contributor docs drifting apart.
+
+## Security
+
+Please do not open a public issue for sensitive vulnerabilities. Follow the process in [SECURITY.md](SECURITY.md).
+
+## Ways to help beyond code
+
+Contributions are also welcome in the form of:
+
+- issue triage
+- docs improvements
+- self-hosting feedback
+- bug reproduction steps
+- UI polish suggestions
+- tests and regression coverage
+
+Thanks for helping make Tribu stronger.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="#quick-start">Quick Start</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="#phone-sync">Phone Sync</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/tribu/wiki">Wiki</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
-  <a href="https://github.com/itsDNNS/tribu/wiki/Contributing">Contributing</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
+  <a href="CONTRIBUTING.md">Contributing</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/tribu/wiki/Roadmap">Roadmap</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/tribu/wiki/Changelog">Changelog</a>
 </p>
@@ -176,7 +176,7 @@ After setup, open **Settings → Phone sync** in Tribu to copy the CalDAV and Ca
 - **Want it in your stack fast?** Jump to [Quick Start](#quick-start) and run it with Docker Compose on your server, NAS, or mini PC.
 - **Want phone integration from day one?** Use [Phone Sync](#phone-sync) for CalDAV and CardDAV setup with supported clients.
 - **Want to inspect how it is built before you commit?** Start with the [Architecture](https://github.com/itsDNNS/tribu/wiki/Architecture) and [Self-Hosting Guide](docs/self-hosting.md).
-- **Want to contribute or extend it?** Head to [Contributing](https://github.com/itsDNNS/tribu/wiki/Contributing) and the [Plugin Manifest](https://github.com/itsDNNS/tribu/wiki/Plugin-Manifest).
+- **Want to contribute or extend it?** Start with [Contributing](CONTRIBUTING.md), then use the [Plugin Manifest](https://github.com/itsDNNS/tribu/wiki/Plugin-Manifest) for extension-specific details.
 
 ## Quick Start
 
@@ -259,7 +259,7 @@ docker compose up -d
 
 </details>
 
-> **Development setup?** See [Contributing](https://github.com/itsDNNS/tribu/wiki/Contributing) for building from source.
+> **Development setup?** See [Contributing](CONTRIBUTING.md) for local workflow, testing, and PR expectations.
 
 ## Tech Stack
 
@@ -294,7 +294,7 @@ Tribu is not only trying to be pleasant for families using it. It is also set up
 | [Architecture](https://github.com/itsDNNS/tribu/wiki/Architecture) | Backend modules, frontend patterns, security, API reference |
 | [Plugin Manifest](https://github.com/itsDNNS/tribu/wiki/Plugin-Manifest) | How to build feature, theme, and language plugins |
 | [Roadmap](https://github.com/itsDNNS/tribu/wiki/Roadmap) | Development phases and planned features |
-| [Contributing](https://github.com/itsDNNS/tribu/wiki/Contributing) | Dev setup, project structure, PR guidelines |
+| [Contributing](CONTRIBUTING.md) | Local dev setup, testing, project boundaries, and PR expectations |
 | [Security](SECURITY.md) | Security policy and responsible disclosure |
 | [Changelog](https://github.com/itsDNNS/tribu/wiki/Changelog) | Release history |
 


### PR DESCRIPTION
## Summary
- add a repo-local CONTRIBUTING.md so contributor guidance lives in the repository instead of only in the wiki
- document architecture-first contribution expectations, local dev setup, testing, boundaries, and PR expectations
- update README contributor links to point to the new local guide while keeping deeper docs in the wiki

## Test Plan
- [x] Reviewed README and CONTRIBUTING.md locally
- [x] Verified public-writing punctuation in README and CONTRIBUTING.md
- [x] Checked repo structure and existing docs before writing the guide
