### PR TITLE
docs: add community social proof paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Need the right place?
 
 - **Questions and setup help:** use [Discussions Q&A](https://github.com/itsDNNS/tribu/discussions/categories/q-a)
 - **Ideas and early product feedback:** use [Discussions Ideas](https://github.com/itsDNNS/tribu/discussions/categories/ideas)
+- **Want to share your setup or screenshots:** use [Discussions Show and tell](https://github.com/itsDNNS/tribu/discussions/categories/show-and-tell)
 - **Reproducible bugs or scoped feature requests:** open an [Issue](https://github.com/itsDNNS/tribu/issues)
 - **Want the latest packaged version:** check [Releases](https://github.com/itsDNNS/tribu/releases)
 - **Sensitive security reports:** follow the [Security Policy](SECURITY.md)


### PR DESCRIPTION
## Summary
- add a clearer path for people to share their Tribu setups and screenshots publicly
- seed Discussions with maintainer posts for onboarding and show-and-tell momentum
- keep README and wiki home aligned with the new community proof path

## Test plan
- not run (documentation and GitHub discussion changes only)
- verified new discussion URLs and updated README/wiki paths after changes
