### PR TITLE
Fix reload bootstrap delay

### DIFF
--- a/frontend/__tests__/contexts/AppContext.test.js
+++ b/frontend/__tests__/contexts/AppContext.test.js
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AppProvider, useApp } from '../../contexts/AppContext';
+import * as api from '../../lib/api';
+
+jest.mock('../../lib/api');
+
+function Probe() {
+  const { loading, loggedIn, familyId } = useApp();
+  return (
+    <div>
+      <span data-testid="loading">{loading ? 'loading' : 'ready'}</span>
+      <span data-testid="logged-in">{loggedIn ? 'yes' : 'no'}</span>
+      <span data-testid="family-id">{familyId}</span>
+    </div>
+  );
+}
+
+describe('AppProvider bootstrap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.history.replaceState(null, '', '/');
+
+    api.apiGetMe.mockResolvedValue({
+      ok: true,
+      data: {
+        id: 1,
+        email: 'tester@example.com',
+        display_name: 'Tester',
+        profile_image: '',
+        has_completed_onboarding: true,
+        must_change_password: false,
+      },
+    });
+    api.apiGetMyFamilies.mockResolvedValue({
+      ok: true,
+      data: [{ family_id: 7, family_name: 'Test Family', role: 'admin', is_adult: true }],
+    });
+    api.apiGetDashboard.mockResolvedValue({ ok: true, data: { next_events: [], upcoming_birthdays: [] } });
+    api.apiGetEvents.mockResolvedValue({ ok: true, data: [] });
+    api.apiGetMembers.mockResolvedValue({ ok: true, data: [] });
+    api.apiGetContacts.mockResolvedValue({ ok: true, data: [] });
+    api.apiGetBirthdays.mockResolvedValue({ ok: true, data: [] });
+    api.apiGetShoppingLists.mockResolvedValue({ ok: true, data: [] });
+    api.apiGetNavOrder.mockResolvedValue({ ok: true, data: { nav_order: ['dashboard'] } });
+    api.apiGetTimeFormat.mockResolvedValue({ ok: true, data: { time_format: '24h' } });
+    api.apiGetUnreadCount.mockResolvedValue({ ok: true, data: { count: 0 } });
+    api.apiGetNotifications.mockResolvedValue({ ok: true, data: [] });
+    api.connectNotificationStream.mockReturnValue({ close: jest.fn() });
+  });
+
+  test('does not keep the app shell blocked by slow secondary data loaders', async () => {
+    api.apiGetTasks.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <AppProvider>
+        <Probe />
+      </AppProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('logged-in')).toHaveTextContent('yes'));
+    await waitFor(() => expect(screen.getByTestId('family-id')).toHaveTextContent('7'));
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('ready'));
+    expect(api.apiGetTasks).toHaveBeenCalledWith('7');
+  });
+});

--- a/frontend/contexts/AppContext.js
+++ b/frontend/contexts/AppContext.js
@@ -88,6 +88,22 @@ function AppOrchestrator({ children }) {
     setLoading(false);
   }, [families, loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, setLoading, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult]);
 
+  const loadFamilyDataInBackground = useCallback((fid) => {
+    void Promise.allSettled([
+      loadDashboard(fid),
+      loadEvents(fid),
+      loadMembers(fid),
+      loadContacts(fid),
+      loadBirthdays(fid),
+      loadTasks(fid),
+      loadShoppingLists(fid),
+      loadNavOrderWrapped(),
+      api.apiGetTimeFormat().then(({ ok, data: tfData }) => {
+        if (ok && tfData?.time_format) setTimeFormat(tfData.time_format);
+      }),
+    ]);
+  }, [loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadNavOrderWrapped, setTimeFormat]);
+
   const enterDemo = useCallback(() => {
     const demo = buildDemoData(lang);
     setDemoMode(true);
@@ -193,26 +209,25 @@ function AppOrchestrator({ children }) {
 
     (async () => {
       setLoading(true);
-      const { ok: meOk, data: meData } = await api.apiGetMe();
-      if (meOk) {
-        setMe(meData);
-        if (meData.profile_image) setProfileImage(meData.profile_image);
-      }
+      try {
+        const { ok: meOk, data: meData } = await api.apiGetMe();
+        if (meOk) {
+          setMe(meData);
+          if (meData.profile_image) setProfileImage(meData.profile_image);
+        }
 
-      const { ok: famOk, data: famData } = await api.apiGetMyFamilies();
-      if (famOk && famData.length > 0) {
-        setFamilies(famData);
-        const fid = String(famData[0].family_id);
-        setFamilyId(fid);
-        setMyFamilyRole(famData[0].role);
-        setMyFamilyIsAdult(famData[0].is_adult);
-        await Promise.all([loadDashboard(fid), loadEvents(fid), loadMembers(fid), loadContacts(fid), loadBirthdays(fid), loadTasks(fid), loadShoppingLists(fid), loadNavOrderWrapped()]);
-        // Load time format setting
-        const { ok: tfOk, data: tfData } = await api.apiGetTimeFormat();
-        if (tfOk && tfData?.time_format) setTimeFormat(tfData.time_format);
+        const { ok: famOk, data: famData } = await api.apiGetMyFamilies();
+        if (famOk && famData.length > 0) {
+          setFamilies(famData);
+          const fid = String(famData[0].family_id);
+          setFamilyId(fid);
+          setMyFamilyRole(famData[0].role);
+          setMyFamilyIsAdult(famData[0].is_adult);
+          loadFamilyDataInBackground(fid);
+        }
+      } finally {
+        setLoading(false);
       }
-
-      setLoading(false);
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loggedIn]);

--- a/frontend/e2e/tests/bootstrap.spec.js
+++ b/frontend/e2e/tests/bootstrap.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({ serviceWorkers: 'block' });
+
+function json(route, data) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(data),
+  });
+}
+
+test.describe('Bootstrap', () => {
+  test('renders the app shell before slow secondary loaders finish', async ({ page }) => {
+    let slowTasksRequested = false;
+    const startedAt = Date.now();
+
+    await page.route(/\/api\//, async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const path = url.pathname.replace(/^\/api/, '');
+
+      if (path === '/auth/me') {
+        return json(route, {
+          id: 1,
+          email: 'tester@example.com',
+          display_name: 'Tester',
+          profile_image: '',
+          has_completed_onboarding: true,
+          must_change_password: false,
+        });
+      }
+      if (path === '/families/me') {
+        return json(route, [{ family_id: 7, family_name: 'Test Family', role: 'admin', is_adult: true }]);
+      }
+      if (path === '/dashboard/summary') return json(route, { next_events: [], upcoming_birthdays: [] });
+      if (path === '/calendar/events') return json(route, { items: [] });
+      if (path === '/families/7/members') return json(route, []);
+      if (path === '/contacts') return json(route, []);
+      if (path === '/birthdays') return json(route, []);
+      if (path === '/shopping/lists') return json(route, []);
+      if (path === '/nav/order') return json(route, { nav_order: ['dashboard'] });
+      if (path === '/admin/settings/time-format') return json(route, { time_format: '24h' });
+      if (path === '/notifications/unread-count') return json(route, { count: 0 });
+      if (path === '/notifications') return json(route, []);
+      if (path === '/notifications/stream') {
+        return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' });
+      }
+      if (path === '/tasks') {
+        slowTasksRequested = true;
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(json(route, { items: [] }));
+          }, 10000);
+        });
+      }
+      return json(route, {});
+    });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /Tester/ })).toBeVisible({ timeout: 5000 });
+    await expect(page).toHaveTitle('Tribu');
+
+    expect(slowTasksRequested).toBe(true);
+    expect(Date.now() - startedAt).toBeLessThan(6000);
+  });
+});

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -68,6 +68,8 @@ export default function TribuApp({ Component, pageProps }) {
       <AppProvider>
         <ToastProvider>
           <Head>
+            <title>Tribu</title>
+            <meta name="description" content="Self-hosted family organizer for calendars, tasks, shopping lists, contacts, meal planning, and more." />
             <script dangerouslySetInnerHTML={{ __html: DISPLAY_MODE_BOOTSTRAP }} />
             <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
           </Head>


### PR DESCRIPTION
## Summary

- Stop blocking the app shell on secondary module data during reload.
- Keep auth and family selection in the critical path, then load dashboard, calendar, contacts, birthdays, tasks, shopping, navigation order, and time format in the background.
- Set a clean default browser tab title and page description.
- Add regression coverage for a slow secondary data request so the first visible app render stays fast.

## Validation

- Frontend unit suite passed.
- Production build passed.
- Browser reload scenario passed with a delayed secondary request.
