### PR TITLE
docs: clarify documentation ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to Tribu.
 
 This file is the fastest repo-local guide for contributors. Use it to understand how to propose work, run the app locally, verify changes, and decide where code should live.
 
-For deeper references, also see:
+For contributor workflow inside the repository, treat this file as the canonical source. Use the wiki for deeper architecture, roadmap, changelog, and plugin reference material.
 
 - [Architecture](https://github.com/itsDNNS/tribu/wiki/Architecture)
 - [Plugin Manifest](https://github.com/itsDNNS/tribu/wiki/Plugin-Manifest)

--- a/README.md
+++ b/README.md
@@ -287,16 +287,15 @@ Tribu is not only trying to be pleasant for families using it. It is also set up
 
 ## Documentation
 
+Use the document that matches your intent:
+
 | | |
 |---|---|
-| [Self-Hosting Guide](docs/self-hosting.md) | Configuration, reverse proxy, backups, updating, troubleshooting |
-| [Wiki](https://github.com/itsDNNS/tribu/wiki) | Screenshots, features, themes, getting started |
-| [Architecture](https://github.com/itsDNNS/tribu/wiki/Architecture) | Backend modules, frontend patterns, security, API reference |
-| [Plugin Manifest](https://github.com/itsDNNS/tribu/wiki/Plugin-Manifest) | How to build feature, theme, and language plugins |
-| [Roadmap](https://github.com/itsDNNS/tribu/wiki/Roadmap) | Development phases and planned features |
+| [README](README.md) | Product overview, screenshots, positioning, and quick start |
 | [Contributing](CONTRIBUTING.md) | Local dev setup, testing, project boundaries, and PR expectations |
+| [Self-Hosting Guide](docs/self-hosting.md) | Configuration, reverse proxy, backups, updating, and troubleshooting |
+| [Wiki](https://github.com/itsDNNS/tribu/wiki) | Architecture, roadmap, changelog, plugin details, and reference pages |
 | [Security](SECURITY.md) | Security policy and responsible disclosure |
-| [Changelog](https://github.com/itsDNNS/tribu/wiki/Changelog) | Release history |
 
 ## Support
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -2,6 +2,15 @@
 
 Everything you need to run Tribu on your own server.
 
+## Use this guide for
+
+- installing Tribu on your own infrastructure
+- configuring environment variables, reverse proxy, and phone sync
+- backups, updates, and troubleshooting in production-like setups
+
+If you want the public overview, start with the [README](../README.md).
+If you want local development workflow, tests, and PR expectations, use [CONTRIBUTING.md](../CONTRIBUTING.md).
+
 ## Prerequisites
 
 - **Docker** with **Compose v2** (`docker compose` — not the legacy `docker-compose`)


### PR DESCRIPTION
## Summary
- clarify which document should be used for product overview, contributing workflow, self-hosting, and deeper reference material
- make README and self-hosting guide point more clearly to the right next document
- align the wiki home and wiki contributing page with the new repo-local CONTRIBUTING.md

## Test Plan
- [x] Reviewed README, CONTRIBUTING.md, and self-hosting guide locally
- [x] Reviewed and updated wiki Home and Contributing pages
- [x] Checked public-facing markdown for em dashes in edited repo files and wiki files
