### PR TITLE
docs: polish repo community entry points

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a reproducible product, self-hosting, or documentation bug.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        If this is a setup question or you are unsure whether it is a bug yet, please consider starting in [Discussions Q&A](https://github.com/itsDNNS/tribu/discussions/categories/q-a) first.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is going wrong?
+      placeholder: A short description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Tell us how to trigger the problem.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Web app / UI
+        - Self-hosting / deployment
+        - Phone sync / CalDAV / CardDAV
+        - Authentication / SSO
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Share only what is relevant.
+      placeholder: |
+        - Tribu version:
+        - Browser or device:
+        - Deployment method:
+        - Reverse proxy:
+        - OS / platform:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or extra context
+      description: Paste logs or add screenshots if they help.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and setup help
+    url: https://github.com/itsDNNS/tribu/discussions/categories/q-a
+    about: Ask for self-hosting help, setup support, or product questions in Discussions Q&A.
+  - name: Ideas and feature discussion
+    url: https://github.com/itsDNNS/tribu/discussions/categories/ideas
+    about: Share product ideas, feature concepts, and early feedback in Discussions.
+  - name: Security vulnerability report
+    url: https://github.com/itsDNNS/tribu/security/advisories/new
+    about: Report sensitive vulnerabilities privately through GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose a product improvement, workflow enhancement, or self-hosting capability.
+title: "feature: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea.
+
+        If you want early discussion before turning it into a tracked issue, [Discussions Ideas](https://github.com/itsDNNS/tribu/discussions/categories/ideas) is a good place to shape it first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: What friction, gap, or need are you trying to solve?
+      placeholder: What is missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you want.
+      placeholder: How should this work?
+    validations:
+      required: true
+  - type: textarea
+    id: households
+    attributes:
+      label: Who benefits
+      description: Tell us whether this is mainly for families, self-hosters, contributors, or multiple groups.
+      placeholder: Who would use or benefit from this?
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Core product experience
+        - Calendar / tasks / shopping / reminders
+        - Family onboarding / adoption
+        - Self-hosting / infrastructure
+        - Phone sync / interoperability
+        - Plugins / extensibility
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or related ideas
+      placeholder: Any alternatives, prior workarounds, or related discussions?

--- a/README.md
+++ b/README.md
@@ -301,7 +301,14 @@ Use the document that matches your intent:
 
 If Tribu helps your family stay organized, consider supporting development.
 
-If you are a self-hoster or contributor, starring the repo, opening issues, improving docs, or contributing code all help make the project stronger too.
+If you are a self-hoster or contributor, starring the repo, opening issues, improving docs, joining Discussions, or contributing code all help make the project stronger too.
+
+Need the right place?
+
+- **Questions and setup help:** use [Discussions Q&A](https://github.com/itsDNNS/tribu/discussions/categories/q-a)
+- **Ideas and early product feedback:** use [Discussions Ideas](https://github.com/itsDNNS/tribu/discussions/categories/ideas)
+- **Reproducible bugs or scoped feature requests:** open an [Issue](https://github.com/itsDNNS/tribu/issues)
+- **Sensitive security reports:** follow the [Security Policy](SECURITY.md)
 
 - [Ko-fi](https://ko-fi.com/itsdnns)
 - [PayPal](https://paypal.me/itsDNNS)


### PR DESCRIPTION
## Summary
- add issue forms and contact routing so questions, ideas, bugs, and security reports land in the right place
- tighten the README support section to point visitors to Discussions, Issues, and the security policy clearly
- mirror the same routing guidance on the wiki home page for better community navigation

## Test plan
- not run (documentation and GitHub issue-form changes only)
- verified discussion categories and repo community settings with gh
- reviewed repo and wiki diffs for wording consistency and link targets
