### PR TITLE
Fix recipe dialog viewport anchoring

### DIFF
--- a/frontend/e2e/tests/recipe-dialog-layout.spec.js
+++ b/frontend/e2e/tests/recipe-dialog-layout.spec.js
@@ -1,0 +1,81 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({ serviceWorkers: 'block' });
+
+function json(route, data) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(data),
+  });
+}
+
+async function mockApi(page) {
+  await page.route(/\/api\//, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname.replace(/^\/api/, '');
+
+    if (path === '/auth/me') {
+      return json(route, {
+        id: 1,
+        email: 'tester@example.com',
+        display_name: 'Tester',
+        profile_image: '',
+        has_completed_onboarding: true,
+        must_change_password: false,
+      });
+    }
+    if (path === '/families/me') {
+      return json(route, [{ family_id: 7, family_name: 'Test Family', role: 'admin', is_adult: true }]);
+    }
+    if (path === '/recipes') return json(route, []);
+    if (path === '/dashboard/summary') return json(route, { next_events: [], upcoming_birthdays: [] });
+    if (path === '/calendar/events') return json(route, { items: [] });
+    if (path === '/families/7/members') return json(route, []);
+    if (path === '/contacts') return json(route, []);
+    if (path === '/birthdays') return json(route, []);
+    if (path === '/shopping/lists') return json(route, []);
+    if (path === '/tasks') return json(route, { items: [] });
+    if (path === '/nav/order') return json(route, { nav_order: ['recipes', 'dashboard', 'settings'] });
+    if (path === '/admin/settings/time-format') return json(route, { time_format: '24h' });
+    if (path === '/notifications/unread-count') return json(route, { count: 0 });
+    if (path === '/notifications') return json(route, []);
+    if (path === '/notifications/stream') {
+      return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' });
+    }
+    return json(route, {});
+  });
+}
+
+test.describe('Recipe dialog layout', () => {
+  test('keeps the add recipe dialog and backdrop within the viewport', async ({ page }) => {
+    await mockApi(page);
+
+    await page.goto('/#recipes');
+    await page.getByRole('button', { name: 'Add recipe' }).click();
+    await expect(page.getByRole('dialog', { name: 'Add recipe' })).toBeVisible();
+
+    const metrics = await page.locator('.recipe-dialog').evaluate((dialog) => {
+      const dialogRect = dialog.getBoundingClientRect();
+      const backdropRect = document.querySelector('.cal-dialog-backdrop').getBoundingClientRect();
+      return {
+        dialogTop: dialogRect.top,
+        dialogBottom: dialogRect.bottom,
+        backdropTop: backdropRect.top,
+        backdropLeft: backdropRect.left,
+        backdropRight: backdropRect.right,
+        backdropBottom: backdropRect.bottom,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(metrics.backdropTop).toBe(0);
+    expect(metrics.backdropLeft).toBe(0);
+    expect(metrics.backdropRight).toBe(metrics.viewportWidth);
+    expect(metrics.backdropBottom).toBe(metrics.viewportHeight);
+    expect(metrics.dialogTop).toBeGreaterThanOrEqual(0);
+    expect(metrics.dialogBottom).toBeLessThanOrEqual(metrics.viewportHeight);
+  });
+});

--- a/frontend/e2e/tests/recipes.spec.js
+++ b/frontend/e2e/tests/recipes.spec.js
@@ -3,6 +3,30 @@ const { getFamilyId, seedShoppingList } = require('../helpers/api-setup');
 const { navigateTo } = require('../helpers/navigation');
 
 test.describe('Recipes', () => {
+  async function expectRecipeDialogInViewport(page) {
+    const metrics = await page.locator('.recipe-dialog').evaluate((dialog) => {
+      const dialogRect = dialog.getBoundingClientRect();
+      const backdropRect = document.querySelector('.cal-dialog-backdrop').getBoundingClientRect();
+      return {
+        dialogTop: dialogRect.top,
+        dialogBottom: dialogRect.bottom,
+        backdropTop: backdropRect.top,
+        backdropLeft: backdropRect.left,
+        backdropRight: backdropRect.right,
+        backdropBottom: backdropRect.bottom,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(metrics.backdropTop).toBe(0);
+    expect(metrics.backdropLeft).toBe(0);
+    expect(metrics.backdropRight).toBe(metrics.viewportWidth);
+    expect(metrics.backdropBottom).toBe(metrics.viewportHeight);
+    expect(metrics.dialogTop).toBeGreaterThanOrEqual(0);
+    expect(metrics.dialogBottom).toBeLessThanOrEqual(metrics.viewportHeight);
+  }
+
   test('create a recipe, push ingredients to shopping, and copy it into a meal plan', async ({ authedPage: page, apiCtx }) => {
     const familyId = await getFamilyId(apiCtx);
     await seedShoppingList(apiCtx, familyId, 'Recipe Shopping List');
@@ -11,6 +35,7 @@ test.describe('Recipes', () => {
 
     await navigateTo(page, 'Recipes');
     await page.getByRole('button', { name: 'Add recipe' }).click();
+    await expectRecipeDialogInViewport(page);
 
     await page.getByRole('dialog', { name: 'Add recipe' }).getByPlaceholder('e.g. Tomato pasta').fill('Playwright Pancakes');
     await page.getByPlaceholder('Servings').fill('4');

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -707,7 +707,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .dashboard-header-actions { display: flex; align-items: center; gap: var(--space-sm); }
 .btn-icon { width: 44px; height: 44px; padding: 0; display: inline-flex; align-items: center; justify-content: center; }
 .view-enter { animation: viewEnter 0.4s var(--ease-out-expo) both; }
-@keyframes viewEnter { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes viewEnter { from { opacity: 0; } to { opacity: 1; } }
 
 /* ═══════════════════════════════════════════
    BENTO GRID (Dashboard)


### PR DESCRIPTION
## Summary
- Remove the transform from the shared view-enter animation so fixed dialog backdrops stay anchored to the viewport.
- Add a focused browser regression for the add recipe dialog backdrop and viewport bounds.
- Extend the recipe E2E flow with the same viewport guard before filling the form.

## Validation
- Browser regression for the add recipe dialog passed on desktop and mobile.
- Recipe view component test passed.
- Frontend unit suite passed.
- Production frontend build passed.
- Remote E2E passed.