### PR TITLE
docs: align deep reference docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ cd backend
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-pip install pytest
+pip install pytest httpx
 export DATABASE_URL="postgresql://tribu:***@localhost:5432/tribu"
 export JWT_SECRET="your-generated-64-char-hex"  # generate with: openssl rand -hex 32
 uvicorn app.main:app --reload --port 8000
@@ -110,6 +110,8 @@ Required backend environment variables:
 - `JWT_SECRET`
 
 If you want a ready database/cache quickly, start the supporting services from the compose stack and point your local backend at them.
+
+Backend tests currently expect `pytest` and `httpx` to be available inside `backend/.venv` in addition to the packages from `requirements.txt`.
 
 ### Frontend
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,13 +11,13 @@ We will acknowledge reports within 48 hours and provide a timeline for fixes.
 | Feature | Implementation |
 |---------|---------------|
 | Password storage | bcrypt (legacy PBKDF2-SHA256 hashes are verified and auto-rehashed on login) |
-| Password policy | Minimum 8 characters (enforced via Pydantic schema validation) |
+| Password policy | Minimum 8 characters with at least 1 uppercase letter and 1 digit (enforced via Pydantic schema validation) |
 | Authentication | httpOnly cookie (JWT HS256), Bearer token fallback for API testing |
 | Rate limiting | 10/min for registration, 20/min for login (slowapi) |
 | CORS | Restricted to `localhost`, `127.0.0.1`, and `192.168.x.x` via regex |
 | Data isolation | All queries filtered by `family_id` with membership verification |
 | Docker containers | Non-root user (`tribu`) in both backend and frontend images |
-| Docker networking | PostgreSQL and Redis not exposed to host, only accessible within Docker network |
+| Docker networking | PostgreSQL and Valkey are not exposed to the host and stay inside the Docker network |
 | Build process | Multi-stage frontend build, `.dockerignore` files for both services |
 | CSV import | Row limit (500), range checks on month/day fields, email format validation |
 
@@ -47,8 +47,8 @@ Follow these steps before exposing Tribu to the internet:
 2. **Enable secure cookies**: Set `SECURE_COOKIES=true` in your `.env` file. This adds the `Secure` flag to auth cookies so they are only sent over HTTPS.
 3. **Generate strong secrets**: Use `openssl rand -hex 32` for `JWT_SECRET` and `openssl rand -hex 16` for `POSTGRES_PASSWORD`. Never reuse secrets across instances.
 4. **Restrict CORS** (optional): The default regex allows all `192.168.x.x` addresses. If your instance is public, consider narrowing this to your specific domain by modifying the `allow_origin_regex` in `backend/app/main.py`.
-5. **Backups**: Schedule regular PostgreSQL dumps of the `tribu_pg_data` Docker volume. A minimal cron job: `docker exec tribu-postgres pg_dump -U tribu tribu > backup_$(date +%F).sql`
-6. **Keep images updated**: Rebuild Docker images periodically to pick up security patches in base images (Python, Node, PostgreSQL, Redis).
+5. **Backups**: Schedule regular PostgreSQL backups and test restore procedures. The [Self-Hosting Guide](docs/self-hosting.md#backup-and-restore) documents the built-in backup flow.
+6. **Keep images updated**: Rebuild Docker images periodically to pick up security patches in base images and dependencies.
 
 ## Known Limitations
 
@@ -61,7 +61,7 @@ Follow these steps before exposing Tribu to the internet:
 
 ## Docker Security
 
-Both the backend and frontend Dockerfiles create a dedicated non-root user (`tribu`) and run all processes under that user. The Docker Compose configuration does not expose database or cache ports to the host, keeping PostgreSQL and Redis accessible only within the Docker network.
+Both the backend and frontend Dockerfiles create a dedicated non-root user (`tribu`) and run all processes under that user. The Docker Compose configuration does not expose database or cache ports to the host, keeping PostgreSQL and Valkey accessible only within the Docker network.
 
 Build artifacts are minimized through:
 - Multi-stage builds for the frontend (build step separated from runtime)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -13,7 +13,7 @@ If you want local development workflow, tests, and PR expectations, use [CONTRIB
 
 ## Prerequisites
 
-- **Docker** with **Compose v2** (`docker compose` — not the legacy `docker-compose`)
+- **Docker** with **Compose v2** (`docker compose`, not the legacy `docker-compose`)
 - **512 MB RAM** minimum, **1 GB disk** for the database volume
 - A **domain with TLS** if you plan to expose Tribu to the internet (see [Reverse Proxy](#reverse-proxy))
 
@@ -51,11 +51,11 @@ The backend refuses to start if these are missing.
 |----------|---------|-------------|
 | `SECURE_COOKIES` | `false` | Set to `true` when running behind a TLS reverse proxy. Enables the `Secure` flag on auth cookies. |
 | `BASE_URL` | *(auto-detect)* | Public URL of your instance (e.g. `https://tribu.example.com`). Used for push notification payloads. Auto-detected from request headers if not set. |
+| `JWT_EXPIRE_HOURS` | `24` | Session lifetime in hours for Tribu's auth tokens and cookies. |
 | `VAPID_PUBLIC_KEY` | *(empty)* | VAPID public key for push notifications. See [Push Notifications](#push-notifications-optional). |
 | `VAPID_PRIVATE_KEY` | *(empty)* | VAPID private key for push notifications. |
 | `VAPID_CLAIMS_EMAIL` | *(empty)* | Contact email for VAPID claims (e.g. `mailto:admin@example.com`). |
-| `REDIS_URL` | `redis://valkey:6379/0` | Optional Valkey/Redis connection string override. |
-| `JWT_EXPIRE_HOURS` | `24` | How long JWT tokens stay valid, in hours. |
+| `REDIS_URL` | `redis://valkey:6379/0` | Optional Valkey-compatible cache connection string override. |
 
 ### Docker Compose Internals
 
@@ -297,7 +297,7 @@ Use **Test discovery** to verify the provider is reachable before saving.
 
 ### 4. Reverse proxy
 
-All Tribu reverse-proxy examples in this guide already forward `/auth/oidc/*` to the Tribu frontend, which proxies it to the backend. No extra rules are needed. If you use a custom split setup that routes `/api/*` directly to the backend, do **not** route `/auth/oidc/*` directly — keep it going through the frontend so the callback URL (`/auth/oidc/callback`) matches what your IdP has registered.
+All Tribu reverse-proxy examples in this guide already forward `/auth/oidc/*` to the Tribu frontend, which proxies it to the backend. No extra rules are needed. If you use a custom split setup that routes `/api/*` directly to the backend, do **not** route `/auth/oidc/*` directly. Keep it going through the frontend so the callback URL (`/auth/oidc/callback`) matches what your IdP has registered.
 
 ### 5. Secret storage
 
@@ -424,8 +424,8 @@ Configure automatic backups in **Settings > Admin > Backup**:
 
 Each backup is a `tribu-backup-YYYY-MM-DD-HHMMSS.tar.gz` archive containing:
 
-- `database.dump` — PostgreSQL dump (`pg_dump -Fc` custom format)
-- `metadata.json` — backup version, Alembic revision, PostgreSQL version, timestamp
+- `database.dump`: PostgreSQL dump (`pg_dump -Fc` custom format)
+- `metadata.json`: backup version, Alembic revision, PostgreSQL version, timestamp
 
 ### Manual Backup
 
@@ -487,8 +487,8 @@ docker compose logs postgres
 ```
 
 Common causes:
-- Missing `JWT_SECRET` or `POSTGRES_PASSWORD` — the backend exits immediately with an error message
-- Port 8000 or 3000 already in use — change the host port in `docker-compose.yml` (e.g. `"8080:8000"`)
+- Missing `JWT_SECRET` or `POSTGRES_PASSWORD`: the backend exits immediately with an error message
+- Port 8000 or 3000 already in use: change the host port in `docker-compose.yml` (e.g. `"8080:8000"`)
 
 ### Database connection errors
 
@@ -519,7 +519,7 @@ If running locally without TLS, keep `SECURE_COOKIES=false`.
 ### Push notifications not working
 
 - VAPID keys must be set in `.env` **and** the backend must be restarted
-- Push notifications require HTTPS — they won't work over plain HTTP
+- Push notifications require HTTPS, so they will not work over plain HTTP
 - The user must explicitly enable notifications in their profile settings
 - Check browser permissions (Settings > Site permissions > Notifications)
 


### PR DESCRIPTION
## Summary
- tighten repo-local deep docs so contributor, self-hosting, and security guidance stay consistent
- refresh wiki reference pages to match current wording, Valkey naming, and shipped phone sync behavior
- remove stale public-facing wording that no longer matches the current product/docs structure

## Test plan
- not run (documentation-only changes)
- audited repo and wiki diffs for wording consistency and stale references
