### PR TITLE
Add managed calendar subscription feeds

### DIFF
--- a/backend/alembic/versions/0034_add_calendar_subscriptions.py
+++ b/backend/alembic/versions/0034_add_calendar_subscriptions.py
@@ -1,0 +1,105 @@
+"""Add persistent calendar subscriptions.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-04-26
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0034"
+down_revision: Union[str, None] = "0033"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(table: str) -> bool:
+    return table in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table: str, column: str) -> bool:
+    insp = sa.inspect(op.get_bind())
+    if table not in insp.get_table_names():
+        return False
+    return column in {c["name"] for c in insp.get_columns(table)}
+
+
+def upgrade() -> None:
+    if not _has_table("calendar_subscriptions"):
+        op.create_table(
+            "calendar_subscriptions",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("family_id", sa.Integer(), nullable=False),
+            sa.Column("name", sa.String(length=200), nullable=False),
+            sa.Column("source_url", sa.String(length=500), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="active"),
+            sa.Column("last_synced_at", sa.DateTime(), nullable=True),
+            sa.Column("last_sync_status", sa.String(length=20), nullable=True),
+            sa.Column("last_sync_error", sa.String(length=300), nullable=True),
+            sa.Column("last_created", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("last_updated", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("last_skipped", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("family_id", "source_url", name="uq_calendar_subscriptions_family_url"),
+        )
+        op.create_index("ix_calendar_subscriptions_family_id", "calendar_subscriptions", ["family_id"])
+        op.create_index("ix_calendar_subscriptions_family_status", "calendar_subscriptions", ["family_id", "status"])
+
+    if not _has_table("calendar_subscription_syncs"):
+        op.create_table(
+            "calendar_subscription_syncs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("subscription_id", sa.Integer(), nullable=False),
+            sa.Column("family_id", sa.Integer(), nullable=False),
+            sa.Column("started_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("finished_at", sa.DateTime(), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False),
+            sa.Column("created", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("updated", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("skipped", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("error_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("error_summary", sa.String(length=300), nullable=True),
+            sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["subscription_id"], ["calendar_subscriptions.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_calendar_subscription_syncs_family_id", "calendar_subscription_syncs", ["family_id"])
+        op.create_index("ix_calendar_subscription_syncs_subscription_id", "calendar_subscription_syncs", ["subscription_id"])
+        op.create_index("ix_calendar_subscription_syncs_subscription_started", "calendar_subscription_syncs", ["subscription_id", "started_at"])
+
+    if not _has_column("calendar_events", "subscription_id"):
+        with op.batch_alter_table("calendar_events") as batch:
+            batch.add_column(sa.Column("subscription_id", sa.Integer(), nullable=True))
+            batch.create_foreign_key(
+                "fk_calendar_events_subscription_id",
+                "calendar_subscriptions",
+                ["subscription_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+            batch.create_index("ix_calendar_events_subscription_id", ["subscription_id"])
+
+
+def downgrade() -> None:
+    if _has_column("calendar_events", "subscription_id"):
+        with op.batch_alter_table("calendar_events") as batch:
+            batch.drop_index("ix_calendar_events_subscription_id")
+            batch.drop_constraint("fk_calendar_events_subscription_id", type_="foreignkey")
+            batch.drop_column("subscription_id")
+    if _has_table("calendar_subscription_syncs"):
+        op.drop_index("ix_calendar_subscription_syncs_subscription_started", table_name="calendar_subscription_syncs")
+        op.drop_index("ix_calendar_subscription_syncs_subscription_id", table_name="calendar_subscription_syncs")
+        op.drop_index("ix_calendar_subscription_syncs_family_id", table_name="calendar_subscription_syncs")
+        op.drop_table("calendar_subscription_syncs")
+    if _has_table("calendar_subscriptions"):
+        op.drop_index("ix_calendar_subscriptions_family_status", table_name="calendar_subscriptions")
+        op.drop_index("ix_calendar_subscriptions_family_id", table_name="calendar_subscriptions")
+        op.drop_table("calendar_subscriptions")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -35,6 +35,7 @@ class Family(Base):
 
     memberships = relationship("Membership", back_populates="family", cascade="all, delete-orphan")
     calendar_events = relationship("CalendarEvent", back_populates="family", cascade="all, delete-orphan")
+    calendar_subscriptions = relationship("CalendarSubscription", back_populates="family", cascade="all, delete-orphan")
     birthdays = relationship("FamilyBirthday", back_populates="family", cascade="all, delete-orphan")
     tasks = relationship("Task", back_populates="family", cascade="all, delete-orphan")
     shopping_lists = relationship("ShoppingList", back_populates="family", cascade="all, delete-orphan")
@@ -110,6 +111,7 @@ class CalendarEvent(Base):
     imported_at = Column(DateTime, nullable=True)
     last_synced_at = Column(DateTime, nullable=True)
     sync_status = Column(String(20), nullable=True)
+    subscription_id = Column(Integer, ForeignKey("calendar_subscriptions.id", ondelete="SET NULL"), nullable=True, index=True)
 
     __table_args__ = (
         UniqueConstraint("family_id", "ical_uid", name="uq_calendar_events_family_uid"),
@@ -117,6 +119,53 @@ class CalendarEvent(Base):
     )
 
     family = relationship("Family", back_populates="calendar_events")
+    subscription = relationship("CalendarSubscription", back_populates="events")
+
+
+class CalendarSubscription(Base):
+    __tablename__ = "calendar_subscriptions"
+    __table_args__ = (
+        UniqueConstraint("family_id", "source_url", name="uq_calendar_subscriptions_family_url"),
+        Index("ix_calendar_subscriptions_family_status", "family_id", "status"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String(200), nullable=False)
+    source_url = Column(String(500), nullable=False)
+    status = Column(String(20), nullable=False, default="active", server_default="active")
+    last_synced_at = Column(DateTime, nullable=True)
+    last_sync_status = Column(String(20), nullable=True)
+    last_sync_error = Column(String(300), nullable=True)
+    last_created = Column(Integer, nullable=False, default=0, server_default="0")
+    last_updated = Column(Integer, nullable=False, default=0, server_default="0")
+    last_skipped = Column(Integer, nullable=False, default=0, server_default="0")
+    created_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow, server_default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=utcnow, onupdate=utcnow, server_default=func.now())
+
+    family = relationship("Family", back_populates="calendar_subscriptions")
+    events = relationship("CalendarEvent", back_populates="subscription")
+    syncs = relationship("CalendarSubscriptionSync", back_populates="subscription", cascade="all, delete-orphan", order_by="CalendarSubscriptionSync.started_at.desc()")
+
+
+class CalendarSubscriptionSync(Base):
+    __tablename__ = "calendar_subscription_syncs"
+    __table_args__ = (Index("ix_calendar_subscription_syncs_subscription_started", "subscription_id", "started_at"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    subscription_id = Column(Integer, ForeignKey("calendar_subscriptions.id", ondelete="CASCADE"), nullable=False, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    started_at = Column(DateTime, nullable=False, default=utcnow, server_default=func.now())
+    finished_at = Column(DateTime, nullable=True)
+    status = Column(String(20), nullable=False)
+    created = Column(Integer, nullable=False, default=0, server_default="0")
+    updated = Column(Integer, nullable=False, default=0, server_default="0")
+    skipped = Column(Integer, nullable=False, default=0, server_default="0")
+    error_count = Column(Integer, nullable=False, default=0, server_default="0")
+    error_summary = Column(String(300), nullable=True)
+
+    subscription = relationship("CalendarSubscription", back_populates="syncs")
 
 
 class FamilyBirthday(Base):

--- a/backend/app/modules/calendar_router.py
+++ b/backend/app/modules/calendar_router.py
@@ -6,6 +6,7 @@ from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from app.core import cache
+from app.core.clock import utcnow
 from app.core.calendar_subscriptions import (
     IcsSubscriptionError,
     fetch_ics_text,
@@ -17,8 +18,8 @@ from app.core.ics_utils import events_to_ics, ics_to_event_dicts
 from app.core.recurrence import VALID_RECURRENCES, expand_event
 from app.core.scopes import require_scope
 from app.database import get_db
-from app.models import CalendarEvent, Membership, Notification, User
-from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, CalendarEventCreate, CalendarEventResponse, CalendarEventUpdate, CalendarIcsImport, CalendarIcsSubscribe, PaginatedCalendarEvents
+from app.models import CalendarEvent, CalendarSubscription, CalendarSubscriptionSync, Membership, Notification, User
+from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, CalendarEventCreate, CalendarEventResponse, CalendarEventUpdate, CalendarIcsImport, CalendarIcsSubscribe, CalendarSubscriptionCreate, CalendarSubscriptionResponse, PaginatedCalendarEvents
 from app.core.errors import error_detail, EVENT_NOT_FOUND, END_BEFORE_START, INVALID_RECURRENCE
 
 router = APIRouter(prefix="/calendar", tags=["calendar"], responses={**AUTH_RESPONSES})
@@ -130,7 +131,140 @@ def calendar_feed_ics(
         headers={"Content-Disposition": "inline; filename=tribu-calendar.ics"},
     )
 
+def _subscription_label(source_name: str | None, source_url: str) -> str:
+    return (source_name or "").strip() or hostname_from_url(source_url) or source_url
 
+
+def _safe_subscription_error(exc: Exception) -> str:
+    if isinstance(exc, IcsSubscriptionError):
+        return str(exc)
+    return "Could not fetch subscription URL"
+
+
+def _sync_history(subscription: CalendarSubscription, limit: int = 5) -> list[CalendarSubscriptionSync]:
+    return sorted(subscription.syncs or [], key=lambda row: row.started_at, reverse=True)[:limit]
+
+
+def _subscription_response(subscription: CalendarSubscription) -> CalendarSubscriptionResponse:
+    return CalendarSubscriptionResponse(
+        id=subscription.id,
+        family_id=subscription.family_id,
+        name=subscription.name,
+        source_url=subscription.source_url,
+        status=subscription.status,
+        last_synced_at=subscription.last_synced_at,
+        last_sync_status=subscription.last_sync_status,
+        last_sync_error=subscription.last_sync_error,
+        last_created=subscription.last_created or 0,
+        last_updated=subscription.last_updated or 0,
+        last_skipped=subscription.last_skipped or 0,
+        created_by_user_id=subscription.created_by_user_id,
+        created_at=subscription.created_at,
+        updated_at=subscription.updated_at,
+        sync_history=_sync_history(subscription),
+    )
+
+
+def _refresh_calendar_subscription(
+    db: Session,
+    *,
+    subscription: CalendarSubscription,
+    user_id: int,
+) -> tuple[int, int, int, list[dict]]:
+    started_at = utcnow()
+    created = 0
+    updated = 0
+    skipped = 0
+    errors: list[dict] = []
+    status = "success"
+    error_summary = None
+
+    try:
+        ics_text = fetch_ics_text(subscription.source_url)
+        valid_events, errors = ics_to_event_dicts(
+            ics_text,
+            subscription.family_id,
+            user_id,
+            source_type="subscription",
+            source_name=subscription.name,
+            source_url=subscription.source_url,
+        )
+        MAX_EVENTS = 500
+        now = utcnow()
+        for event_dict in valid_events[:MAX_EVENTS]:
+            event_dict["subscription_id"] = subscription.id
+            event_dict["source_name"] = subscription.name
+            event_dict["source_url"] = subscription.source_url
+            event_dict["last_synced_at"] = now
+            event_dict["sync_status"] = "ok"
+            ical_uid = event_dict.get("ical_uid")
+            existing = None
+            if ical_uid:
+                existing = (
+                    db.query(CalendarEvent)
+                    .filter(
+                        CalendarEvent.family_id == subscription.family_id,
+                        CalendarEvent.ical_uid == ical_uid,
+                    )
+                    .first()
+                )
+            if existing:
+                owned_by_this_feed = (
+                    existing.source_type == "subscription"
+                    and (existing.subscription_id == subscription.id or (existing.subscription_id is None and existing.source_url == subscription.source_url))
+                )
+                if not owned_by_this_feed:
+                    skipped += 1
+                    errors.append({
+                        "index": created + updated + skipped,
+                        "summary": event_dict.get("title", ""),
+                        "error": "VEVENT UID already exists as a non-subscription or different-feed event; skipped to avoid overwriting it",
+                    })
+                    continue
+                for key, value in event_dict.items():
+                    if key in {"imported_at", "created_by_user_id"}:
+                        continue
+                    setattr(existing, key, value)
+                updated += 1
+            else:
+                db.add(CalendarEvent(**event_dict))
+                created += 1
+        if len(valid_events) > MAX_EVENTS:
+            skipped += len(valid_events) - MAX_EVENTS
+            errors.append({"index": MAX_EVENTS, "summary": "", "error": f"Only the first {MAX_EVENTS} events were processed"})
+        if errors:
+            status = "partial" if created or updated else "failed"
+            error_summary = errors[0].get("error")
+    except Exception as exc:
+        status = "failed"
+        error_summary = _safe_subscription_error(exc)
+        errors = [{"index": 0, "summary": "", "error": error_summary}]
+
+    finished_at = utcnow()
+    subscription.last_synced_at = finished_at
+    subscription.last_sync_status = status
+    subscription.last_sync_error = error_summary
+    subscription.last_created = created
+    subscription.last_updated = updated
+    subscription.last_skipped = skipped
+    subscription.updated_at = finished_at
+    db.add(CalendarSubscriptionSync(
+        subscription_id=subscription.id,
+        family_id=subscription.family_id,
+        started_at=started_at,
+        finished_at=finished_at,
+        status=status,
+        created=created,
+        updated=updated,
+        skipped=skipped,
+        error_count=len(errors),
+        error_summary=error_summary,
+    ))
+    db.commit()
+    db.refresh(subscription)
+    if created or updated:
+        cache.invalidate_pattern(f"tribu:dashboard:{subscription.family_id}:*")
+    return created, updated, skipped, errors
 
 
 def _classify_ics_preview(
@@ -447,6 +581,116 @@ def subscribe_calendar_ics(
     if created or updated:
         cache.invalidate_pattern(f"tribu:dashboard:{payload.family_id}:*")
     return {"status": "ok", "created": created, "updated": updated, "skipped": skipped, "errors": errors}
+
+
+@router.get(
+    "/subscriptions",
+    response_model=list[CalendarSubscriptionResponse],
+    summary="List managed calendar subscriptions",
+    description="Return stored external ICS feeds and recent refresh history. Adult only. Scope: `calendar:read`.",
+)
+def list_calendar_subscriptions(
+    family_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("calendar:read"),
+):
+    ensure_adult(db, user.id, family_id)
+    subscriptions = (
+        db.query(CalendarSubscription)
+        .filter(CalendarSubscription.family_id == family_id)
+        .order_by(CalendarSubscription.created_at.desc())
+        .all()
+    )
+    return [_subscription_response(subscription) for subscription in subscriptions]
+
+
+@router.post(
+    "/subscriptions",
+    response_model=CalendarSubscriptionResponse,
+    summary="Create or refresh a managed calendar subscription",
+    description="Store an external ICS feed and refresh it immediately. Adult only. Scope: `calendar:write`.",
+)
+def create_calendar_subscription(
+    payload: CalendarSubscriptionCreate,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("calendar:write"),
+):
+    ensure_adult(db, user.id, payload.family_id)
+    try:
+        normalized_url = validate_subscription_url(payload.source_url)
+    except IcsSubscriptionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    subscription = (
+        db.query(CalendarSubscription)
+        .filter(
+            CalendarSubscription.family_id == payload.family_id,
+            CalendarSubscription.source_url == normalized_url,
+        )
+        .first()
+    )
+    if subscription:
+        subscription.name = _subscription_label(payload.source_name or subscription.name, normalized_url)
+        subscription.status = "active"
+        subscription.updated_at = utcnow()
+    else:
+        subscription = CalendarSubscription(
+            family_id=payload.family_id,
+            name=_subscription_label(payload.source_name, normalized_url),
+            source_url=normalized_url,
+            status="active",
+            created_by_user_id=user.id,
+        )
+        db.add(subscription)
+    db.flush()
+    _refresh_calendar_subscription(db, subscription=subscription, user_id=user.id)
+    return _subscription_response(subscription)
+
+
+@router.post(
+    "/subscriptions/{subscription_id}/refresh",
+    response_model=CalendarSubscriptionResponse,
+    summary="Refresh a managed calendar subscription",
+    description="Fetch a stored external ICS feed now and update its owned events. Adult only. Scope: `calendar:write`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def refresh_calendar_subscription(
+    subscription_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("calendar:write"),
+):
+    subscription = db.query(CalendarSubscription).filter(CalendarSubscription.id == subscription_id).first()
+    if not subscription:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    ensure_adult(db, user.id, subscription.family_id)
+    _refresh_calendar_subscription(db, subscription=subscription, user_id=user.id)
+    return _subscription_response(subscription)
+
+
+@router.delete(
+    "/subscriptions/{subscription_id}",
+    summary="Delete a managed calendar subscription",
+    description="Remove the stored feed record. Imported events remain in the calendar with their source metadata. Adult only. Scope: `calendar:write`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def delete_calendar_subscription(
+    subscription_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("calendar:write"),
+):
+    subscription = db.query(CalendarSubscription).filter(CalendarSubscription.id == subscription_id).first()
+    if not subscription:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    ensure_adult(db, user.id, subscription.family_id)
+    family_id = subscription.family_id
+    db.query(CalendarEvent).filter(CalendarEvent.subscription_id == subscription.id).update({CalendarEvent.subscription_id: None})
+    db.delete(subscription)
+    db.commit()
+    return {"status": "deleted", "subscription_id": subscription_id, "family_id": family_id}
 
 
 @router.post(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -458,6 +458,51 @@ class CalendarIcsSubscribe(BaseModel):
     )
 
 
+class CalendarSubscriptionCreate(BaseModel):
+    """Create or refresh a managed external ICS subscription feed."""
+    family_id: int = Field(..., description="Target family ID")
+    source_url: str = Field(..., max_length=500, description="External http(s) URL of the ICS feed")
+    source_name: Optional[str] = Field(None, max_length=200, description="Optional human-readable feed label")
+
+
+class CalendarSubscriptionSyncResponse(BaseModel):
+    """One refresh attempt for a managed calendar subscription."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    subscription_id: int
+    family_id: int
+    started_at: datetime
+    finished_at: Optional[datetime] = None
+    status: str
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+    error_count: int = 0
+    error_summary: Optional[str] = None
+
+
+class CalendarSubscriptionResponse(BaseModel):
+    """Managed external ICS subscription feed with latest sync status."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    family_id: int
+    name: str
+    source_url: str
+    status: str
+    last_synced_at: Optional[datetime] = None
+    last_sync_status: Optional[str] = None
+    last_sync_error: Optional[str] = None
+    last_created: int = 0
+    last_updated: int = 0
+    last_skipped: int = 0
+    created_by_user_id: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+    sync_history: list[CalendarSubscriptionSyncResponse] = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Tasks
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_calendar_subscriptions.py
+++ b/backend/tests/test_calendar_subscriptions.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import sessionmaker
 
 from app.database import Base, get_db
 from app.main import app
-from app.models import CalendarEvent, Family, Membership, PersonalAccessToken, User
+from app.models import CalendarEvent, CalendarSubscription, CalendarSubscriptionSync, Family, Membership, PersonalAccessToken, User
 from app.security import hash_password, PAT_PREFIX
 from app.core.calendar_subscriptions import IcsSubscriptionError, fetch_ics_text
 
@@ -452,3 +452,97 @@ class TestFetchFailureSafe:
         text = resp.text
         assert "10.0.0.5" not in text
         assert "Traceback" not in text
+
+
+
+class TestManagedSubscriptions:
+    def test_create_persists_feed_status_and_sync_history(self, monkeypatch):
+        token, family_id = _seed_adult()
+        _patch_fetch(monkeypatch, lambda url, **kw: _ics("managed-1@feed.example.com", summary="Practice"))
+
+        client = TestClient(app)
+        resp = client.post(
+            "/calendar/subscriptions",
+            json={
+                "family_id": family_id,
+                "source_url": "https://feed.example.com/team.ics",
+                "source_name": "Team",
+            },
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["name"] == "Team"
+        assert body["source_url"] == "https://feed.example.com/team.ics"
+        assert body["last_sync_status"] == "success"
+        assert body["last_created"] == 1
+        assert body["last_updated"] == 0
+        assert body["last_skipped"] == 0
+        assert body["sync_history"][0]["status"] == "success"
+
+        db = TestSession()
+        try:
+            subscription = db.query(CalendarSubscription).one()
+            assert subscription.name == "Team"
+            event = db.query(CalendarEvent).filter(CalendarEvent.ical_uid == "managed-1@feed.example.com").one()
+            assert event.subscription_id == subscription.id
+            assert event.source_type == "subscription"
+            assert db.query(CalendarSubscriptionSync).count() == 1
+        finally:
+            db.close()
+
+    def test_list_refresh_and_delete_managed_subscription(self, monkeypatch):
+        token, family_id = _seed_adult()
+        url = "https://feed.example.com/team.ics"
+        client = TestClient(app)
+
+        _patch_fetch(monkeypatch, lambda u, **kw: _ics("managed-refresh@feed.example.com", summary="Practice"))
+        first = client.post(
+            "/calendar/subscriptions",
+            json={"family_id": family_id, "source_url": url, "source_name": "Team"},
+            headers=_auth(token),
+        )
+        assert first.status_code == 200, first.text
+        subscription_id = first.json()["id"]
+
+        listed = client.get(f"/calendar/subscriptions?family_id={family_id}", headers=_auth(token))
+        assert listed.status_code == 200, listed.text
+        assert listed.json()[0]["id"] == subscription_id
+
+        _patch_fetch(monkeypatch, lambda u, **kw: _ics("managed-refresh@feed.example.com", summary="Practice updated"))
+        refreshed = client.post(f"/calendar/subscriptions/{subscription_id}/refresh", headers=_auth(token))
+        assert refreshed.status_code == 200, refreshed.text
+        assert refreshed.json()["last_updated"] == 1
+
+        deleted = client.delete(f"/calendar/subscriptions/{subscription_id}", headers=_auth(token))
+        assert deleted.status_code == 200, deleted.text
+
+        db = TestSession()
+        try:
+            assert db.query(CalendarSubscription).count() == 0
+            event = db.query(CalendarEvent).filter(CalendarEvent.ical_uid == "managed-refresh@feed.example.com").one()
+            assert event.title == "Practice updated"
+            assert event.subscription_id is None
+            assert event.source_type == "subscription"
+        finally:
+            db.close()
+
+    def test_managed_refresh_failure_records_safe_status(self, monkeypatch):
+        token, family_id = _seed_adult()
+
+        def _boom(url, **kw):
+            raise RuntimeError("internal host 10.1.2.3 failed")
+
+        _patch_fetch(monkeypatch, _boom)
+        client = TestClient(app)
+        resp = client.post(
+            "/calendar/subscriptions",
+            json={"family_id": family_id, "source_url": "https://feed.example.com/bad.ics"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["last_sync_status"] == "failed"
+        assert body["last_sync_error"] == "Could not fetch subscription URL"
+        assert "10.1.2.3" not in resp.text
+        assert body["sync_history"][0]["status"] == "failed"

--- a/frontend/__tests__/components/DataTab.test.js
+++ b/frontend/__tests__/components/DataTab.test.js
@@ -26,6 +26,10 @@ jest.mock('../../lib/api', () => ({
   apiPreviewImportCalendarIcs: jest.fn(),
   apiSubscribeCalendarIcs: jest.fn(),
   apiPreviewSubscribeCalendarIcs: jest.fn(),
+  apiGetCalendarSubscriptions: jest.fn(),
+  apiCreateCalendarSubscription: jest.fn(),
+  apiRefreshCalendarSubscription: jest.fn(),
+  apiDeleteCalendarSubscription: jest.fn(),
   apiExportContactsCsv: jest.fn(),
   apiImportContactsCsv: jest.fn(),
 }));
@@ -44,12 +48,13 @@ describe('DataTab calendar subscriptions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAppState = baseState();
+    api.apiGetCalendarSubscriptions.mockResolvedValue({ ok: true, data: [] });
   });
 
   test('subscribes to an external ICS URL and renders the refresh summary', async () => {
-    api.apiSubscribeCalendarIcs.mockResolvedValue({
+    api.apiCreateCalendarSubscription.mockResolvedValue({
       ok: true,
-      data: { created: 1, updated: 2, skipped: 0, errors: [] },
+      data: { id: 7, name: 'School', last_created: 1, last_updated: 2, last_skipped: 0, sync_history: [] },
     });
 
     render(<DataTab />);
@@ -60,10 +65,10 @@ describe('DataTab calendar subscriptions', () => {
     fireEvent.change(screen.getByPlaceholderText('Feed name (optional)'), {
       target: { value: 'School' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Subscribe / refresh feed' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save and refresh feed' }));
 
     await waitFor(() => {
-      expect(api.apiSubscribeCalendarIcs).toHaveBeenCalledWith(
+      expect(api.apiCreateCalendarSubscription).toHaveBeenCalledWith(
         42,
         'https://school.example.com/calendar.ics',
         'School',
@@ -72,6 +77,37 @@ describe('DataTab calendar subscriptions', () => {
     expect(await screen.findByText('Created 1, updated 2, skipped 0.')).toBeInTheDocument();
     expect(mockAppState.loadDashboard).toHaveBeenCalled();
   });
+
+  test('renders managed feeds and refreshes one', async () => {
+    api.apiGetCalendarSubscriptions.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 7,
+        name: 'School',
+        source_url: 'https://school.example.com/calendar.ics',
+        last_sync_status: 'success',
+        last_created: 1,
+        last_updated: 0,
+        last_skipped: 0,
+        sync_history: [{ id: 1, status: 'success', created: 1, updated: 0, skipped: 0 }],
+      }],
+    });
+    api.apiRefreshCalendarSubscription.mockResolvedValue({
+      ok: true,
+      data: { id: 7, name: 'School', last_created: 0, last_updated: 1, last_skipped: 0, sync_history: [] },
+    });
+
+    render(<DataTab />);
+
+    expect(await screen.findByText('School')).toBeInTheDocument();
+    expect(screen.getByText('https://school.example.com/calendar.ics')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+
+    await waitFor(() => {
+      expect(api.apiRefreshCalendarSubscription).toHaveBeenCalledWith(7);
+    });
+    expect(await screen.findByText('Created 0, updated 1, skipped 0.')).toBeInTheDocument();
+  });
 });
 
 
@@ -79,6 +115,7 @@ describe('DataTab calendar import previews', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAppState = baseState();
+    api.apiGetCalendarSubscriptions.mockResolvedValue({ ok: true, data: [] });
   });
 
   test('previews pasted ICS without importing it', async () => {
@@ -126,7 +163,7 @@ describe('DataTab calendar import previews', () => {
         'School',
       );
     });
-    expect(api.apiSubscribeCalendarIcs).not.toHaveBeenCalled();
+    expect(api.apiCreateCalendarSubscription).not.toHaveBeenCalled();
     expect(await screen.findByText('Preview: would create 3, update 0, skip 1. No calendar changes yet.')).toBeInTheDocument();
     expect(await screen.findByText(/Dup/)).toBeInTheDocument();
   });

--- a/frontend/components/settings/DataTab.js
+++ b/frontend/components/settings/DataTab.js
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Database, Rss, Download, Upload, ChevronUp, ChevronDown, Plus, Copy, Check } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Database, Rss, Download, Upload, ChevronUp, ChevronDown, Plus, Copy, Check, RefreshCw, Trash2 } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
 import { copyTextToClipboard, downloadBlob } from '../../lib/helpers';
@@ -19,6 +19,9 @@ export default function DataTab() {
   const [icsSubName, setIcsSubName] = useState('');
   const [icsSubMsg, setIcsSubMsg] = useState('');
   const [icsSubErrors, setIcsSubErrors] = useState([]);
+  const [calendarSubscriptions, setCalendarSubscriptions] = useState([]);
+  const [subscriptionBusyId, setSubscriptionBusyId] = useState(null);
+  const [subscriptionsLoading, setSubscriptionsLoading] = useState(false);
   const [showContactsImport, setShowContactsImport] = useState(false);
   const [csvText, setCsvText] = useState('');
   const [contactsMsg, setContactsMsg] = useState('');
@@ -33,6 +36,36 @@ export default function DataTab() {
 
   const subCalendarUrl = subToken ? `${window.location.origin}/api/calendar/events/feed.ics?family_id=${familyId}&token=${subToken}` : '';
   const subContactsUrl = subToken ? `${window.location.origin}/api/contacts/feed.vcf?family_id=${familyId}&token=${subToken}` : '';
+
+
+  function formatSubscriptionCounts(subscription) {
+    const template = t(messages, 'module.calendar.subscription_last_counts') || 'Created {created}, updated {updated}, skipped {skipped}';
+    return template
+      .replace('{created}', subscription?.last_created ?? 0)
+      .replace('{updated}', subscription?.last_updated ?? 0)
+      .replace('{skipped}', subscription?.last_skipped ?? 0);
+  }
+
+  function subscriptionStatusLabel(subscription) {
+    const status = subscription?.last_sync_status || 'pending';
+    return t(messages, `module.calendar.subscription_status_${status}`) || status;
+  }
+
+  async function loadCalendarSubscriptions() {
+    if (!familyId) return;
+    setSubscriptionsLoading(true);
+    const res = await api.apiGetCalendarSubscriptions(Number(familyId));
+    setSubscriptionsLoading(false);
+    if (res.ok) {
+      setCalendarSubscriptions(res.data || []);
+    } else {
+      setIcsSubMsg(t(messages, 'module.calendar.subscription_loaded_error') || 'Could not load saved feeds');
+    }
+  }
+
+  useEffect(() => {
+    loadCalendarSubscriptions();
+  }, [familyId]);
 
   async function handleCreateSubToken() {
     setSubCreating(true);
@@ -115,18 +148,53 @@ export default function DataTab() {
     e.preventDefault();
     setIcsSubMsg('');
     setIcsSubErrors([]);
-    const { ok, data } = await api.apiSubscribeCalendarIcs(Number(familyId), icsSubUrl, icsSubName);
+    const { ok, data } = await api.apiCreateCalendarSubscription(Number(familyId), icsSubUrl, icsSubName);
     if (!ok) {
       const detail = data?.detail ? `: ${data.detail}` : '';
       return setIcsSubMsg(`${t(messages, 'module.calendar.subscription_error') || 'Subscription failed'}${detail}`);
     }
     const template = t(messages, 'module.calendar.subscription_success') || 'Created {created}, updated {updated}, skipped {skipped}.';
     setIcsSubMsg(template
-      .replace('{created}', data.created ?? 0)
-      .replace('{updated}', data.updated ?? 0)
-      .replace('{skipped}', data.skipped ?? 0));
-    if (data.errors?.length) setIcsSubErrors(data.errors);
-    await loadDashboard();
+      .replace('{created}', data.last_created ?? 0)
+      .replace('{updated}', data.last_updated ?? 0)
+      .replace('{skipped}', data.last_skipped ?? 0));
+    const latestErrors = data.sync_history?.[0]?.error_summary ? [{ index: 0, summary: data.name, error: data.sync_history[0].error_summary }] : [];
+    if (latestErrors.length) setIcsSubErrors(latestErrors);
+    setIcsSubUrl('');
+    setIcsSubName('');
+    await Promise.all([loadCalendarSubscriptions(), loadDashboard()]);
+  }
+
+  async function handleRefreshManagedSubscription(subscriptionId) {
+    setSubscriptionBusyId(subscriptionId);
+    setIcsSubMsg('');
+    setIcsSubErrors([]);
+    const { ok, data } = await api.apiRefreshCalendarSubscription(subscriptionId);
+    setSubscriptionBusyId(null);
+    if (!ok) {
+      const detail = data?.detail ? `: ${data.detail}` : '';
+      return setIcsSubMsg(`${t(messages, 'module.calendar.subscription_error') || 'Subscription failed'}${detail}`);
+    }
+    const template = t(messages, 'module.calendar.subscription_success') || 'Created {created}, updated {updated}, skipped {skipped}.';
+    setIcsSubMsg(template
+      .replace('{created}', data.last_created ?? 0)
+      .replace('{updated}', data.last_updated ?? 0)
+      .replace('{skipped}', data.last_skipped ?? 0));
+    const latestErrors = data.sync_history?.[0]?.error_summary ? [{ index: 0, summary: data.name, error: data.sync_history[0].error_summary }] : [];
+    if (latestErrors.length) setIcsSubErrors(latestErrors);
+    await Promise.all([loadCalendarSubscriptions(), loadDashboard()]);
+  }
+
+  async function handleDeleteManagedSubscription(subscriptionId) {
+    setSubscriptionBusyId(subscriptionId);
+    const { ok, data } = await api.apiDeleteCalendarSubscription(subscriptionId);
+    setSubscriptionBusyId(null);
+    if (!ok) {
+      const detail = data?.detail ? `: ${data.detail}` : '';
+      return setIcsSubMsg(`${t(messages, 'module.calendar.subscription_error') || 'Subscription failed'}${detail}`);
+    }
+    setIcsSubMsg(t(messages, 'module.calendar.subscription_deleted') || 'Feed removed. Existing events stay in the calendar.');
+    await loadCalendarSubscriptions();
   }
 
   function handleIcsFile(e) {
@@ -205,7 +273,7 @@ export default function DataTab() {
                   {t(messages, 'module.calendar.preview_subscription_submit')}
                 </button>
                 <button className="btn-primary" type="submit" disabled={!icsSubUrl.trim()}>
-                  {t(messages, 'module.calendar.subscription_submit')}
+                  {t(messages, 'module.calendar.subscription_create_submit') || t(messages, 'module.calendar.subscription_submit')}
                 </button>
               </div>
             </form>
@@ -224,6 +292,43 @@ export default function DataTab() {
                 </ul>
               </div>
             )}
+            <div className="settings-subsection">
+              <div className="set-data-sub-heading">{t(messages, 'module.calendar.managed_subscriptions')}</div>
+              {subscriptionsLoading && <p className="set-data-muted-info">...</p>}
+              {!subscriptionsLoading && calendarSubscriptions.length === 0 && (
+                <p className="set-data-muted-info">{t(messages, 'module.calendar.managed_subscriptions_empty')}</p>
+              )}
+              {calendarSubscriptions.map((subscription) => (
+                <div key={subscription.id} className="set-data-block">
+                  <div className="set-data-flex-row">
+                    <div className="set-data-flex-grow">
+                      <strong>{subscription.name}</strong>
+                      <div><code>{subscription.source_url}</code></div>
+                      <p className="set-data-muted-info">
+                        {subscriptionStatusLabel(subscription)} · {formatSubscriptionCounts(subscription)}
+                        {subscription.last_sync_error ? ` · ${subscription.last_sync_error}` : ''}
+                      </p>
+                      {subscription.sync_history?.length > 0 && (
+                        <details>
+                          <summary>{t(messages, 'module.calendar.subscription_history')}</summary>
+                          <ul className="set-data-warning-list">
+                            {subscription.sync_history.map((sync) => (
+                              <li key={sync.id}>{sync.status}: {sync.created}/{sync.updated}/{sync.skipped}{sync.error_summary ? ` · ${sync.error_summary}` : ''}</li>
+                            ))}
+                          </ul>
+                        </details>
+                      )}
+                    </div>
+                    <button className="btn-ghost set-data-no-shrink" type="button" disabled={subscriptionBusyId === subscription.id} onClick={() => handleRefreshManagedSubscription(subscription.id)}>
+                      <RefreshCw size={14} /> {t(messages, 'module.calendar.subscription_refresh')}
+                    </button>
+                    <button className="btn-ghost set-data-no-shrink" type="button" disabled={subscriptionBusyId === subscription.id} onClick={() => handleDeleteManagedSubscription(subscription.id)}>
+                      <Trash2 size={14} /> {t(messages, 'module.calendar.subscription_delete')}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
           {showCalImport && (
             <div className="settings-subsection">

--- a/frontend/i18n/modules/calendar/de.json
+++ b/frontend/i18n/modules/calendar/de.json
@@ -57,5 +57,18 @@
   "module.calendar.edit_recurring_warning": "Die Bearbeitung ändert die gesamte Terminserie.",
   "module.calendar.source_import": "Importiert",
   "module.calendar.source_subscription": "Abonniert",
-  "module.calendar.source_readonly_hint": "Stammt aus einem externen Feed. Änderungen bitte in der Quell-App vornehmen – ein erneuter Import aktualisiert diesen Eintrag."
+  "module.calendar.source_readonly_hint": "Stammt aus einem externen Feed. Änderungen bitte in der Quell-App vornehmen – ein erneuter Import aktualisiert diesen Eintrag.",
+  "module.calendar.managed_subscriptions": "Gespeicherte Feeds",
+  "module.calendar.managed_subscriptions_empty": "Noch keine gespeicherten Feeds. Füge oben einen hinzu, um Status und Verlauf zu behalten.",
+  "module.calendar.subscription_create_submit": "Feed speichern und aktualisieren",
+  "module.calendar.subscription_refresh": "Aktualisieren",
+  "module.calendar.subscription_delete": "Löschen",
+  "module.calendar.subscription_status_success": "Letzte Aktualisierung erfolgreich",
+  "module.calendar.subscription_status_partial": "Letzte Aktualisierung mit Hinweisen",
+  "module.calendar.subscription_status_failed": "Letzte Aktualisierung fehlgeschlagen",
+  "module.calendar.subscription_status_pending": "Noch nicht aktualisiert",
+  "module.calendar.subscription_last_counts": "Erstellt {created}, aktualisiert {updated}, übersprungen {skipped}",
+  "module.calendar.subscription_history": "Letzte Aktualisierungen",
+  "module.calendar.subscription_loaded_error": "Gespeicherte Feeds konnten nicht geladen werden",
+  "module.calendar.subscription_deleted": "Feed entfernt. Bestehende Termine bleiben im Kalender."
 }

--- a/frontend/i18n/modules/calendar/en.json
+++ b/frontend/i18n/modules/calendar/en.json
@@ -57,5 +57,18 @@
   "module.calendar.edit_recurring_warning": "Editing this event changes the whole recurring series.",
   "module.calendar.source_import": "Imported",
   "module.calendar.source_subscription": "Subscribed",
-  "module.calendar.source_readonly_hint": "From an external feed. Edit it in the source app — re-importing will update this entry."
+  "module.calendar.source_readonly_hint": "From an external feed. Edit it in the source app — re-importing will update this entry.",
+  "module.calendar.managed_subscriptions": "Managed feeds",
+  "module.calendar.managed_subscriptions_empty": "No saved feeds yet. Add one above to keep its status and refresh history.",
+  "module.calendar.subscription_create_submit": "Save and refresh feed",
+  "module.calendar.subscription_refresh": "Refresh",
+  "module.calendar.subscription_delete": "Delete",
+  "module.calendar.subscription_status_success": "Last refresh succeeded",
+  "module.calendar.subscription_status_partial": "Last refresh had warnings",
+  "module.calendar.subscription_status_failed": "Last refresh failed",
+  "module.calendar.subscription_status_pending": "Not refreshed yet",
+  "module.calendar.subscription_last_counts": "Created {created}, updated {updated}, skipped {skipped}",
+  "module.calendar.subscription_history": "Recent refreshes",
+  "module.calendar.subscription_loaded_error": "Could not load saved feeds",
+  "module.calendar.subscription_deleted": "Feed removed. Existing events stay in the calendar."
 }

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -204,6 +204,22 @@ export function apiPreviewSubscribeCalendarIcs(family_id, source_url, source_nam
   return post('/calendar/events/subscribe-ics/preview', { family_id, source_url, source_name });
 }
 
+export function apiGetCalendarSubscriptions(family_id) {
+  return request(`/calendar/subscriptions?family_id=${family_id}`);
+}
+
+export function apiCreateCalendarSubscription(family_id, source_url, source_name = '') {
+  return post('/calendar/subscriptions', { family_id, source_url, source_name });
+}
+
+export function apiRefreshCalendarSubscription(subscriptionId) {
+  return post(`/calendar/subscriptions/${subscriptionId}/refresh`, {});
+}
+
+export function apiDeleteCalendarSubscription(subscriptionId) {
+  return del(`/calendar/subscriptions/${subscriptionId}`);
+}
+
 // Tasks
 export async function apiGetTasks(familyId) {
   const res = await request(`/tasks?family_id=${familyId}`);


### PR DESCRIPTION
## Summary
- add managed external ICS subscription feeds with persisted refresh status and recent sync history
- store feed ownership on subscription-imported events so manual refreshes only update rows owned by the same feed
- surface saved feeds in Settings with refresh/delete controls and bilingual copy

## Validation
- `cd backend && DATABASE_URL=sqlite:///./test.db JWT_SECRET='[REDACTED]' pytest -q` → 351 passed
- `cd frontend && npm test -- --runInBand` → 173 passed
- `cd frontend && npm run build` → passed
- `cd frontend && BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/tests/settings.spec.js` → 4 passed

Refs #170
