### PR TITLE
Improve reminder delivery reliability

### DIFF
--- a/backend/alembic/versions/0032_notification_sent_log_reliability.py
+++ b/backend/alembic/versions/0032_notification_sent_log_reliability.py
@@ -1,0 +1,99 @@
+"""Add reliability metadata to notification_sent_log.
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-04-25
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0032"
+down_revision: Union[str, None] = "0031"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "notification_sent_log"
+PARTIAL_UQ_NAME = "uq_notification_sent_log_user_trigger_key"
+TRIGGER_KEY_INDEX = "ix_notification_sent_log_trigger_key"
+
+
+def _columns(table: str) -> set[str]:
+    insp = sa.inspect(op.get_bind())
+    if table not in insp.get_table_names():
+        return set()
+    return {c["name"] for c in insp.get_columns(table)}
+
+
+def _index_exists(table: str, name: str) -> bool:
+    insp = sa.inspect(op.get_bind())
+    if table not in insp.get_table_names():
+        return False
+    return name in {ix["name"] for ix in insp.get_indexes(table)}
+
+
+def upgrade() -> None:
+    cols = _columns(TABLE)
+    if not cols:
+        return
+
+    with op.batch_alter_table(TABLE) as batch:
+        if "trigger_key" not in cols:
+            batch.add_column(sa.Column("trigger_key", sa.String(), nullable=True))
+        if "status" not in cols:
+            batch.add_column(
+                sa.Column("status", sa.String(), nullable=False, server_default="pending")
+            )
+        if "delivery_attempts" not in cols:
+            batch.add_column(
+                sa.Column("delivery_attempts", sa.Integer(), nullable=False, server_default="0")
+            )
+        if "last_attempt_at" not in cols:
+            batch.add_column(sa.Column("last_attempt_at", sa.DateTime(), nullable=True))
+        if "last_error" not in cols:
+            batch.add_column(sa.Column("last_error", sa.Text(), nullable=True))
+        if "delivered_at" not in cols:
+            batch.add_column(sa.Column("delivered_at", sa.DateTime(), nullable=True))
+
+    # Partial unique index: prevents duplicate (user_id, trigger_key) pairs
+    # for new rows while leaving legacy rows (trigger_key IS NULL) unaffected.
+    # Both PostgreSQL and SQLite (>= 3.8) support partial indexes; SQLAlchemy
+    # accepts the dialect-specific WHERE via *_where kwargs.
+    if not _index_exists(TABLE, PARTIAL_UQ_NAME):
+        op.create_index(
+            PARTIAL_UQ_NAME,
+            TABLE,
+            ["user_id", "trigger_key"],
+            unique=True,
+            postgresql_where=sa.text("trigger_key IS NOT NULL"),
+            sqlite_where=sa.text("trigger_key IS NOT NULL"),
+        )
+
+    if not _index_exists(TABLE, TRIGGER_KEY_INDEX):
+        op.create_index(TRIGGER_KEY_INDEX, TABLE, ["trigger_key"])
+
+
+def downgrade() -> None:
+    cols = _columns(TABLE)
+    if not cols:
+        return
+
+    if _index_exists(TABLE, TRIGGER_KEY_INDEX):
+        op.drop_index(TRIGGER_KEY_INDEX, table_name=TABLE)
+    if _index_exists(TABLE, PARTIAL_UQ_NAME):
+        op.drop_index(PARTIAL_UQ_NAME, table_name=TABLE)
+
+    with op.batch_alter_table(TABLE) as batch:
+        for col in (
+            "delivered_at",
+            "last_error",
+            "last_attempt_at",
+            "delivery_attempts",
+            "status",
+            "trigger_key",
+        ):
+            if col in cols:
+                batch.drop_column(col)

--- a/backend/app/core/push.py
+++ b/backend/app/core/push.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+from dataclasses import dataclass, field, asdict
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -9,32 +11,81 @@ from app.models import PushSubscription
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class PushResult:
+    """Outcome of a single send_push_for_user call.
+
+    Counts cover the subscriptions actually attempted in this call. ``removed``
+    counts 410-Gone subscriptions that were deleted from the database.
+    ``errors`` holds short, redacted snippets so the scheduler can log
+    last_error without persisting full stack traces.
+    """
+
+    attempted: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    removed: int = 0
+    errors: list[str] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+    @property
+    def all_failed(self) -> bool:
+        return self.attempted > 0 and self.succeeded == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
 def get_vapid_public_key() -> str | None:
     return os.environ.get("VAPID_PUBLIC_KEY") or None
 
 
-def send_push_for_user(db: Session, user_id: int, title: str, body: str, url: str | None = None):
+def _short_error(exc: BaseException, limit: int = 200) -> str:
+    msg = f"{type(exc).__name__}: {exc}"
+    return msg[:limit]
+
+
+def send_push_for_user(
+    db: Session,
+    user_id: int,
+    title: str,
+    body: str,
+    url: str | None = None,
+) -> PushResult:
+    """Send a web-push payload to every active subscription for ``user_id``.
+
+    Returns a :class:`PushResult` describing the attempt. Subscriptions that
+    return HTTP 410 Gone are removed from the database (preserved behavior).
+    Callers can treat ``result.attempted == 0`` together with ``skipped_reason``
+    as "push was not actually delivered" without raising.
+    """
+    result = PushResult()
+
     public_key = os.environ.get("VAPID_PUBLIC_KEY")
     private_key = os.environ.get("VAPID_PRIVATE_KEY")
     claims_email = os.environ.get("VAPID_CLAIMS_EMAIL")
 
     if not public_key or not private_key or not claims_email:
-        return
+        result.skipped_reason = "vapid_not_configured"
+        return result
 
     try:
         from pywebpush import webpush, WebPushException
     except ImportError:
         logger.warning("pywebpush not installed, skipping push notification")
-        return
+        result.skipped_reason = "pywebpush_missing"
+        return result
 
     subscriptions = db.query(PushSubscription).filter(PushSubscription.user_id == user_id).all()
     if not subscriptions:
-        return
+        result.skipped_reason = "no_subscriptions"
+        return result
 
     payload = json.dumps({"title": title, "body": body, "url": url})
     vapid_claims = {"sub": f"mailto:{claims_email}"}
 
     for sub in subscriptions:
+        result.attempted += 1
         try:
             webpush(
                 subscription_info={
@@ -45,11 +96,25 @@ def send_push_for_user(db: Session, user_id: int, title: str, body: str, url: st
                 vapid_private_key=private_key,
                 vapid_claims=vapid_claims,
             )
+            result.succeeded += 1
         except WebPushException as e:
-            if hasattr(e, "response") and e.response is not None and e.response.status_code == 410:
+            response = getattr(e, "response", None)
+            status = getattr(response, "status_code", None)
+            if status == 410:
                 logger.info("Push subscription gone (410), removing: %s", sub.endpoint[:60])
                 db.delete(sub)
-            else:
-                logger.warning("Push failed for endpoint %s: %s", sub.endpoint[:60], e)
-        except Exception:
+                result.removed += 1
+                # 410 means the subscription is permanently invalid; we do not
+                # count it as a transient failure that should drive retries.
+                continue
+            result.failed += 1
+            snippet = _short_error(e)
+            result.errors.append(snippet)
+            logger.warning("Push failed for endpoint %s: %s", sub.endpoint[:60], snippet)
+        except Exception as e:
+            result.failed += 1
+            snippet = _short_error(e)
+            result.errors.append(snippet)
             logger.exception("Unexpected push error for endpoint %s", sub.endpoint[:60])
+
+    return result

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -5,10 +5,13 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
+from sqlalchemy import or_
+
 from app.core import cache
 from app.core.backup import create_backup, enforce_retention
 from app.core.clock import utcnow
 from app.core.push import send_push_for_user
+from app.core.recurrence import expand_event
 from app.database import SessionLocal
 from app.models import (
     CalendarEvent, FamilyBirthday, Membership, Notification,
@@ -94,12 +97,25 @@ def _in_quiet_hours(quiet_start: str | None, quiet_end: str | None, now: datetim
         return current_minutes >= start_minutes or current_minutes < end_minutes
 
 
+def _event_trigger_key(event_id: int, starts_at: datetime) -> str:
+    # Include the occurrence timestamp so a rescheduled event re-alerts.
+    return f"event:{event_id}:{starts_at.replace(microsecond=0).isoformat()}"
+
+
+def _task_trigger_key(task_id: int, due_date: datetime) -> str:
+    # Include the due timestamp so a moved due-date re-alerts.
+    return f"task:{task_id}:{due_date.replace(microsecond=0).isoformat()}"
+
+
+def _birthday_trigger_key(birthday_id: int, target_date) -> str:
+    return f"birthday:{birthday_id}:{target_date.isoformat()}"
+
+
 def _check_notifications():
     db = SessionLocal()
     try:
         now = utcnow()
-        today = now.date()
-        tomorrow = today + timedelta(days=1)
+        tomorrow = now.date() + timedelta(days=1)
 
         memberships = db.query(Membership).all()
         user_families: dict[int, list[int]] = {}
@@ -116,30 +132,162 @@ def _check_notifications():
             default = NotificationPreference(user_id=uid, reminders_enabled=True, reminder_minutes=30)
             return default
 
-        def already_sent(source_type: str, source_id: int, uid: int) -> bool:
-            return db.query(NotificationSentLog).filter(
-                NotificationSentLog.source_type == source_type,
-                NotificationSentLog.source_id == source_id,
-                NotificationSentLog.user_id == uid,
-                NotificationSentLog.sent_at >= datetime(today.year, today.month, today.day),
-            ).first() is not None
+        def get_log(uid: int, trigger_key: str) -> NotificationSentLog | None:
+            return (
+                db.query(NotificationSentLog)
+                .filter(
+                    NotificationSentLog.user_id == uid,
+                    NotificationSentLog.trigger_key == trigger_key,
+                )
+                .first()
+            )
 
-        def create_notif(uid: int, fid: int, ntype: str, title: str, body: str, link: str | None, source_type: str, source_id: int):
+        def adopt_legacy_log(
+            uid: int,
+            source_type: str,
+            source_id: int,
+            trigger_key: str,
+        ) -> bool:
+            """Attach a deterministic trigger key to a same-day legacy log.
+
+            Before 0032, the scheduler created the in-app Notification and a
+            source/user/day log together. If such a legacy log already exists,
+            the reminder was already surfaced, so adopting the log avoids
+            creating a duplicate in-app notification after upgrade.
+            """
+            start_of_day = datetime(now.year, now.month, now.day)
+            legacy = (
+                db.query(NotificationSentLog)
+                .filter(
+                    NotificationSentLog.user_id == uid,
+                    NotificationSentLog.source_type == source_type,
+                    NotificationSentLog.source_id == source_id,
+                    NotificationSentLog.trigger_key.is_(None),
+                    NotificationSentLog.sent_at >= start_of_day,
+                )
+                .order_by(NotificationSentLog.sent_at.desc())
+                .first()
+            )
+            if not legacy:
+                return False
+            legacy.trigger_key = trigger_key
+            legacy.status = "delivered"
+            legacy.delivered_at = legacy.delivered_at or legacy.sent_at or now
+            legacy.last_attempt_at = legacy.last_attempt_at or legacy.sent_at or now
+            legacy.last_error = None
+            return True
+
+        def deliver(
+            uid: int,
+            fid: int,
+            ntype: str,
+            title: str,
+            body: str,
+            link: str | None,
+            source_type: str,
+            source_id: int,
+            trigger_key: str,
+        ) -> None:
+            """Idempotent reminder delivery for a (user, trigger_key) pair.
+
+            On first invocation creates exactly one in-app Notification and one
+            NotificationSentLog row. On retry runs reuses the existing log,
+            does NOT create another in-app Notification, but may re-attempt
+            push if push is enabled and the previous attempt failed.
+            """
             pref = get_pref(uid)
             if _in_quiet_hours(pref.quiet_start, pref.quiet_end, now):
                 return
-            notif = Notification(
-                user_id=uid, family_id=fid, type=ntype,
-                title=title, body=body, link=link,
-            )
-            db.add(notif)
-            log = NotificationSentLog(source_type=source_type, source_id=source_id, user_id=uid)
-            db.add(log)
+
+            log = get_log(uid, trigger_key)
+            first_run = log is None
+
+            if first_run and adopt_legacy_log(uid, source_type, source_id, trigger_key):
+                return
+
+            if first_run:
+                notif = Notification(
+                    user_id=uid, family_id=fid, type=ntype,
+                    title=title, body=body, link=link,
+                )
+                db.add(notif)
+                log = NotificationSentLog(
+                    source_type=source_type,
+                    source_id=source_id,
+                    user_id=uid,
+                    trigger_key=trigger_key,
+                    status="pending",
+                    delivery_attempts=0,
+                )
+                db.add(log)
+                # Flush so the partial-unique index catches concurrent inserts
+                # before push, and so subsequent get_log calls find the row.
+                db.flush()
+            else:
+                # Retry: only proceed if the previous attempt was not delivered.
+                if log.status == "delivered":
+                    return
+
+            push_result = None
             if pref.push_enabled:
                 try:
-                    send_push_for_user(db, uid, title, body, link)
-                except Exception:
+                    push_result = send_push_for_user(db, uid, title, body, link)
+                except Exception as exc:
                     logger.exception("Push notification failed for user %s", uid)
+                    log.delivery_attempts = (log.delivery_attempts or 0) + 1
+                    log.last_attempt_at = now
+                    log.last_error = f"unexpected: {type(exc).__name__}: {exc}"[:500]
+                    log.status = "failed"
+                    return
+
+            log.delivery_attempts = (log.delivery_attempts or 0) + 1
+            log.last_attempt_at = now
+
+            if push_result is None:
+                # Push disabled — in-app delivery is the only channel and it
+                # succeeded the moment we created the Notification row.
+                log.status = "delivered"
+                log.delivered_at = now
+                log.last_error = None
+                return
+
+            if push_result.attempted == 0:
+                # No subscriptions / VAPID not configured / library missing.
+                # In-app notification still landed, so the reminder reached
+                # the user via the only channel that was active.
+                log.status = "delivered"
+                log.delivered_at = now
+                log.last_error = (
+                    f"push_skipped:{push_result.skipped_reason}"
+                    if push_result.skipped_reason
+                    else None
+                )
+                return
+
+            if push_result.succeeded > 0:
+                log.status = "delivered"
+                log.delivered_at = now
+                log.last_error = (
+                    "; ".join(push_result.errors)[:500] if push_result.errors else None
+                )
+            elif push_result.failed == 0:
+                # Only gone subscriptions were removed. The in-app
+                # notification exists and there is no transient endpoint left
+                # to retry, so the reminder is complete.
+                log.status = "delivered"
+                log.delivered_at = now
+                log.last_error = (
+                    f"push_removed_subscriptions:{push_result.removed}"
+                    if push_result.removed
+                    else None
+                )
+            else:
+                # Every attempted endpoint failed transiently — keep the
+                # row retryable so the next scheduler tick can try again.
+                log.status = "failed"
+                log.last_error = (
+                    "; ".join(push_result.errors)[:500] if push_result.errors else "push_failed"
+                )
 
         # 1. Event reminders
         for uid, fam_ids in user_families.items():
@@ -151,20 +299,37 @@ def _check_notifications():
                 db.query(CalendarEvent)
                 .filter(
                     CalendarEvent.family_id.in_(fam_ids),
-                    CalendarEvent.starts_at > now,
-                    CalendarEvent.starts_at <= window,
                     CalendarEvent.all_day == False,
+                    CalendarEvent.starts_at <= window,
+                    or_(
+                        CalendarEvent.starts_at > now,
+                        CalendarEvent.recurrence.isnot(None),
+                    ),
+                    or_(
+                        CalendarEvent.recurrence.is_(None),
+                        CalendarEvent.recurrence_end.is_(None),
+                        CalendarEvent.recurrence_end >= now,
+                    ),
                 )
                 .all()
             )
             for ev in events:
-                if not already_sent("event", ev.id, uid):
-                    mins = int((ev.starts_at - now).total_seconds() / 60)
-                    create_notif(
+                occurrences = (
+                    expand_event(ev, range_start=now, range_end=window + timedelta(seconds=1))
+                    if ev.recurrence
+                    else [{"starts_at": ev.starts_at}]
+                )
+                for occurrence in occurrences:
+                    starts_at = occurrence["starts_at"]
+                    if starts_at <= now or starts_at > window:
+                        continue
+                    mins = int((starts_at - now).total_seconds() / 60)
+                    deliver(
                         uid, ev.family_id, "event_reminder",
                         ev.title,
                         f"Starts in {mins} minutes",
                         "calendar", "event", ev.id,
+                        _event_trigger_key(ev.id, starts_at),
                     )
 
 
@@ -181,13 +346,13 @@ def _check_notifications():
                 .all()
             )
             for task in overdue:
-                if not already_sent("task", task.id, uid):
-                    create_notif(
-                        uid, task.family_id, "task_due",
-                        task.title,
-                        "Task is overdue",
-                        "tasks", "task", task.id,
-                    )
+                deliver(
+                    uid, task.family_id, "task_due",
+                    task.title,
+                    "Task is overdue",
+                    "tasks", "task", task.id,
+                    _task_trigger_key(task.id, task.due_date),
+                )
 
         # 3. Birthday reminders (tomorrow)
         for uid, fam_ids in user_families.items():
@@ -204,13 +369,13 @@ def _check_notifications():
                 .all()
             )
             for bd in birthdays:
-                if not already_sent("birthday", bd.id, uid):
-                    create_notif(
-                        uid, bd.family_id, "birthday",
-                        bd.person_name,
-                        f"Birthday tomorrow ({tomorrow.strftime('%b %d')})",
-                        "dashboard", "birthday", bd.id,
-                    )
+                deliver(
+                    uid, bd.family_id, "birthday",
+                    bd.person_name,
+                    f"Birthday tomorrow ({tomorrow.strftime('%b %d')})",
+                    "dashboard", "birthday", bd.id,
+                    _birthday_trigger_key(bd.id, tomorrow),
+                )
 
         db.commit()
         # Invalidate notification count caches for affected users

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -315,6 +315,25 @@ class NotificationSentLog(Base):
     source_id = Column(Integer, nullable=False)
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     sent_at = Column(DateTime, nullable=False, server_default=func.now())
+    # Reliability metadata: nullable for legacy rows, populated for rows
+    # written by the scheduler since 0032.
+    trigger_key = Column(String, nullable=True, index=True)
+    status = Column(String, nullable=False, default="pending", server_default="pending")
+    delivery_attempts = Column(Integer, nullable=False, default=0, server_default="0")
+    last_attempt_at = Column(DateTime, nullable=True)
+    last_error = Column(Text, nullable=True)
+    delivered_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uq_notification_sent_log_user_trigger_key",
+            "user_id",
+            "trigger_key",
+            unique=True,
+            sqlite_where=text("trigger_key IS NOT NULL"),
+            postgresql_where=text("trigger_key IS NOT NULL"),
+        ),
+    )
 
 
 class UserNavOrder(Base):

--- a/backend/tests/test_notification_reliability.py
+++ b/backend/tests/test_notification_reliability.py
@@ -1,0 +1,481 @@
+"""Reliability tests for the reminder scheduler (issue #169).
+
+Drives ``app.core.scheduler._check_notifications`` against an shared SQLite
+database with a monkeypatched ``send_push_for_user`` so we can
+assert how the scheduler treats trigger keys, retries, and push results.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base
+from app.models import (
+    CalendarEvent,
+    Family,
+    Membership,
+    Notification,
+    NotificationPreference,
+    NotificationSentLog,
+    PushSubscription,
+    Task,
+    User,
+)
+from app.security import hash_password
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestSession = sessionmaker(bind=engine, autoflush=False)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch):
+    Base.metadata.create_all(bind=engine)
+    # Make ``SessionLocal()`` inside the scheduler hand out the in-memory
+    # test session so we don't need to spin up the real engine.
+    from app.core import scheduler as scheduler_module
+
+    monkeypatch.setattr(scheduler_module, "SessionLocal", TestSession)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _seed_user(db, email: str = "rel@example.com") -> tuple[User, Family]:
+    user = User(email=email, password_hash=hash_password("p"), display_name="Rel")
+    fam = Family(name="Rel-Family")
+    db.add_all([user, fam])
+    db.flush()
+    db.add(Membership(user_id=user.id, family_id=fam.id, role="admin", is_adult=True))
+    db.flush()
+    return user, fam
+
+
+def _set_pref(db, user_id: int, *, push_enabled: bool = False) -> None:
+    pref = NotificationPreference(
+        user_id=user_id,
+        reminders_enabled=True,
+        reminder_minutes=30,
+        push_enabled=push_enabled,
+    )
+    db.add(pref)
+    db.flush()
+
+
+def _freeze_now(monkeypatch, now: datetime) -> None:
+    from app.core import scheduler as scheduler_module
+
+    monkeypatch.setattr(scheduler_module, "utcnow", lambda: now)
+
+
+def test_event_reminder_idempotent_across_runs(monkeypatch):
+    """Two scheduler runs for the same event reminder must produce one
+    Notification row and one log row, not duplicates."""
+    db = TestSession()
+    try:
+        user, fam = _seed_user(db, "evt@example.com")
+        _set_pref(db, user.id, push_enabled=False)
+        now = datetime(2026, 4, 25, 12, 0, 0, tzinfo=timezone.utc).replace(tzinfo=None)
+        ev = CalendarEvent(
+            family_id=fam.id,
+            title="Standup",
+            starts_at=now + timedelta(minutes=15),
+            all_day=False,
+        )
+        db.add(ev)
+        db.commit()
+        user_id, ev_id = user.id, ev.id
+    finally:
+        db.close()
+
+    _freeze_now(monkeypatch, now)
+
+    from app.core.scheduler import _check_notifications
+
+    _check_notifications()
+    _check_notifications()
+
+    db = TestSession()
+    try:
+        notifs = db.query(Notification).filter(Notification.user_id == user_id).all()
+        logs = db.query(NotificationSentLog).filter(NotificationSentLog.user_id == user_id).all()
+        assert len(notifs) == 1, f"expected 1 Notification, got {len(notifs)}"
+        assert len(logs) == 1, f"expected 1 sent-log row, got {len(logs)}"
+
+        log = logs[0]
+        assert log.trigger_key is not None
+        assert log.trigger_key.startswith(f"event:{ev_id}:")
+        assert log.status == "delivered"
+        # The second scheduler run is a no-op once the in-app-only
+        # reminder is delivered.
+        assert log.delivery_attempts == 1
+        assert log.delivered_at is not None
+    finally:
+        db.close()
+
+
+def test_same_day_legacy_log_is_adopted_without_duplicate_notification(monkeypatch):
+    """After upgrading to trigger keys, a same-day legacy sent log means
+    the pre-upgrade scheduler already created the in-app notification."""
+    db = TestSession()
+    try:
+        user, fam = _seed_user(db, "legacy@example.com")
+        _set_pref(db, user.id, push_enabled=False)
+        now = datetime(2026, 4, 25, 12, 0, 0)
+        ev = CalendarEvent(
+            family_id=fam.id,
+            title="Legacy Standup",
+            starts_at=now + timedelta(minutes=15),
+            all_day=False,
+        )
+        db.add(ev)
+        db.flush()
+        db.add(Notification(
+            user_id=user.id,
+            family_id=fam.id,
+            type="event_reminder",
+            title=ev.title,
+            body="Starts in 15 minutes",
+            link="calendar",
+        ))
+        db.add(NotificationSentLog(
+            source_type="event",
+            source_id=ev.id,
+            user_id=user.id,
+            sent_at=now,
+            trigger_key=None,
+        ))
+        db.commit()
+        user_id, ev_id = user.id, ev.id
+    finally:
+        db.close()
+
+    _freeze_now(monkeypatch, now)
+    from app.core.scheduler import _check_notifications
+
+    _check_notifications()
+
+    db = TestSession()
+    try:
+        notifs = db.query(Notification).filter(Notification.user_id == user_id).all()
+        logs = db.query(NotificationSentLog).filter(NotificationSentLog.user_id == user_id).all()
+        assert len(notifs) == 1
+        assert len(logs) == 1
+        assert logs[0].trigger_key.startswith(f"event:{ev_id}:")
+        assert logs[0].status == "delivered"
+    finally:
+        db.close()
+
+
+
+def test_changing_event_starts_at_changes_trigger_key():
+    """Rescheduling an event must produce a different trigger key so the
+    user is alerted again at the new time."""
+    from app.core.scheduler import _event_trigger_key
+
+    base_id = 7
+    t1 = datetime(2026, 4, 25, 9, 0, 0)
+    t2 = datetime(2026, 4, 25, 11, 0, 0)
+    assert _event_trigger_key(base_id, t1) != _event_trigger_key(base_id, t2)
+
+
+def test_changing_task_due_date_changes_trigger_key():
+    from app.core.scheduler import _task_trigger_key
+
+    base_id = 11
+    d1 = datetime(2026, 4, 25, 9, 0, 0)
+    d2 = datetime(2026, 4, 26, 9, 0, 0)
+    assert _task_trigger_key(base_id, d1) != _task_trigger_key(base_id, d2)
+
+
+def test_transient_push_failure_keeps_one_notification_and_retries(monkeypatch):
+    """If push fails on every endpoint the in-app notification is still
+    created (only once), the log is marked failed, attempts increment, and
+    the next run can retry without duplicating the notification."""
+    db = TestSession()
+    try:
+        user, fam = _seed_user(db, "push@example.com")
+        _set_pref(db, user.id, push_enabled=True)
+        now = datetime(2026, 4, 25, 12, 0, 0)
+        ev = CalendarEvent(
+            family_id=fam.id,
+            title="Therapy",
+            starts_at=now + timedelta(minutes=10),
+            all_day=False,
+        )
+        db.add(ev)
+        db.commit()
+        user_id, ev_id = user.id, ev.id
+    finally:
+        db.close()
+
+    _freeze_now(monkeypatch, now)
+
+    from app.core import push as push_module
+    from app.core import scheduler as scheduler_module
+
+    call_count = {"n": 0}
+
+    def fake_push_fail(db, uid, title, body, url=None):
+        call_count["n"] += 1
+        return push_module.PushResult(
+            attempted=1, succeeded=0, failed=1, removed=0, errors=["boom"]
+        )
+
+    def fake_push_ok(db, uid, title, body, url=None):
+        call_count["n"] += 1
+        return push_module.PushResult(attempted=1, succeeded=1)
+
+    # First run: push fails for every endpoint.
+    monkeypatch.setattr(scheduler_module, "send_push_for_user", fake_push_fail)
+    scheduler_module._check_notifications()
+
+    db = TestSession()
+    try:
+        notifs = db.query(Notification).filter(Notification.user_id == user_id).all()
+        logs = db.query(NotificationSentLog).filter(NotificationSentLog.user_id == user_id).all()
+        assert len(notifs) == 1
+        assert len(logs) == 1
+        log = logs[0]
+        assert log.status == "failed"
+        assert log.delivery_attempts == 1
+        assert log.last_error and "boom" in log.last_error
+        assert log.delivered_at is None
+        assert log.trigger_key.startswith(f"event:{ev_id}:")
+    finally:
+        db.close()
+
+    # Second run: push succeeds. Notification count must remain 1, log
+    # must be reused and flipped to delivered.
+    monkeypatch.setattr(scheduler_module, "send_push_for_user", fake_push_ok)
+    scheduler_module._check_notifications()
+
+    db = TestSession()
+    try:
+        notifs = db.query(Notification).filter(Notification.user_id == user_id).all()
+        logs = db.query(NotificationSentLog).filter(NotificationSentLog.user_id == user_id).all()
+        assert len(notifs) == 1, "retry must not create a second in-app Notification"
+        assert len(logs) == 1
+        log = logs[0]
+        assert log.status == "delivered"
+        assert log.delivery_attempts == 2
+        assert log.delivered_at is not None
+    finally:
+        db.close()
+
+    # Third run after delivery: must be a no-op (no more push calls).
+    third_baseline = call_count["n"]
+    scheduler_module._check_notifications()
+    assert call_count["n"] == third_baseline, "delivered logs must not retry push"
+
+
+def test_recurring_event_occurrence_creates_one_reminder(monkeypatch):
+    """Recurring events are virtual occurrences, but each occurrence still
+    needs a deterministic reminder key and idempotent delivery."""
+    db = TestSession()
+    try:
+        user, fam = _seed_user(db, "recur@example.com")
+        _set_pref(db, user.id, push_enabled=False)
+        now = datetime(2026, 4, 25, 12, 0, 0)
+        ev = CalendarEvent(
+            family_id=fam.id,
+            title="Daily meds",
+            starts_at=now - timedelta(days=3) + timedelta(minutes=20),
+            all_day=False,
+            recurrence="daily",
+        )
+        db.add(ev)
+        db.commit()
+        user_id, ev_id = user.id, ev.id
+        expected_occurrence = now + timedelta(minutes=20)
+    finally:
+        db.close()
+
+    _freeze_now(monkeypatch, now)
+    from app.core.scheduler import _check_notifications, _event_trigger_key
+
+    _check_notifications()
+    _check_notifications()
+
+    db = TestSession()
+    try:
+        notifs = db.query(Notification).filter(Notification.user_id == user_id).all()
+        logs = db.query(NotificationSentLog).filter(NotificationSentLog.user_id == user_id).all()
+        assert len(notifs) == 1
+        assert len(logs) == 1
+        assert logs[0].trigger_key == _event_trigger_key(ev_id, expected_occurrence)
+        assert logs[0].status == "delivered"
+    finally:
+        db.close()
+
+
+def test_removed_only_push_result_is_not_retried(monkeypatch):
+    db = TestSession()
+    try:
+        user, fam = _seed_user(db, "gone-retry@example.com")
+        _set_pref(db, user.id, push_enabled=True)
+        now = datetime(2026, 4, 25, 12, 0, 0)
+        ev = CalendarEvent(
+            family_id=fam.id,
+            title="Gone endpoint",
+            starts_at=now + timedelta(minutes=10),
+            all_day=False,
+        )
+        db.add(ev)
+        db.commit()
+        user_id = user.id
+    finally:
+        db.close()
+
+    _freeze_now(monkeypatch, now)
+    from app.core import push as push_module
+    from app.core import scheduler as scheduler_module
+
+    calls = {"n": 0}
+
+    def fake_removed_only(db, uid, title, body, url=None):
+        calls["n"] += 1
+        return push_module.PushResult(attempted=1, succeeded=0, failed=0, removed=1)
+
+    monkeypatch.setattr(scheduler_module, "send_push_for_user", fake_removed_only)
+    scheduler_module._check_notifications()
+    scheduler_module._check_notifications()
+
+    db = TestSession()
+    try:
+        logs = db.query(NotificationSentLog).filter(NotificationSentLog.user_id == user_id).all()
+        assert len(logs) == 1
+        assert logs[0].status == "delivered"
+        assert logs[0].last_error == "push_removed_subscriptions:1"
+        assert calls["n"] == 1
+    finally:
+        db.close()
+
+
+
+def test_push_410_removes_subscription(monkeypatch):
+    """A 410 Gone response from the web-push endpoint must remove the
+    subscription and be reflected in the PushResult.removed counter."""
+    from app.core import push as push_module
+
+    db = TestSession()
+    try:
+        user, _ = _seed_user(db, "gone@example.com")
+        sub = PushSubscription(
+            user_id=user.id,
+            endpoint="https://example.invalid/sub-1",
+            p256dh="p",
+            auth="a",
+        )
+        db.add(sub)
+        db.commit()
+        user_id = user.id
+    finally:
+        db.close()
+
+    monkeypatch.setenv("VAPID_PUBLIC_KEY", "pub")
+    monkeypatch.setenv("VAPID_PRIVATE_KEY", "priv")
+    monkeypatch.setenv("VAPID_CLAIMS_EMAIL", "ops@example.com")
+
+    class _FakeResponse:
+        status_code = 410
+
+    class _FakeWebPushException(Exception):
+        def __init__(self, msg, response=None):
+            super().__init__(msg)
+            self.response = response
+
+    def _fake_webpush(*_, **__):
+        raise _FakeWebPushException("gone", response=_FakeResponse())
+
+    fake_module = type(
+        "fake_pywebpush",
+        (),
+        {"webpush": staticmethod(_fake_webpush), "WebPushException": _FakeWebPushException},
+    )
+    import sys
+
+    monkeypatch.setitem(sys.modules, "pywebpush", fake_module)
+
+    db = TestSession()
+    try:
+        result = push_module.send_push_for_user(db, user_id, "t", "b", "/x")
+        db.commit()
+    finally:
+        db.close()
+
+    assert result.attempted == 1
+    assert result.removed == 1
+    assert result.failed == 0
+    assert result.succeeded == 0
+
+    db = TestSession()
+    try:
+        remaining = db.query(PushSubscription).filter(PushSubscription.user_id == user_id).count()
+        assert remaining == 0, "410 Gone subscription should be deleted"
+    finally:
+        db.close()
+
+
+def test_birthday_uses_target_date_in_trigger_key():
+    """Birthday trigger keys must include the target date so each year's
+    occurrence is treated as a new reminder."""
+    from app.core.scheduler import _birthday_trigger_key
+
+    bd_id = 3
+    d1 = datetime(2026, 4, 26).date()
+    d2 = datetime(2027, 4, 26).date()
+    assert _birthday_trigger_key(bd_id, d1) != _birthday_trigger_key(bd_id, d2)
+    assert "birthday:3:2026-04-26" == _birthday_trigger_key(bd_id, d1)
+
+
+def test_task_due_creates_one_log_then_does_not_duplicate(monkeypatch):
+    """Overdue task reminder also obeys idempotency."""
+    db = TestSession()
+    try:
+        user, fam = _seed_user(db, "task@example.com")
+        _set_pref(db, user.id, push_enabled=False)
+        now = datetime(2026, 4, 25, 12, 0, 0)
+        task = Task(
+            family_id=fam.id,
+            title="Pay bill",
+            status="open",
+            due_date=now - timedelta(hours=2),
+        )
+        db.add(task)
+        db.commit()
+        user_id, task_id = user.id, task.id
+    finally:
+        db.close()
+
+    _freeze_now(monkeypatch, now)
+    from app.core.scheduler import _check_notifications
+
+    _check_notifications()
+    _check_notifications()
+
+    db = TestSession()
+    try:
+        logs = db.query(NotificationSentLog).filter(NotificationSentLog.user_id == user_id).all()
+        notifs = db.query(Notification).filter(Notification.user_id == user_id).all()
+        assert len(notifs) == 1
+        assert len(logs) == 1
+        assert logs[0].trigger_key.startswith(f"task:{task_id}:")
+        assert logs[0].status == "delivered"
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- makes reminder delivery idempotent with deterministic trigger keys
- records delivery and retry state for notification send logs
- handles transient push failures, removed subscriptions, and recurring event reminders more reliably

## Test plan
- `pytest tests/test_notification_reliability.py tests/test_recurrence.py -q`

Closes #169
