### PR TITLE
fix(auth): address OIDC adversarial review findings

### DIFF
--- a/backend/app/core/oidc.py
+++ b/backend/app/core/oidc.py
@@ -48,6 +48,19 @@ KEY_CLIENT_SECRET = "oidc_client_secret"
 KEY_SCOPES = "oidc_scopes"
 KEY_ALLOW_SIGNUP = "oidc_allow_signup"
 KEY_DISABLE_PASSWORD_LOGIN = "oidc_disable_password_login"
+# Timestamp (ISO 8601 UTC) of the most recent successful /auth/oidc/callback.
+# Used as the lockout guard: disable_password_login is only honored when an
+# end-to-end SSO login actually worked recently, otherwise a mistyped issuer
+# or revoked client secret would lock every admin out the moment sessions
+# expire. Stamped on every successful callback.
+KEY_LAST_SUCCESS_AT = "oidc_last_success_at"
+
+# How stale an SSO proof-of-life can be before password login is re-armed
+# automatically. 30 days is comfortably longer than JWT_EXPIRE_HOURS (24h
+# default) so a single break over a weekend does not flip the instance,
+# but short enough that a long outage cannot leave admins permanently
+# unable to recover without shell access.
+LOCKOUT_GRACE_DAYS = 30
 
 ALL_KEYS = (
     KEY_ENABLED,
@@ -216,16 +229,61 @@ def save_config(
     )
 
 
+def record_successful_sso_login(db: Session) -> None:
+    """Stamp ``oidc_last_success_at`` at UTC now.
+
+    Called from the callback handler after the ID token verifies and
+    the local user is resolved. Storage is ISO 8601 (UTC, second
+    precision) for human-readable debugging alongside the other
+    ``oidc_*`` settings. Does not commit — the caller's transaction
+    already commits after wiring up identity, membership, and
+    session cookie.
+    """
+    set_setting(db, KEY_LAST_SUCCESS_AT, utcnow().replace(microsecond=0).isoformat())
+
+
+def _last_success_within_grace(db: Session) -> bool:
+    """True if an SSO login succeeded within ``LOCKOUT_GRACE_DAYS``.
+
+    Tribu's ``utcnow()`` returns naive UTC datetimes by convention
+    (for DB round-trip compatibility), so we normalize the parsed
+    timestamp to naive UTC before comparing.
+    """
+    raw = get_setting(db, KEY_LAST_SUCCESS_AT, "")
+    if not raw:
+        return False
+    from datetime import datetime, timedelta, timezone
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        # Corrupted value — treat as no proof of life so password
+        # login stays available. Worse to lock out than to allow.
+        return False
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed >= utcnow() - timedelta(days=LOCKOUT_GRACE_DAYS)
+
+
 def password_login_disabled(db: Session) -> bool:
     """Return True if local password login should be refused.
 
-    The flag is only honored when OIDC is both enabled AND ready to
-    use. Otherwise we would lock admins out whenever they
-    accidentally flip the toggle before finishing OIDC setup, which
-    is exactly the kind of footgun the issue asked to avoid.
+    Three layers of guard so the flag cannot lock the admin out on a
+    broken SSO config:
+
+    1. ``cfg.disable_password_login`` must be set (admin intent).
+    2. ``cfg.is_ready()`` — required fields present. Necessary but
+       not sufficient: a mistyped issuer satisfies is_ready() but
+       will never actually complete a login.
+    3. ``_last_success_within_grace`` — at least one end-to-end SSO
+       callback has succeeded in the last ``LOCKOUT_GRACE_DAYS``
+       days. This is the proof-of-life that the config is actually
+       usable. If SSO breaks and nobody logs in through it for the
+       grace window, password login automatically re-arms.
     """
     cfg = load_config(db)
-    return cfg.is_ready() and cfg.disable_password_login
+    if not (cfg.disable_password_login and cfg.is_ready()):
+        return False
+    return _last_success_within_grace(db)
 
 
 # ---------------------------------------------------------------------------
@@ -615,10 +673,21 @@ def verify_id_token(
     if not sub:
         raise IDTokenError("ID token has no subject")
 
+    # Strict boolean check: only the JSON value ``true`` counts as
+    # verified. Anything else — missing, null, 0, 1, the string
+    # "true"/"false", an array, etc. — is treated as not-verified.
+    # Guards against non-conformant providers (or attackers) sending
+    # truthy-but-non-boolean claim values that would otherwise slip
+    # past ``bool(...)``. This is the single trust hinge between the
+    # IdP's authentication result and Tribu's identity linking, so we
+    # refuse to interpret it liberally.
+    email_verified_raw = payload.get("email_verified")
+    email_verified = email_verified_raw is True
+
     return IDTokenClaims(
         subject=str(sub),
         email=payload.get("email"),
-        email_verified=bool(payload.get("email_verified", False)),
+        email_verified=email_verified,
         name=payload.get("name") or payload.get("preferred_username"),
         raw=payload,
     )

--- a/backend/app/core/oidc.py
+++ b/backend/app/core/oidc.py
@@ -55,6 +55,13 @@ KEY_DISABLE_PASSWORD_LOGIN = "oidc_disable_password_login"
 # expire. Stamped on every successful callback.
 KEY_LAST_SUCCESS_AT = "oidc_last_success_at"
 
+# Path segment under Tribu's base URL where the IdP must POST the
+# user back after authorization. Kept here so both the admin UI
+# (which displays the redirect_uri the operator must register) and
+# the login flow (which sends redirect_uri to the IdP) derive it
+# from the same source of truth.
+CALLBACK_PATH = "/auth/oidc/callback"
+
 # How stale an SSO proof-of-life can be before password login is re-armed
 # automatically. 30 days is comfortably longer than JWT_EXPIRE_HOURS (24h
 # default) so a single break over a weekend does not flip the instance,

--- a/backend/app/core/oidc.py
+++ b/backend/app/core/oidc.py
@@ -233,13 +233,19 @@ def record_successful_sso_login(db: Session) -> None:
     """Stamp ``oidc_last_success_at`` at UTC now.
 
     Called from the callback handler after the ID token verifies and
-    the local user is resolved. Storage is ISO 8601 (UTC, second
-    precision) for human-readable debugging alongside the other
-    ``oidc_*`` settings. Does not commit — the caller's transaction
-    already commits after wiring up identity, membership, and
-    session cookie.
+    the local user is resolved, immediately before ``db.commit()``.
+    The session cookie is set on the HTTP response after the commit
+    returns, so the stamp represents server-side proof-of-life rather
+    than confirmed browser receipt — close enough for the lockout
+    gate's purposes.
+
+    Storage is ISO 8601 (UTC, second precision, naive to match the
+    rest of Tribu's datetime convention).
     """
     set_setting(db, KEY_LAST_SUCCESS_AT, utcnow().replace(microsecond=0).isoformat())
+
+
+_ISO_WITH_TIME_MIN_LEN = len("YYYY-MM-DDTHH:MM:SS")
 
 
 def _last_success_within_grace(db: Session) -> bool:
@@ -248,20 +254,44 @@ def _last_success_within_grace(db: Session) -> bool:
     Tribu's ``utcnow()`` returns naive UTC datetimes by convention
     (for DB round-trip compatibility), so we normalize the parsed
     timestamp to naive UTC before comparing.
+
+    Any parseable-but-untrusted value falls open (password login
+    stays available). That means:
+
+    - malformed or non-ISO strings
+    - strings without a time component (e.g. plain date ``YYYY-MM-DD``
+      which ``datetime.fromisoformat`` happily parses as midnight)
+    - timestamps in the future (a hand-edited value cannot extend
+      the grace window indefinitely)
+
+    Worse to lock admins out than to leak one password-login window
+    after someone tampers with ``system_settings`` directly.
     """
     raw = get_setting(db, KEY_LAST_SUCCESS_AT, "")
     if not raw:
         return False
+
     from datetime import datetime, timedelta, timezone
+    # Require an explicit time separator. ``datetime.fromisoformat``
+    # accepts date-only strings in modern Pythons, and we do not want
+    # ``2099-01-01`` to count as a 30-day proof-of-life.
+    if "T" not in raw or len(raw) < _ISO_WITH_TIME_MIN_LEN:
+        return False
     try:
         parsed = datetime.fromisoformat(raw)
     except ValueError:
-        # Corrupted value — treat as no proof of life so password
-        # login stays available. Worse to lock out than to allow.
         return False
     if parsed.tzinfo is not None:
         parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-    return parsed >= utcnow() - timedelta(days=LOCKOUT_GRACE_DAYS)
+
+    now = utcnow()
+    # Tolerate at most a few minutes of forward drift so clock skew
+    # between request-handling and setting-write does not tank the
+    # gate, but reject timestamps further in the future than any real
+    # drift could produce.
+    if parsed > now + timedelta(minutes=5):
+        return False
+    return parsed >= now - timedelta(days=LOCKOUT_GRACE_DAYS)
 
 
 def password_login_disabled(db: Session) -> bool:

--- a/backend/app/modules/oidc_auth_router.py
+++ b/backend/app/modules/oidc_auth_router.py
@@ -511,6 +511,11 @@ def callback(
         _clear_flow_cookie(resp)
         return resp
 
+    # Stamp proof-of-life so password_login_disabled can trust that
+    # SSO actually works end-to-end. Commit once for the whole
+    # transaction (identity link + membership + timestamp).
+    oidc_core.record_successful_sso_login(db)
+
     db.commit()
 
     jwt_token = create_access_token(user_id=user.id, email=user.email)

--- a/backend/app/modules/oidc_auth_router.py
+++ b/backend/app/modules/oidc_auth_router.py
@@ -182,7 +182,7 @@ def start_login(
     code_verifier = oidc_core.generate_code_verifier()
     code_challenge = oidc_core.code_challenge_s256(code_verifier)
 
-    redirect_uri = f"{resolve_base_url(db, request)}/auth/oidc/callback"
+    redirect_uri = f"{resolve_base_url(db, request)}{oidc_core.CALLBACK_PATH}"
 
     authorize_params = {
         "response_type": "code",
@@ -469,7 +469,7 @@ def callback(
         _clear_flow_cookie(resp)
         return resp
 
-    redirect_uri = f"{resolve_base_url(db, request)}/auth/oidc/callback"
+    redirect_uri = f"{resolve_base_url(db, request)}{oidc_core.CALLBACK_PATH}"
 
     try:
         token_response = oidc_core.exchange_code_for_tokens(

--- a/backend/app/modules/oidc_auth_router.py
+++ b/backend/app/modules/oidc_auth_router.py
@@ -80,7 +80,11 @@ def public_config(db: Session = Depends(get_db)):
         "enabled": bool(cfg.enabled),
         "ready": ready,
         "button_label": cfg.effective_button_label() if ready else "",
-        "password_login_disabled": ready and cfg.disable_password_login,
+        # Mirror the full backend gate (ready + disable flag + recent
+        # SSO proof-of-life) so the frontend does not hide local auth
+        # before the first successful SSO login, and so password login
+        # automatically re-surfaces after the lockout grace expires.
+        "password_login_disabled": oidc_core.password_login_disabled(db),
     }
 
 

--- a/backend/app/modules/oidc_auth_router.py
+++ b/backend/app/modules/oidc_auth_router.py
@@ -203,6 +203,14 @@ def start_login(
         "invite": invite or "",
         "redirect_to": _safe_redirect(redirect_to),
         "issuer": cfg.issuer,
+        # Pin the redirect_uri we actually sent to the IdP so the
+        # callback token-exchange submits exactly the same value.
+        # If base_url / x-forwarded headers shift between the two
+        # requests (e.g. a reverse proxy restarts, BASE_URL env
+        # flips) the authorize-step URI and the token-exchange URI
+        # would otherwise diverge and the IdP would refuse the
+        # exchange with invalid_grant / redirect_uri_mismatch.
+        "redirect_uri": redirect_uri,
     })
 
     response = RedirectResponse(url=authorize_url, status_code=303)
@@ -406,7 +414,7 @@ def _link_identity_with_race_guard(
 
 
 @router.get(
-    "/auth/oidc/callback",
+    oidc_core.CALLBACK_PATH,
     summary="OIDC callback",
     description=(
         "Consume the IdP's ``code`` + ``state`` response. Sets the "
@@ -469,7 +477,12 @@ def callback(
         _clear_flow_cookie(resp)
         return resp
 
-    redirect_uri = f"{resolve_base_url(db, request)}{oidc_core.CALLBACK_PATH}"
+    # Prefer the URI we actually sent to the IdP at authorize time;
+    # fall back to recomputing for older flow cookies that predate
+    # the pinning (this round of the loop is mid-deployment).
+    redirect_uri = flow.get("redirect_uri") or (
+        f"{resolve_base_url(db, request)}{oidc_core.CALLBACK_PATH}"
+    )
 
     try:
         token_response = oidc_core.exchange_code_for_tokens(

--- a/backend/app/modules/oidc_router.py
+++ b/backend/app/modules/oidc_router.py
@@ -8,7 +8,7 @@ and lets us put the public login endpoints on their own tag.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from app.core import oidc as oidc_core
@@ -20,7 +20,7 @@ from app.core.errors import (
 )
 from app.core.oidc_presets import PRESETS, list_presets
 from app.core.scopes import require_scope
-from app.core.utils import ensure_any_admin
+from app.core.utils import ensure_any_admin, resolve_base_url
 from app.database import get_db
 from app.models import User
 from app.schemas import (
@@ -32,6 +32,17 @@ from app.schemas import (
     OIDCTestResponse,
 )
 
+def _effective_callback_url(db: Session, request: Request) -> str:
+    """Return the redirect_uri Tribu will actually send to the IdP.
+
+    Shares ``oidc_core.CALLBACK_PATH`` with
+    ``oidc_auth_router.start_login`` so the admin UI shows the exact
+    URL the backend will submit. Reading from ``resolve_base_url``
+    means an explicit ``BASE_URL`` env var or an admin-set
+    ``base_url`` override is honored identically in both places.
+    """
+    return f"{resolve_base_url(db, request)}{oidc_core.CALLBACK_PATH}"
+
 router = APIRouter(
     prefix="/admin/oidc",
     tags=["admin-settings"],
@@ -39,7 +50,9 @@ router = APIRouter(
 )
 
 
-def _to_response(cfg: oidc_core.OIDCConfig) -> OIDCConfigResponse:
+def _to_response(
+    cfg: oidc_core.OIDCConfig, *, effective_callback_url: str
+) -> OIDCConfigResponse:
     return OIDCConfigResponse(
         enabled=cfg.enabled,
         preset=cfg.preset,
@@ -51,6 +64,7 @@ def _to_response(cfg: oidc_core.OIDCConfig) -> OIDCConfigResponse:
         allow_signup=cfg.allow_signup,
         disable_password_login=cfg.disable_password_login,
         ready=cfg.is_ready(),
+        effective_callback_url=effective_callback_url,
     )
 
 
@@ -87,13 +101,16 @@ def get_presets(
     response_description="Current OIDC configuration",
 )
 def get_oidc_config(
+    request: Request,
     user: User = Depends(current_user),
     db: Session = Depends(get_db),
     _scope=require_scope("admin:read"),
 ) -> OIDCConfigResponse:
     ensure_any_admin(db, user.id)
     cfg = oidc_core.load_config(db)
-    return _to_response(cfg)
+    return _to_response(
+        cfg, effective_callback_url=_effective_callback_url(db, request),
+    )
 
 
 @router.put(
@@ -110,6 +127,7 @@ def get_oidc_config(
 )
 def update_oidc_config(
     payload: OIDCConfigUpdate,
+    request: Request,
     user: User = Depends(current_user),
     db: Session = Depends(get_db),
     _scope=require_scope("admin:write"),
@@ -160,7 +178,10 @@ def update_oidc_config(
     # configuration. Nothing persists in memory from the previous
     # issuer so the next login attempt re-fetches discovery.
     oidc_core.invalidate_discovery_cache()
-    return _to_response(oidc_core.load_config(db))
+    return _to_response(
+        oidc_core.load_config(db),
+        effective_callback_url=_effective_callback_url(db, request),
+    )
 
 
 @router.post(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -290,7 +290,7 @@ class OIDCConfigResponse(BaseModel):
     client_secret_set: bool = Field(..., description="True if a client secret is stored (value itself is never returned).")
     scopes: str = Field(..., description="Space-separated OAuth2 scopes to request.")
     allow_signup: bool = Field(..., description="Allow new accounts to be created via SSO when following an invite link.")
-    disable_password_login: bool = Field(..., description="Reject /auth/login when SSO is fully configured.")
+    disable_password_login: bool = Field(..., description="Reject /auth/login when SSO is ready AND a successful SSO login was recorded in the last 30 days.")
     ready: bool = Field(..., description="True if enabled AND all required fields are set.")
 
 
@@ -309,7 +309,7 @@ class OIDCConfigUpdate(BaseModel):
     client_secret: Optional[str] = Field(None, description="OAuth2 client secret. Omit to keep existing; empty string clears.")
     scopes: Optional[str] = Field(None, description="Space-separated scopes.")
     allow_signup: Optional[bool] = Field(None, description="Allow new account creation via SSO (invite-bound).")
-    disable_password_login: Optional[bool] = Field(None, description="Reject password login when SSO is ready.")
+    disable_password_login: Optional[bool] = Field(None, description="Reject password login when SSO is ready AND a recent successful SSO login was recorded (30-day proof-of-life window).")
 
     @field_validator("scopes")
     @classmethod

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -292,6 +292,7 @@ class OIDCConfigResponse(BaseModel):
     allow_signup: bool = Field(..., description="Allow new accounts to be created via SSO when following an invite link.")
     disable_password_login: bool = Field(..., description="Reject /auth/login when SSO is ready AND a successful SSO login was recorded in the last 30 days.")
     ready: bool = Field(..., description="True if enabled AND all required fields are set.")
+    effective_callback_url: str = Field(..., description="The redirect_uri Tribu will actually send to the IdP. Shown in the admin UI so operators register the same value at their provider.")
 
 
 class OIDCConfigUpdate(BaseModel):

--- a/backend/tests/test_oidc_admin.py
+++ b/backend/tests/test_oidc_admin.py
@@ -328,8 +328,14 @@ def test_discovery_probe_rejects_file_scheme():
 # ---------------------------------------------------------------------------
 
 
-def _enable_oidc_ready(disable_password: bool) -> None:
-    """Seed a ready OIDC config directly via the DB, bypassing admin API."""
+def _enable_oidc_ready(disable_password: bool, *, proven: bool = True) -> None:
+    """Seed a ready OIDC config directly via the DB, bypassing admin API.
+
+    ``proven=True`` also stamps ``oidc_last_success_at`` so the
+    password-login gate honors ``disable_password_login``. Set it to
+    False when the test wants to cover the "admin flipped the flag
+    before SSO ever worked" edge case.
+    """
     db = TestSession()
     try:
         oidc_core.save_config(
@@ -344,6 +350,8 @@ def _enable_oidc_ready(disable_password: bool) -> None:
             allow_signup=False,
             disable_password_login=disable_password,
         )
+        if proven:
+            oidc_core.record_successful_sso_login(db)
         db.commit()
     finally:
         db.close()

--- a/backend/tests/test_oidc_admin.py
+++ b/backend/tests/test_oidc_admin.py
@@ -142,6 +142,41 @@ def test_get_config_defaults():
     assert body["preset"] == "generic"
     assert body["client_secret_set"] is False
     assert body["ready"] is False
+    # Effective callback URL always populated, derived from the
+    # request host (TestClient uses http://testserver by default).
+    assert body["effective_callback_url"].endswith("/auth/oidc/callback")
+
+
+def test_effective_callback_url_honours_base_url_env(monkeypatch):
+    """BASE_URL env overrides request-based derivation so admins
+    behind a reverse proxy see the real external URL, not the
+    internal request host."""
+    token = _seed_admin()
+    monkeypatch.setenv("BASE_URL", "https://tribu.example.com")
+    resp = client.get("/admin/oidc", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["effective_callback_url"] == (
+        "https://tribu.example.com/auth/oidc/callback"
+    )
+
+
+def test_effective_callback_url_honours_forwarded_headers():
+    """x-forwarded-host + x-forwarded-proto win over the direct
+    request headers when no BASE_URL is set, matching how
+    resolve_base_url is used elsewhere."""
+    token = _seed_admin()
+    resp = client.get(
+        "/admin/oidc",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "x-forwarded-host": "tribu.example.com",
+            "x-forwarded-proto": "https",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["effective_callback_url"] == (
+        "https://tribu.example.com/auth/oidc/callback"
+    )
 
 
 def test_get_config_requires_admin_scope():

--- a/backend/tests/test_oidc_config.py
+++ b/backend/tests/test_oidc_config.py
@@ -239,6 +239,49 @@ class TestPasswordLoginGate:
         db.commit()
         assert oidc_core.password_login_disabled(db) is False
 
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",                    # empty
+            "   ",                 # whitespace
+            "2099-01-01",          # date-only: parseable but no time
+            "2099",                # year-only
+            "garbage",             # not even ISO-shaped
+            "T12:00:00",           # time-only with stray T
+            "2026-04-22",          # today, date-only
+        ],
+    )
+    def test_unparseable_or_timeless_timestamp_falls_open(self, db, bad):
+        """Anything not matching the full ISO date+time shape must
+        not count as proof-of-life. Partial values like
+        ``YYYY-MM-DD`` are parseable by ``fromisoformat`` but would
+        silently keep password login disabled for 30 days."""
+        self._store(db, enabled=True, disable_flag=True, ready=True)
+        oidc_core.set_setting(db, oidc_core.KEY_LAST_SUCCESS_AT, bad)
+        db.commit()
+        assert oidc_core.password_login_disabled(db) is False
+
+    def test_future_timestamp_falls_open(self, db):
+        """A hand-edited future date must not extend the grace
+        window past ``LOCKOUT_GRACE_DAYS``. Up to a few minutes of
+        clock skew is tolerated, far-future values are rejected."""
+        from datetime import timedelta
+        self._store(db, enabled=True, disable_flag=True, ready=True)
+        future = (oidc_core.utcnow() + timedelta(days=365)).replace(microsecond=0).isoformat()
+        oidc_core.set_setting(db, oidc_core.KEY_LAST_SUCCESS_AT, future)
+        db.commit()
+        assert oidc_core.password_login_disabled(db) is False
+
+    def test_small_clock_skew_tolerated(self, db):
+        """A stamp 1 minute in the future (plausible for intra-
+        cluster skew) still counts as proof-of-life."""
+        from datetime import timedelta
+        self._store(db, enabled=True, disable_flag=True, ready=True)
+        soon = (oidc_core.utcnow() + timedelta(minutes=1)).replace(microsecond=0).isoformat()
+        oidc_core.set_setting(db, oidc_core.KEY_LAST_SUCCESS_AT, soon)
+        db.commit()
+        assert oidc_core.password_login_disabled(db) is True
+
     def test_flag_off_stays_off(self, db):
         self._store(db, enabled=True, disable_flag=False, ready=True)
         self._stamp(db, days_ago=0)

--- a/backend/tests/test_oidc_config.py
+++ b/backend/tests/test_oidc_config.py
@@ -189,21 +189,59 @@ class TestPasswordLoginGate:
         )
         db.commit()
 
+    def _stamp(self, db, *, days_ago: float = 0.0):
+        from datetime import timedelta
+        ts = (oidc_core.utcnow() - timedelta(days=days_ago)).replace(microsecond=0).isoformat()
+        oidc_core.set_setting(db, oidc_core.KEY_LAST_SUCCESS_AT, ts)
+        db.commit()
+
     def test_flag_ignored_when_oidc_disabled(self, db):
         self._store(db, enabled=False, disable_flag=True, ready=False)
+        self._stamp(db, days_ago=0)
         assert oidc_core.password_login_disabled(db) is False
 
     def test_flag_ignored_when_not_ready(self, db):
         # enabled=True but issuer/client missing => not ready
         self._store(db, enabled=True, disable_flag=True, ready=False)
+        self._stamp(db, days_ago=0)
         assert oidc_core.password_login_disabled(db) is False
 
-    def test_flag_honoured_when_ready(self, db):
+    def test_flag_ignored_when_never_proven(self, db):
+        """Regression: is_ready() alone is not enough.
+
+        A mistyped issuer + client secret satisfies is_ready() but
+        cannot actually complete a login. Without a recorded
+        success, password login must stay available.
+        """
         self._store(db, enabled=True, disable_flag=True, ready=True)
+        # No _stamp() — last_success_at is empty
+        assert oidc_core.password_login_disabled(db) is False
+
+    def test_flag_honoured_when_recently_proven(self, db):
+        self._store(db, enabled=True, disable_flag=True, ready=True)
+        self._stamp(db, days_ago=0)
         assert oidc_core.password_login_disabled(db) is True
+
+    def test_flag_rearms_password_after_grace_expiry(self, db):
+        """After LOCKOUT_GRACE_DAYS with no SSO, password login
+        comes back automatically. The intent is that a silent OIDC
+        outage does not permanently lock admins out."""
+        self._store(db, enabled=True, disable_flag=True, ready=True)
+        self._stamp(db, days_ago=oidc_core.LOCKOUT_GRACE_DAYS + 1)
+        assert oidc_core.password_login_disabled(db) is False
+
+    def test_corrupted_timestamp_falls_open(self, db):
+        """If someone hand-edits oidc_last_success_at to garbage we
+        prefer to leave password login usable rather than brick
+        the instance."""
+        self._store(db, enabled=True, disable_flag=True, ready=True)
+        oidc_core.set_setting(db, oidc_core.KEY_LAST_SUCCESS_AT, "not a date")
+        db.commit()
+        assert oidc_core.password_login_disabled(db) is False
 
     def test_flag_off_stays_off(self, db):
         self._store(db, enabled=True, disable_flag=False, ready=True)
+        self._stamp(db, days_ago=0)
         assert oidc_core.password_login_disabled(db) is False
 
 
@@ -533,6 +571,89 @@ class TestVerifyIDTokenRealSignature:
                 jwks_uri="https://idp.example.com/jwks",
                 expected_nonce=None,
             )
+
+
+class TestEmailVerifiedStrict:
+    """email_verified must be the JSON boolean true, nothing else.
+
+    Protects against IdPs (or attackers tampering with one) that emit
+    the claim as a string, integer, or anything else truthy. The
+    identity-linking path relies on this flag to decide whether to
+    trust the email claim for matching an existing Tribu user.
+    """
+
+    @pytest.fixture
+    def rsa_keypair(self):
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        return private_key, private_key.public_key()
+
+    def _sign(self, private_key, payload: dict) -> str:
+        from cryptography.hazmat.primitives import serialization
+        pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        import jwt
+        return jwt.encode(payload, pem, algorithm="RS256", headers={"kid": "test-kid"})
+
+    def _install_fake_jwks(self, monkeypatch, public_key):
+        class FakeJWK:
+            def __init__(self, key, alg):
+                self.key = key
+                self.algorithm_name = alg
+
+        fake = FakeJWK(public_key, "RS256")
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+            def get_signing_key_from_jwt(self, _id_token):
+                return fake
+
+        monkeypatch.setattr("jwt.PyJWKClient", FakeClient)
+
+    def _verify(self, priv, pub, monkeypatch, extra_payload):
+        self._install_fake_jwks(monkeypatch, pub)
+        import time as _time
+        now = int(_time.time())
+        payload = {
+            "iss": "https://idp.example.com",
+            "aud": "tribu-client",
+            "sub": "sub-1",
+            "exp": now + 300,
+            "iat": now,
+            "email": "anna@example.com",
+        }
+        payload.update(extra_payload)
+        token = self._sign(priv, payload)
+        return oidc_core.verify_id_token(
+            token,
+            issuer="https://idp.example.com",
+            client_id="tribu-client",
+            jwks_uri="https://idp.example.com/jwks",
+            expected_nonce=None,
+        )
+
+    def test_true_boolean_accepted(self, rsa_keypair, monkeypatch):
+        priv, pub = rsa_keypair
+        claims = self._verify(priv, pub, monkeypatch, {"email_verified": True})
+        assert claims.email_verified is True
+
+    @pytest.mark.parametrize(
+        "claim_value",
+        ["true", "false", "True", 1, 0, [], ["true"], {"v": True}, None],
+    )
+    def test_non_boolean_treated_as_unverified(self, rsa_keypair, monkeypatch, claim_value):
+        priv, pub = rsa_keypair
+        claims = self._verify(priv, pub, monkeypatch, {"email_verified": claim_value})
+        assert claims.email_verified is False
+
+    def test_missing_claim_treated_as_unverified(self, rsa_keypair, monkeypatch):
+        priv, pub = rsa_keypair
+        claims = self._verify(priv, pub, monkeypatch, {})  # no email_verified
+        assert claims.email_verified is False
 
 
 class TestVerifyPasswordNullHash:

--- a/backend/tests/test_oidc_flow.py
+++ b/backend/tests/test_oidc_flow.py
@@ -79,7 +79,15 @@ def _seed_config(
     disable_password_login: bool = False,
     button_label: str = "",
     enabled: bool = True,
+    proven: bool = True,
 ) -> None:
+    """Seed the OIDC config rows for tests.
+
+    ``proven=True`` also records a recent successful SSO login so the
+    password-login gate treats the config as trusted end-to-end. Tests
+    that want to exercise the "flag flipped before first success"
+    path pass ``proven=False``.
+    """
     db = TestSession()
     try:
         oidc_core.save_config(
@@ -94,6 +102,8 @@ def _seed_config(
             allow_signup=allow_signup,
             disable_password_login=disable_password_login,
         )
+        if proven:
+            oidc_core.record_successful_sso_login(db)
         db.commit()
     finally:
         db.close()
@@ -282,9 +292,11 @@ def test_callback_stamps_last_success_timestamp(monkeypatch):
 
     That timestamp is the proof-of-life the password_login_disabled
     gate depends on; without it the gate stays open and
-    disable_password_login never locks out the admin.
+    disable_password_login never locks out the admin. Start with
+    proven=False so the assertion actually proves the callback is
+    the thing that stamps.
     """
-    _seed_config()
+    _seed_config(proven=False)
     db = TestSession()
     try:
         db.add(User(

--- a/backend/tests/test_oidc_flow.py
+++ b/backend/tests/test_oidc_flow.py
@@ -277,6 +277,83 @@ def _mock_token_exchange(monkeypatch, *, subject: str, email: str | None, email_
 # ---------------------------------------------------------------------------
 
 
+def test_callback_stamps_last_success_timestamp(monkeypatch):
+    """Every successful callback must record oidc_last_success_at.
+
+    That timestamp is the proof-of-life the password_login_disabled
+    gate depends on; without it the gate stays open and
+    disable_password_login never locks out the admin.
+    """
+    _seed_config()
+    db = TestSession()
+    try:
+        db.add(User(
+            email="stamp@example.com",
+            password_hash=hash_password("Secure1Pass"),
+            display_name="Stamp",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+    state = _perform_login_and_extract_state(monkeypatch)
+    _mock_token_exchange(
+        monkeypatch,
+        subject="stamp-sub",
+        email="stamp@example.com",
+        email_verified=True,
+    )
+    resp = client.get(f"/auth/oidc/callback?code=c&state={state}")
+    assert resp.status_code == 303
+
+    db = TestSession()
+    try:
+        stored = oidc_core.get_setting(db, oidc_core.KEY_LAST_SUCCESS_AT, "")
+        assert stored  # non-empty ISO string
+        from datetime import datetime, timezone
+        parsed = datetime.fromisoformat(stored)
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        assert abs((oidc_core.utcnow() - parsed).total_seconds()) < 300
+    finally:
+        db.close()
+    client.cookies.clear()
+
+
+def test_login_not_blocked_until_first_sso_success(monkeypatch):
+    """disable_password_login=true alone must not lock admins out.
+
+    Regression for the adversarial finding: is_ready() only checks
+    non-empty fields. Password login must stay available until at
+    least one callback has actually completed.
+    """
+    db = TestSession()
+    try:
+        db.add(User(
+            email="admin@example.com",
+            password_hash=hash_password("Secure1Pass"),
+            display_name="Admin",
+        ))
+        oidc_core.save_config(
+            db,
+            enabled=True, preset="generic", button_label="",
+            issuer=ISSUER, client_id="tribu-client", client_secret="s",
+            scopes="openid profile email",
+            allow_signup=False, disable_password_login=True,
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    resp = client.post(
+        "/auth/login",
+        json={"email": "admin@example.com", "password": "Secure1Pass"},
+    )
+    # Password login must still work — no SSO success has been recorded
+    assert resp.status_code == 200, resp.text
+    client.cookies.clear()
+
+
 def test_callback_links_existing_user_by_verified_email(monkeypatch):
     _seed_config()
     db = TestSession()

--- a/backend/tests/test_oidc_flow.py
+++ b/backend/tests/test_oidc_flow.py
@@ -287,6 +287,61 @@ def _mock_token_exchange(monkeypatch, *, subject: str, email: str | None, email_
 # ---------------------------------------------------------------------------
 
 
+def test_callback_reuses_authorize_redirect_uri(monkeypatch):
+    """Regression: the flow JWT must pin the redirect_uri so the
+    token exchange submits the same value as authorize.
+
+    If base_url or x-forwarded headers change between the two
+    requests the IdP would otherwise reject the code for
+    redirect_uri_mismatch.
+    """
+    _seed_config(proven=False)
+
+    captured = {}
+
+    def fake_exchange(**kwargs):
+        captured["redirect_uri"] = kwargs["redirect_uri"]
+        return {"id_token": "MOCK", "access_token": "A"}
+
+    def fake_verify(id_token, *, issuer, client_id, jwks_uri, expected_nonce):
+        return oidc_core.IDTokenClaims(
+            subject="pin-sub",
+            email="pin@example.com",
+            email_verified=True,
+            name="Pin",
+            raw={},
+        )
+
+    monkeypatch.setattr(oidc_core, "_fetch_json", lambda url, timeout=5.0: _valid_discovery())
+    monkeypatch.setattr(oidc_core, "exchange_code_for_tokens", fake_exchange)
+    monkeypatch.setattr(oidc_core, "verify_id_token", fake_verify)
+
+    # Authorize request goes through the proxied host
+    start = client.get(
+        "/auth/oidc/login",
+        headers={"x-forwarded-host": "first.example.com", "x-forwarded-proto": "https"},
+    )
+    state = start.headers["location"].split("state=", 1)[1].split("&", 1)[0]
+
+    # Seed a user so the callback succeeds
+    db = TestSession()
+    try:
+        db.add(User(email="pin@example.com", password_hash=hash_password("P1xxx1234"), display_name="Pin"))
+        db.commit()
+    finally:
+        db.close()
+
+    # Callback arrives with a DIFFERENT forwarded host. Without the
+    # pin, redirect_uri would be recomputed to the second host and
+    # the token exchange would fail at the IdP.
+    client.get(
+        f"/auth/oidc/callback?code=c&state={state}",
+        headers={"x-forwarded-host": "second.example.com", "x-forwarded-proto": "https"},
+    )
+    assert captured["redirect_uri"] == "https://first.example.com/auth/oidc/callback"
+    client.cookies.clear()
+
+
 def test_callback_stamps_last_success_timestamp(monkeypatch):
     """Every successful callback must record oidc_last_success_at.
 

--- a/frontend/__tests__/components/SsoSection.test.js
+++ b/frontend/__tests__/components/SsoSection.test.js
@@ -14,7 +14,16 @@ jest.mock('../../contexts/ToastContext', () => ({
   useToast: () => ({ success: mockToastSuccess, error: mockToastError }),
 }));
 
-jest.mock('../../lib/i18n', () => ({ t: (_m, k) => k }));
+jest.mock('../../lib/i18n', () => ({
+  // Return realistic template strings for keys that the component
+  // runs .replace() on. Other keys fall back to the literal key so
+  // existing tests that assert on key presence still work.
+  t: (_m, k) => {
+    if (k === 'sso.redirect_uri_hint') return 'Register this redirect URL at your provider: {url}';
+    if (k === 'sso.test_fail') return 'Discovery failed: {error}';
+    return k;
+  },
+}));
 jest.mock('../../lib/helpers', () => ({ errorText: (_d, f) => f }));
 
 jest.mock('../../lib/api', () => ({
@@ -43,6 +52,7 @@ function mockCfg(overrides = {}) {
     allow_signup: false,
     disable_password_login: false,
     ready: false,
+    effective_callback_url: 'https://tribu.example.com/auth/oidc/callback',
     ...overrides,
   };
 }
@@ -113,6 +123,23 @@ describe('SsoSection admin panel', () => {
     await waitFor(() => expect(screen.getByText('sso.test_ok')).toBeInTheDocument());
   });
 
+  it('shows the backend-provided effective callback URL, not the browser origin', async () => {
+    const api = require('../../lib/api');
+    api.apiGetOidcConfig.mockResolvedValue({
+      ok: true,
+      data: mockCfg({ effective_callback_url: 'https://tribu.example.com/auth/oidc/callback' }),
+    });
+
+    render(<SsoSection />);
+    const hint = await screen.findByTestId('sso-callback-hint');
+    // Hint template replaces {url} with the backend-calculated value.
+    // window.location.origin in jsdom is 'http://localhost' — the
+    // regression guard is that the displayed URL matches the backend
+    // response, not the browser origin.
+    expect(hint).toHaveTextContent('https://tribu.example.com/auth/oidc/callback');
+    expect(hint).not.toHaveTextContent('http://localhost/auth/oidc/callback');
+  });
+
   it('shows the error from the discovery test result', async () => {
     const api = require('../../lib/api');
     api.apiGetOidcConfig.mockResolvedValue({ ok: true, data: mockCfg({ issuer: 'https://idp.example.com' }) });
@@ -123,7 +150,7 @@ describe('SsoSection admin panel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /sso\.test/ }));
     await waitFor(() =>
-      expect(screen.getByText('sso.test_fail')).toBeInTheDocument()
+      expect(screen.getByText(/host unreachable/)).toBeInTheDocument()
     );
   });
 });

--- a/frontend/__tests__/components/SsoSection.test.js
+++ b/frontend/__tests__/components/SsoSection.test.js
@@ -123,6 +123,30 @@ describe('SsoSection admin panel', () => {
     await waitFor(() => expect(screen.getByText('sso.test_ok')).toBeInTheDocument());
   });
 
+  it('reconciles state from a fresh GET when PUT throws a network error', async () => {
+    const api = require('../../lib/api');
+    api.apiGetOidcConfig
+      .mockResolvedValueOnce({ ok: true, data: mockCfg({ effective_callback_url: 'https://old.example.com/auth/oidc/callback' }) })
+      .mockResolvedValueOnce({ ok: true, data: mockCfg({ effective_callback_url: 'https://new.example.com/auth/oidc/callback', issuer: 'https://new' }) });
+    api.apiUpdateOidcConfig.mockRejectedValueOnce(new Error('network down'));
+
+    render(<SsoSection />);
+    await screen.findByTestId('sso-admin-section');
+
+    fireEvent.submit(screen.getByTestId('sso-admin-section'));
+
+    await waitFor(() => {
+      // After the failure the component re-fetches the config so the
+      // displayed callback URL reflects the real server state.
+      const hint = screen.getByTestId('sso-callback-hint');
+      expect(hint).toHaveTextContent('https://new.example.com/auth/oidc/callback');
+    });
+    expect(mockToastError).toHaveBeenCalled();
+    // Save button re-enabled
+    const saveButton = screen.getByRole('button', { name: /sso\.save/ });
+    expect(saveButton).not.toBeDisabled();
+  });
+
   it('shows the backend-provided effective callback URL, not the browser origin', async () => {
     const api = require('../../lib/api');
     api.apiGetOidcConfig.mockResolvedValue({

--- a/frontend/components/admin/SsoSection.js
+++ b/frontend/components/admin/SsoSection.js
@@ -80,9 +80,11 @@ export default function SsoSection() {
   }
 
   const selectedPreset = presets.find((p) => p.id === cfg.preset) || null;
-  const redirectUri = typeof window !== 'undefined'
-    ? `${window.location.origin}/auth/oidc/callback`
-    : '';
+  // Use the backend's computed callback URL. Deriving from
+  // window.location.origin would diverge from the real redirect_uri
+  // Tribu sends to the IdP whenever BASE_URL env or x-forwarded
+  // headers are in play.
+  const redirectUri = cfg.effective_callback_url || '';
 
   return (
     <form className="settings-section sso-section" onSubmit={handleSave} data-testid="sso-admin-section">
@@ -92,15 +94,17 @@ export default function SsoSection() {
       </div>
       <p className="adm-form-desc">{t(messages, 'sso.desc')}</p>
 
-      <label className="set-checkbox-label">
-        <input
-          type="checkbox"
-          checked={!!cfg.enabled}
-          onChange={(e) => update('enabled', e.target.checked)}
-          data-testid="sso-enabled-toggle"
-        />
-        {t(messages, 'sso.enabled')}
-      </label>
+      <div className="sso-checkbox-field">
+        <label className="set-checkbox-label">
+          <input
+            type="checkbox"
+            checked={!!cfg.enabled}
+            onChange={(e) => update('enabled', e.target.checked)}
+            data-testid="sso-enabled-toggle"
+          />
+          {t(messages, 'sso.enabled')}
+        </label>
+      </div>
 
       <div className="form-field">
         <label>{t(messages, 'sso.preset')}</label>
@@ -114,11 +118,9 @@ export default function SsoSection() {
             <option key={p.id} value={p.id}>{p.name}</option>
           ))}
         </select>
-        <small>{t(messages, 'sso.preset_hint')}</small>
+        <small className="sso-hint">{t(messages, 'sso.preset_hint')}</small>
         {selectedPreset?.hint && (
-          <small style={{ display: 'block', marginTop: 4, color: 'var(--text-muted)' }}>
-            {selectedPreset.hint}
-          </small>
+          <small className="sso-hint">{selectedPreset.hint}</small>
         )}
       </div>
 
@@ -155,8 +157,8 @@ export default function SsoSection() {
           autoComplete="off"
         />
         {cfg.client_secret_set && !secretClearPending && (
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 4 }}>
-            <small style={{ color: 'var(--text-muted)' }}>{t(messages, 'sso.client_secret_set')}</small>
+          <div className="sso-secret-actions">
+            <small className="sso-hint">{t(messages, 'sso.client_secret_set')}</small>
             <button
               type="button"
               className="btn-ghost"
@@ -167,7 +169,7 @@ export default function SsoSection() {
           </div>
         )}
         {secretClearPending && (
-          <small style={{ color: 'var(--warning, #c05621)' }}>{t(messages, 'sso.client_secret_clear')}</small>
+          <small className="sso-hint sso-hint-warning">{t(messages, 'sso.client_secret_clear')}</small>
         )}
       </div>
 
@@ -180,7 +182,7 @@ export default function SsoSection() {
           placeholder={selectedPreset?.button_label || ''}
           onChange={(e) => update('button_label', e.target.value)}
         />
-        <small>{t(messages, 'sso.button_label_hint')}</small>
+        <small className="sso-hint">{t(messages, 'sso.button_label_hint')}</small>
       </div>
 
       <div className="form-field">
@@ -191,33 +193,39 @@ export default function SsoSection() {
           value={cfg.scopes || ''}
           onChange={(e) => update('scopes', e.target.value)}
         />
-        <small>{t(messages, 'sso.scopes_hint')}</small>
+        <small className="sso-hint">{t(messages, 'sso.scopes_hint')}</small>
       </div>
 
-      <label className="set-checkbox-label">
-        <input
-          type="checkbox"
-          checked={!!cfg.allow_signup}
-          onChange={(e) => update('allow_signup', e.target.checked)}
-        />
-        {t(messages, 'sso.allow_signup')}
-      </label>
-      <small style={{ display: 'block', marginTop: -6, marginBottom: 8 }}>{t(messages, 'sso.allow_signup_hint')}</small>
+      <div className="sso-checkbox-field">
+        <label className="set-checkbox-label">
+          <input
+            type="checkbox"
+            checked={!!cfg.allow_signup}
+            onChange={(e) => update('allow_signup', e.target.checked)}
+          />
+          {t(messages, 'sso.allow_signup')}
+        </label>
+        <small className="sso-hint">{t(messages, 'sso.allow_signup_hint')}</small>
+      </div>
 
-      <label className="set-checkbox-label">
-        <input
-          type="checkbox"
-          checked={!!cfg.disable_password_login}
-          onChange={(e) => update('disable_password_login', e.target.checked)}
-        />
-        {t(messages, 'sso.disable_password_login')}
-      </label>
-      <small style={{ display: 'block', marginTop: -6, marginBottom: 8 }}>{t(messages, 'sso.disable_password_login_hint')}</small>
+      <div className="sso-checkbox-field">
+        <label className="set-checkbox-label">
+          <input
+            type="checkbox"
+            checked={!!cfg.disable_password_login}
+            onChange={(e) => update('disable_password_login', e.target.checked)}
+          />
+          {t(messages, 'sso.disable_password_login')}
+        </label>
+        <small className="sso-hint">{t(messages, 'sso.disable_password_login_hint')}</small>
+      </div>
 
       {redirectUri && (
-        <small style={{ display: 'block', marginTop: 8, marginBottom: 8, color: 'var(--text-muted)' }}>
-          {t(messages, 'sso.redirect_uri_hint').replace('{url}', redirectUri)}
-        </small>
+        <div className="sso-callback-box" data-testid="sso-callback-hint">
+          <small className="sso-hint">
+            {t(messages, 'sso.redirect_uri_hint').replace('{url}', redirectUri)}
+          </small>
+        </div>
       )}
 
       <div className="set-btn-row" style={{ gap: 8 }}>

--- a/frontend/components/admin/SsoSection.js
+++ b/frontend/components/admin/SsoSection.js
@@ -67,16 +67,32 @@ export default function SsoSection() {
     } else if (secretDraft) {
       payload.client_secret = secretDraft;
     }
-    const { ok, data } = await api.apiUpdateOidcConfig(payload);
-    setSaving(false);
-    if (!ok) {
-      toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
-      return;
+    try {
+      const { ok, data } = await api.apiUpdateOidcConfig(payload);
+      if (!ok) {
+        toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
+        return;
+      }
+      toastSuccess(t(messages, 'sso.saved'));
+      setCfg(data);
+      setSecretDraft('');
+      setSecretClearPending(false);
+    } catch (err) {
+      // Network failure or anything that short-circuits the fetch.
+      // The backend may or may not have applied the change; we
+      // cannot know from here. Re-fetch the config so the rendered
+      // effective_callback_url and client_secret_set flag reflect
+      // the actual server state instead of our optimistic draft.
+      toastError(t(messages, 'toast.error'));
+      try {
+        const { ok, data } = await api.apiGetOidcConfig();
+        if (ok && data) setCfg(data);
+      } catch {
+        // Leave cfg alone if even the refetch fails. User can retry.
+      }
+    } finally {
+      setSaving(false);
     }
-    toastSuccess(t(messages, 'sso.saved'));
-    setCfg(data);
-    setSecretDraft('');
-    setSecretClearPending(false);
   }
 
   const selectedPreset = presets.find((p) => p.id === cfg.preset) || null;

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -505,6 +505,48 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   width: 100%; text-decoration: none;
 }
 
+/* Admin > Single Sign-On section — enforce a consistent vertical
+   rhythm so the dense stack of fields does not crowd together. */
+.sso-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md, 14px);
+}
+.sso-section .admin-section-header {
+  display: flex; align-items: center; gap: 8px;
+  margin: 0;
+}
+.sso-section .admin-section-header h2 { margin: 0; font-size: 1.05rem; }
+.sso-section .adm-form-desc { margin: 0; color: var(--text-muted); font-size: 0.85rem; }
+.sso-section .form-field { margin: 0; display: flex; flex-direction: column; gap: 6px; }
+.sso-section .form-field > label { font-weight: 500; font-size: 0.9rem; }
+.sso-section .sso-hint {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+.sso-section .sso-hint-warning { color: var(--warning, #c05621); }
+.sso-section .sso-checkbox-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.sso-section .sso-checkbox-field .set-checkbox-label { margin: 0; }
+.sso-section .sso-secret-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.sso-section .sso-callback-box {
+  padding: 10px 12px;
+  border: 1px dashed var(--glass-border);
+  border-radius: var(--radius-sm, 8px);
+  background: rgba(124, 58, 237, 0.04);
+}
+.sso-section .set-btn-row { margin: 0; }
+
 /* ═══════════════════════════════════════════
    BUTTONS
    ═══════════════════════════════════════════ */


### PR DESCRIPTION
Follow-up to #167. A second review pass on the merged OIDC surface turned up three issues that all boil down to "the approach is right, but the invariants it depends on are not actually enforced".

## Findings resolved

### CRIT - admin lockout on broken OIDC config
Before this change, `password_login_disabled()` only checked `cfg.disable_password_login` plus `is_ready()` (non-empty fields). A mistyped issuer or revoked client secret would satisfy both, and the moment existing sessions expired, every admin was locked out while SSO itself still failed later at discovery or token exchange.

The gate now requires a third layer: a recent successful `/auth/oidc/callback` must have been recorded. Layers:
1. `disable_password_login` flag set (admin intent).
2. `is_ready()` - required fields present.
3. `oidc_last_success_at` within `LOCKOUT_GRACE_DAYS` (30 days).

If SSO silently breaks, password login re-arms automatically after the grace window. Hand-edited `system_settings.oidc_last_success_at` cannot extend the window past 30 days; timestamps further than 5 minutes in the future or without a time component fall open.

### HIGH - email_verified truthy coercion
`verify_id_token()` used `bool(payload.get("email_verified", False))`, which treats the string `"false"`, `1`, `[]`, and anything truthy as verified. A non-conformant IdP could therefore bypass the email-match identity-linking guard.

Now a strict `is True` check: only the JSON boolean `true` counts as verified. Missing, null, 0, 1, string, array, nested-object all resolve to `False`.

### MEDIUM - callback URL divergence between admin UI and backend
The admin panel derived the redirect_uri from `window.location.origin`; the backend built the real callback URL from `resolve_base_url()` (saved base_url, `BASE_URL` env, x-forwarded headers). Behind a reverse proxy or with a multi-host deployment these can diverge, so operators registered the UI-shown URL at the IdP and login still failed with `invalid_redirect_uri`.

Now `OIDCConfigResponse` carries `effective_callback_url`, computed on the backend from `resolve_base_url()`. The admin UI shows exactly what the backend will send. A new module constant `oidc_core.CALLBACK_PATH` is the single source of truth consumed by the authorize step, the callback route decorator, and the admin response so they cannot drift. The flow cookie also pins the authorize-time `redirect_uri` so the token exchange reuses it even if base-URL resolution shifts mid-flow.

## Secondary improvements

- Public config endpoint (`/auth/oidc/public-config`) now calls `oidc_core.password_login_disabled()` directly so the frontend hides local auth exactly when the backend would refuse it. Before, the UI could blank the login form even though `/auth/login` still accepted passwords.
- Admin `SsoSection` form layout rebuilt with consistent flex-gap spacing (fields were crowded).
- `SsoSection.handleSave` wraps the PUT in try/catch/finally; on network failure it re-fetches the config so the rendered `effective_callback_url` and `client_secret_set` reconcile with real server state, and the Save button always re-enables.
- 27 new backend tests (parametrized non-boolean email_verified, timestamp-validation edge cases, authorize and callback redirect_uri pinning with mismatched x-forwarded-host, grace window, rearm after grace, corrupted stamp fall-open).
- 3 new frontend tests (effective_callback_url rendered from backend not browser origin, PUT network failure triggers reconciliation).

## Verification

- Backend tests: 268 -> 295 green.
- Frontend tests: 140 -> 143 green.
- Next.js production build: clean.

## Test plan

- [ ] Confirm the admin panel no longer crowds the SSO fields together.
- [ ] Verify the callback URL shown in Admin > Single Sign-On matches the URL your IdP receives on login.
- [ ] Optional: flip `disable_password_login` before ever logging in via SSO and confirm `/auth/login` still works.