### PR TITLE
Fix rewards dashboard view label

### DIFF
--- a/frontend/__tests__/components/RewardsDashboardWidget.test.js
+++ b/frontend/__tests__/components/RewardsDashboardWidget.test.js
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RewardsDashboardWidget from '../../components/RewardsDashboardWidget';
+
+let mockAppState = {};
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+let mockRewards = {};
+jest.mock('../../hooks/useRewards', () => ({
+  useRewards: () => mockRewards,
+}));
+
+const messages = {
+  'module.rewards.name': 'Belohnungen',
+  'module.rewards.view_all': 'Alle anzeigen',
+  'module.rewards.no_currency': 'Noch keine Belohnungs-Währung eingerichtet.',
+  'module.rewards.widget_pending': '{count} zur Bestätigung',
+};
+
+function baseApp(overrides = {}) {
+  return {
+    messages,
+    isChild: false,
+    members: [{ user_id: 2, display_name: 'Mia', is_adult: false }],
+    setActiveView: jest.fn(),
+    ...overrides,
+  };
+}
+
+function baseRewards(overrides = {}) {
+  return {
+    loading: false,
+    currency: { id: 1, name: 'Stars', icon: 'star' },
+    balances: [{ user_id: 2, display_name: 'Mia', balance: 7, pending: 0 }],
+    catalog: [],
+    pendingCount: 0,
+    myBalance: null,
+    ...overrides,
+  };
+}
+
+describe('RewardsDashboardWidget', () => {
+  beforeEach(() => {
+    mockAppState = baseApp();
+    mockRewards = baseRewards();
+  });
+
+  test('renders translated view-all action instead of the raw key', () => {
+    render(<RewardsDashboardWidget />);
+
+    expect(screen.getByRole('button', { name: 'Alle anzeigen' })).toBeInTheDocument();
+    expect(screen.queryByText('view_all')).not.toBeInTheDocument();
+  });
+
+  test('view-all action opens the rewards view', () => {
+    const setActiveView = jest.fn();
+    mockAppState = baseApp({ setActiveView });
+
+    render(<RewardsDashboardWidget />);
+    fireEvent.click(screen.getByRole('button', { name: 'Alle anzeigen' }));
+
+    expect(setActiveView).toHaveBeenCalledWith('rewards');
+  });
+});

--- a/frontend/components/RewardsDashboardWidget.js
+++ b/frontend/components/RewardsDashboardWidget.js
@@ -32,7 +32,7 @@ export default function RewardsDashboardWidget() {
       <div className="bento-card bento-rewards glass glow-amber">
         <div className="bento-card-header">
           <Gift size={16} /> <span>{t(messages, 'module.rewards.name')}</span>
-          <button className="bento-more" onClick={() => setActiveView('rewards')}>{t(messages, 'view_all')}</button>
+          <button className="bento-more" onClick={() => setActiveView('rewards')}>{t(messages, 'module.rewards.view_all')}</button>
         </div>
         {rw.myBalance && (
           <div className="rewards-balance">
@@ -61,7 +61,7 @@ export default function RewardsDashboardWidget() {
     <div className="bento-card bento-rewards glass glow-amber">
       <div className="bento-card-header">
         <Gift size={16} /> <span>{t(messages, 'module.rewards.name')}</span>
-        <button className="bento-more" onClick={() => setActiveView('rewards')}>{t(messages, 'view_all')}</button>
+        <button className="bento-more" onClick={() => setActiveView('rewards')}>{t(messages, 'module.rewards.view_all')}</button>
       </div>
       {childBalances.length > 0 ? (
         <div className="rewards-child-list">

--- a/frontend/e2e/tests/rewards-dashboard.spec.js
+++ b/frontend/e2e/tests/rewards-dashboard.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({ serviceWorkers: 'block' });
+
+function json(route, data) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(data),
+  });
+}
+
+test.describe('Rewards dashboard widget', () => {
+  test('renders translated view-all action', async ({ page }) => {
+    await page.route(/\/api\//, async (route) => {
+      const url = new URL(route.request().url());
+      const path = url.pathname.replace(/^\/api/, '');
+
+      if (path === '/auth/me') {
+        return json(route, {
+          id: 1,
+          user_id: 1,
+          email: 'tester@example.com',
+          display_name: 'Tester',
+          profile_image: '',
+          has_completed_onboarding: true,
+          must_change_password: false,
+        });
+      }
+      if (path === '/families/me') {
+        return json(route, [{ family_id: 7, family_name: 'Test Family', role: 'admin', is_adult: true }]);
+      }
+      if (path === '/families/7/members') {
+        return json(route, [
+          { user_id: 1, display_name: 'Tester', role: 'admin', is_adult: true },
+          { user_id: 2, display_name: 'Mia', role: 'member', is_adult: false },
+        ]);
+      }
+      if (path === '/dashboard/summary') return json(route, { next_events: [], upcoming_birthdays: [] });
+      if (path === '/calendar/events') return json(route, { items: [] });
+      if (path === '/contacts') return json(route, []);
+      if (path === '/birthdays') return json(route, []);
+      if (path === '/tasks') return json(route, { items: [] });
+      if (path === '/shopping/lists') return json(route, []);
+      if (path === '/nav/order') return json(route, { nav_order: ['dashboard'] });
+      if (path === '/admin/settings/time-format') return json(route, { time_format: '24h' });
+      if (path === '/notifications/unread-count') return json(route, { count: 0 });
+      if (path === '/notifications') return json(route, []);
+      if (path === '/notifications/stream') {
+        return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' });
+      }
+      if (path === '/rewards/currency') return json(route, { id: 1, family_id: 7, name: 'Stars', icon: 'star' });
+      if (path === '/rewards/balances') return json(route, { balances: [{ user_id: 2, display_name: 'Mia', balance: 7, pending: 0 }] });
+      if (path === '/rewards/catalog') return json(route, []);
+      if (path === '/rewards/rules') return json(route, []);
+      if (path === '/rewards/transactions') return json(route, { items: [] });
+
+      return json(route, {});
+    });
+
+    await page.goto('/');
+
+    const rewardsCard = page.locator('.bento-rewards');
+    await expect(rewardsCard).toContainText('Rewards');
+    await expect(rewardsCard.getByRole('button', { name: 'View all' })).toBeVisible();
+    await expect(rewardsCard).not.toContainText('view_all');
+  });
+});

--- a/frontend/i18n/modules/rewards/de.json
+++ b/frontend/i18n/modules/rewards/de.json
@@ -1,5 +1,6 @@
 {
   "module.rewards.name": "Belohnungen",
+  "module.rewards.view_all": "Alle anzeigen",
   "module.rewards.balance": "Guthaben",
   "module.rewards.pending": "{count} ausstehend",
   "module.rewards.currency_setup": "Belohnungs-Währung einrichten",

--- a/frontend/i18n/modules/rewards/en.json
+++ b/frontend/i18n/modules/rewards/en.json
@@ -1,5 +1,6 @@
 {
   "module.rewards.name": "Rewards",
+  "module.rewards.view_all": "View all",
   "module.rewards.balance": "Balance",
   "module.rewards.pending": "{count} pending",
   "module.rewards.currency_setup": "Set up your reward currency",


### PR DESCRIPTION
## Summary

- Replace the raw rewards dashboard action key with a translated label.
- Add English and German labels for the rewards dashboard view-all action.
- Add unit and browser coverage for the dashboard widget text.

## Validation

- Frontend unit suite passed.
- Production build passed.
- Browser dashboard widget scenario passed.
