### PR TITLE
docs: tighten consistency across contributor guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ tribu/
 
 ## Development setup
 
-## Option A: Full stack with Docker Compose
+### Option A: Full stack with Docker Compose
 
 This is the easiest way to boot the whole app locally.
 
@@ -81,7 +81,7 @@ Then open `http://localhost:3000`.
 
 The first registered user becomes the family admin.
 
-## Option B: Local frontend + local backend
+### Option B: Local frontend + local backend
 
 ### Prerequisites
 
@@ -99,8 +99,8 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 pip install pytest
-export DATABASE_URL="postgresql://tribu:password@localhost:5432/tribu"
-export JWT_SECRET="<random-64-char-hex>"  # generate with: openssl rand -hex 32
+export DATABASE_URL="postgresql://tribu:***@localhost:5432/tribu"
+export JWT_SECRET="your-generated-64-char-hex"  # generate with: openssl rand -hex 32
 uvicorn app.main:app --reload --port 8000
 ```
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -54,7 +54,7 @@ The backend refuses to start if these are missing.
 | `VAPID_PUBLIC_KEY` | *(empty)* | VAPID public key for push notifications. See [Push Notifications](#push-notifications-optional). |
 | `VAPID_PRIVATE_KEY` | *(empty)* | VAPID private key for push notifications. |
 | `VAPID_CLAIMS_EMAIL` | *(empty)* | Contact email for VAPID claims (e.g. `mailto:admin@example.com`). |
-| `REDIS_URL` | `redis://valkey:6379/0` | Connection URL for the Valkey/Redis instance. Only change this if you use an external cache. |
+| `REDIS_URL` | `redis://valkey:6379/0` | Optional Valkey/Redis connection string override. |
 | `JWT_EXPIRE_HOURS` | `24` | How long JWT tokens stay valid, in hours. |
 
 ### Docker Compose Internals


### PR DESCRIPTION
## Summary
- clean up small consistency issues in CONTRIBUTING.md and the self-hosting guide
- fix heading hierarchy and clearer example values in repo-local contributor docs
- refresh the wiki home wording so it matches the current README positioning and support language more closely

## Test Plan
- [x] Searched edited repo docs and wiki pages for stale wording patterns
- [x] Checked edited markdown for em dashes and old section names
- [x] Reviewed diffs for README-adjacent docs and wiki home
