### PR TITLE
feat: polish shared home display dashboard

### DIFF
--- a/frontend/__tests__/components/DisplayDashboard.test.js
+++ b/frontend/__tests__/components/DisplayDashboard.test.js
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for the redesigned shared-home display ("The Hearth").
+ *
+ * The component is fed only the privacy-safe payload the
+ * /display/dashboard endpoint produces. These tests assert:
+ *   - Hero clock + family hearth name render with glanceable test ids.
+ *   - Today / Tomorrow grouping of the agenda.
+ *   - Live event detection ("Happening now") via a mock current time.
+ *   - Celebration card hides when no birthdays are due.
+ *   - Empty agenda yields the friendly "hearth is quiet" copy.
+ *   - No emails, user IDs, or admin/personal controls leak into the DOM.
+ */
+
+import { act, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import DisplayDashboard from '../../components/DisplayDashboard';
+
+const ME = { name: 'Kitchen Tablet' };
+
+function buildDashboard(overrides = {}) {
+  return {
+    family_id: 7,
+    family_name: 'Mueller',
+    device_name: 'Kitchen Tablet',
+    members: [
+      { display_name: 'Anna', color: '#7c3aed' },
+      { display_name: 'Mia', color: null },
+      { display_name: 'Grandma Ilse', color: '#f43f5e' },
+    ],
+    next_events: [],
+    upcoming_birthdays: [],
+    ...overrides,
+  };
+}
+
+function isoLocal(d) {
+  // toISOString uses UTC. Build a "naive" local-ISO string the
+  // backend would emit (no trailing Z) so parseLooseDate sees local.
+  const pad = (n) => String(n).padStart(2, '0');
+  return (
+    d.getFullYear() +
+    '-' +
+    pad(d.getMonth() + 1) +
+    '-' +
+    pad(d.getDate()) +
+    'T' +
+    pad(d.getHours()) +
+    ':' +
+    pad(d.getMinutes()) +
+    ':00'
+  );
+}
+
+function renderWithFixedNow(dashboard, fixedNow) {
+  jest.useFakeTimers();
+  jest.setSystemTime(fixedNow);
+  let utils;
+  act(() => {
+    utils = render(<DisplayDashboard me={ME} dashboard={dashboard} />);
+  });
+  return utils;
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('DisplayDashboard — identity + clock', () => {
+  test('renders the family hearth name and device tag', () => {
+    renderWithFixedNow(buildDashboard(), new Date('2026-04-27T08:30:00'));
+
+    expect(screen.getByTestId('display-family-name')).toHaveTextContent(
+      'Mueller'
+    );
+    expect(screen.getByTestId('display-device-name')).toHaveTextContent(
+      'Kitchen Tablet'
+    );
+  });
+
+  test('renders a glanceable clock and date', () => {
+    renderWithFixedNow(buildDashboard(), new Date('2026-04-27T08:30:00'));
+
+    const clock = screen.getByTestId('display-time');
+    const date = screen.getByTestId('display-date');
+    expect(clock).toBeInTheDocument();
+    expect(date).toBeInTheDocument();
+    // Robust: time string contains a colon, date string is non-empty.
+    expect(clock.textContent).toMatch(/\d{1,2}:\d{2}/);
+    expect(date.textContent.length).toBeGreaterThan(3);
+  });
+
+  test('falls back to "Family" when the family name is empty', () => {
+    renderWithFixedNow(
+      buildDashboard({ family_name: '' }),
+      new Date('2026-04-27T08:30:00')
+    );
+    expect(screen.getByTestId('display-family-name')).toHaveTextContent(
+      'Family'
+    );
+  });
+});
+
+describe('DisplayDashboard — agenda grouping', () => {
+  test('groups events by Today and Tomorrow with explicit labels', () => {
+    const fixedNow = new Date('2026-04-27T08:00:00');
+    const todayLater = new Date('2026-04-27T18:00:00');
+    const tomorrow = new Date('2026-04-28T09:00:00');
+    renderWithFixedNow(
+      buildDashboard({
+        next_events: [
+          {
+            title: 'Soccer practice',
+            starts_at: isoLocal(todayLater),
+            ends_at: null,
+            all_day: false,
+            color: null,
+            category: 'Sports',
+          },
+          {
+            title: 'Dentist',
+            starts_at: isoLocal(tomorrow),
+            ends_at: null,
+            all_day: false,
+            color: null,
+            category: null,
+          },
+        ],
+      }),
+      fixedNow
+    );
+
+    const events = screen.getByTestId('display-events');
+    expect(within(events).getByText('Today')).toBeInTheDocument();
+    expect(within(events).getByText('Tomorrow')).toBeInTheDocument();
+    expect(within(events).getByText('Soccer practice')).toBeInTheDocument();
+    expect(within(events).getByText('Dentist')).toBeInTheDocument();
+    // category label appears for events that have one.
+    expect(within(events).getByText('Sports')).toBeInTheDocument();
+  });
+
+  test('marks an event currently in progress as "Happening now"', () => {
+    const fixedNow = new Date('2026-04-27T18:30:00');
+    const startedAlready = new Date('2026-04-27T18:00:00');
+    const endsLater = new Date('2026-04-27T19:30:00');
+    renderWithFixedNow(
+      buildDashboard({
+        next_events: [
+          {
+            title: 'Family dinner',
+            starts_at: isoLocal(startedAlready),
+            ends_at: isoLocal(endsLater),
+            all_day: false,
+            color: '#10b981',
+            category: null,
+          },
+        ],
+      }),
+      fixedNow
+    );
+
+    const focus = screen.getByTestId('display-focus');
+    expect(focus).toHaveAttribute('data-status', 'live');
+    expect(focus).toHaveTextContent(/happening now/i);
+    expect(focus).toHaveTextContent('Family dinner');
+  });
+
+  test('shows the friendly empty hearth message when no events', () => {
+    renderWithFixedNow(
+      buildDashboard({ next_events: [] }),
+      new Date('2026-04-27T08:00:00')
+    );
+
+    const events = screen.getByTestId('display-events');
+    expect(events).toHaveTextContent(/hearth is quiet/i);
+
+    const focus = screen.getByTestId('display-focus');
+    expect(focus).toHaveAttribute('data-status', 'empty');
+    expect(focus).toHaveTextContent(/all clear/i);
+  });
+});
+
+describe('DisplayDashboard — celebration + members', () => {
+  test('renders the next birthday in the celebration card', () => {
+    renderWithFixedNow(
+      buildDashboard({
+        upcoming_birthdays: [
+          { person_name: 'Grandma Ilse', occurs_on: '2026-04-29', days_until: 2 },
+          { person_name: 'Anna', occurs_on: '2026-05-20', days_until: 23 },
+        ],
+      }),
+      new Date('2026-04-27T08:00:00')
+    );
+
+    const card = screen.getByTestId('display-birthdays');
+    expect(within(card).getByText('Grandma Ilse')).toBeInTheDocument();
+    expect(within(card).getByText(/in 2 days/i)).toBeInTheDocument();
+    // only the soonest birthday is the celebrant; later ones don't render here.
+    expect(within(card).queryByText(/in 23 days/i)).not.toBeInTheDocument();
+  });
+
+  test('shows the empty celebration message when no birthdays are due', () => {
+    renderWithFixedNow(
+      buildDashboard({ upcoming_birthdays: [] }),
+      new Date('2026-04-27T08:00:00')
+    );
+
+    const card = screen.getByTestId('display-birthdays');
+    expect(card).toHaveTextContent(/no birthdays/i);
+  });
+
+  test('flags imminent celebrants on the member wall', () => {
+    renderWithFixedNow(
+      buildDashboard({
+        upcoming_birthdays: [
+          { person_name: 'Grandma Ilse', occurs_on: '2026-04-28', days_until: 1 },
+        ],
+      }),
+      new Date('2026-04-27T08:00:00')
+    );
+
+    const members = screen.getByTestId('display-members');
+    const memberItems = within(members).getAllByTestId('display-member');
+    const ilse = memberItems.find((el) => el.textContent.includes('Grandma Ilse'));
+    expect(ilse).toBeTruthy();
+    expect(ilse.className).toMatch(/display-member--celebrant/);
+  });
+
+  test('renders avatar initials for each member without exposing IDs', () => {
+    renderWithFixedNow(buildDashboard(), new Date('2026-04-27T08:00:00'));
+
+    const members = screen.getByTestId('display-members');
+    expect(within(members).getByText('Anna')).toBeInTheDocument();
+    expect(within(members).getByText('Mia')).toBeInTheDocument();
+    // Initial cells render uppercase initials only; never show IDs.
+    expect(members.textContent).not.toMatch(/\bID:/i);
+    expect(members.textContent).not.toMatch(/\buser_id\b/i);
+  });
+});
+
+describe('DisplayDashboard — privacy + chrome isolation', () => {
+  test('does not leak emails, user IDs, or admin controls', () => {
+    renderWithFixedNow(
+      buildDashboard({
+        next_events: [
+          {
+            title: 'Soccer practice',
+            starts_at: '2099-01-02T18:00:00',
+            ends_at: null,
+            all_day: false,
+            color: null,
+            category: null,
+          },
+        ],
+        upcoming_birthdays: [
+          { person_name: 'Grandma Ilse', occurs_on: '2099-01-04', days_until: 2 },
+        ],
+      }),
+      new Date('2026-04-27T08:00:00')
+    );
+
+    const root = screen.getByTestId('display-dashboard');
+    // No e-mail addresses anywhere on the wall display.
+    expect(root.textContent).not.toMatch(/[a-z0-9._%+-]+@[a-z0-9.-]+/i);
+    // No "ID:" labels (numeric IDs would be a leak from the safe payload).
+    expect(root.textContent).not.toMatch(/\bID:/i);
+    // No admin / settings / nav / search controls.
+    expect(screen.queryByText(/^Settings$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Admin$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Logout$/i)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /quick.*add/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/DisplayDashboard.js
+++ b/frontend/components/DisplayDashboard.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Calendar, Cake, Users } from 'lucide-react';
 
 /**
@@ -7,7 +7,13 @@ import { Calendar, Cake, Users } from 'lucide-react';
  * Read-only by design: no settings/admin/search/sidebar/quick-add
  * controls are rendered. The component receives only the data
  * returned by `/display/dashboard`, which is already a curated
- * server-side projection (no member emails, no admin-only metadata).
+ * server-side projection: `family_name`, `device_name`, `members`
+ * (display_name + optional color only — no user_id, email, or
+ * profile image), display-safe events, and birthday countdowns.
+ *
+ * Layout follows the "Tribu Hearth" three-column grid in landscape
+ * (Pulse | Horizon | Tribe) and collapses to a single vertical stack
+ * in portrait or under 1024px.
  */
 export default function DisplayDashboard({ me, dashboard }) {
   const [now, setNow] = useState(() => new Date());
@@ -17,114 +23,467 @@ export default function DisplayDashboard({ me, dashboard }) {
     return () => clearInterval(id);
   }, []);
 
-  const dateLabel = now.toLocaleDateString(undefined, {
-    weekday: 'long', day: '2-digit', month: 'long', year: 'numeric',
-  });
-  const timeLabel = now.toLocaleTimeString(undefined, {
-    hour: '2-digit', minute: '2-digit',
-  });
+  const timeLabel = formatTimeOfDay(now);
+  const dateLabel = formatBigDate(now);
+
+  const events = Array.isArray(dashboard.next_events) ? dashboard.next_events : [];
+  const eventGroups = useMemo(() => groupEventsByDay(events, now), [events, now]);
+  const focus = useMemo(() => pickFocusEvent(events, now), [events, now]);
+
+  const birthdays = Array.isArray(dashboard.upcoming_birthdays)
+    ? dashboard.upcoming_birthdays
+    : [];
+  const celebration = birthdays[0] || null;
+  const imminentNames = new Set(
+    birthdays.filter((b) => b.days_until <= 2).map((b) => b.person_name)
+  );
+
+  const familyName = dashboard.family_name || '';
+  const deviceName = (me && me.name) || dashboard.device_name || '';
 
   return (
-    <div className="display-dashboard" data-testid="display-dashboard">
-      <header className="display-header">
-        <div className="display-header-left">
-          <div className="display-date" data-testid="display-date">{dateLabel}</div>
-          <div className="display-time" data-testid="display-time">{timeLabel}</div>
-        </div>
-        <div className="display-header-right">
-          <div className="display-family-name" data-testid="display-family-name">
-            {dashboard.family_name}
-          </div>
-          <div className="display-device-name" data-testid="display-device-name">
-            {me.name}
-          </div>
-        </div>
-      </header>
-
-      <section className="display-card display-events" data-testid="display-events">
-        <div className="display-card-header">
-          <Calendar size={18} aria-hidden="true" />
-          <h2>Next events</h2>
-        </div>
-        {dashboard.next_events.length === 0 ? (
-          <p className="display-empty">No upcoming events.</p>
-        ) : (
-          <ul className="display-list">
-            {dashboard.next_events.map((event, idx) => (
-              <li key={`${event.starts_at}-${event.title}-${idx}`} className="display-list-row">
-                <div className="display-event-when">
-                  {formatEventWhen(event)}
-                </div>
-                <div className="display-event-title">{event.title}</div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      <section className="display-card display-birthdays" data-testid="display-birthdays">
-        <div className="display-card-header">
-          <Cake size={18} aria-hidden="true" />
-          <h2>Upcoming birthdays</h2>
-        </div>
-        {dashboard.upcoming_birthdays.length === 0 ? (
-          <p className="display-empty">No birthdays in the next 4 weeks.</p>
-        ) : (
-          <ul className="display-list">
-            {dashboard.upcoming_birthdays.map((b) => (
-              <li key={`${b.person_name}-${b.occurs_on}`} className="display-list-row">
-                <div className="display-birthday-name">{b.person_name}</div>
-                <div className="display-birthday-when">
-                  {formatBirthdayWhen(b)}
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      <section className="display-card display-members" data-testid="display-members">
-        <div className="display-card-header">
-          <Users size={18} aria-hidden="true" />
-          <h2>Family</h2>
-        </div>
-        <ul className="display-member-row">
-          {dashboard.members.map((m, idx) => (
-            <li
-              key={`${m.display_name}-${idx}`}
-              className="display-member-chip"
-              style={m.color ? { borderColor: m.color } : undefined}
+    <div
+      className="display-dashboard"
+      data-testid="display-dashboard"
+      role="region"
+      aria-label="Tribu shared home display"
+    >
+      <section className="display-pulse" data-testid="display-pulse">
+        <div className="display-card display-identity">
+          <div className="display-hearth-label">
+            <span className="display-hearth-prefix">The</span>
+            <span
+              className="display-hearth-name"
+              data-testid="display-family-name"
             >
-              <span className="display-member-name">{m.display_name}</span>
-            </li>
-          ))}
-        </ul>
+              {familyName || 'Family'}
+            </span>
+            <span className="display-hearth-suffix">Home</span>
+          </div>
+          {deviceName && (
+            <div
+              className="display-device-tag"
+              data-testid="display-device-name"
+            >
+              {deviceName}
+            </div>
+          )}
+        </div>
+
+        <div className="display-card display-clock-shell" aria-live="off">
+          <div className="display-clock" data-testid="display-time">
+            {timeLabel}
+          </div>
+          <div className="display-date" data-testid="display-date">
+            {dateLabel}
+          </div>
+        </div>
+
+        <FocusCard focus={focus} />
+      </section>
+
+      <section
+        className="display-card display-horizon"
+        data-testid="display-events"
+        aria-live="polite"
+      >
+        <header className="display-section-header">
+          <Calendar size={22} aria-hidden="true" />
+          <h2>Family agenda</h2>
+        </header>
+        {eventGroups.length === 0 ? (
+          <EmptyHearth message="The hearth is quiet — nothing scheduled in the next 14 days." />
+        ) : (
+          <ol className="display-agenda">
+            {eventGroups.map((group) => (
+              <li key={group.key} className="display-agenda-day">
+                <div className="display-agenda-day-head">
+                  <span className="display-agenda-day-name">
+                    {group.dayLabel}
+                  </span>
+                  <span className="display-agenda-day-date">
+                    {group.subLabel}
+                  </span>
+                </div>
+                <ul className="display-agenda-list">
+                  {group.events.map((ev, idx) => (
+                    <AgendaRow
+                      key={`${group.key}-${idx}`}
+                      event={ev}
+                      now={now}
+                    />
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <section className="display-tribe">
+        <div
+          className="display-card display-card-celebration"
+          data-testid="display-birthdays"
+        >
+          <header className="display-section-header">
+            <Cake size={22} aria-hidden="true" />
+            <h2>Celebration</h2>
+          </header>
+          {celebration ? (
+            <CelebrationCard birthday={celebration} />
+          ) : (
+            <EmptyHearth
+              tone="soft"
+              message="No birthdays in the next 4 weeks."
+            />
+          )}
+        </div>
+
+        <div
+          className="display-card display-card-members"
+          data-testid="display-members"
+        >
+          <header className="display-section-header">
+            <Users size={22} aria-hidden="true" />
+            <h2>Family</h2>
+          </header>
+          {dashboard.members && dashboard.members.length > 0 ? (
+            <ul className="display-member-wall">
+              {dashboard.members.map((m, idx) => {
+                const isCelebrant = imminentNames.has(m.display_name);
+                const tint = sanitizeColor(m.color) || fallbackTint(idx);
+                return (
+                  <li
+                    key={`${m.display_name}-${idx}`}
+                    className={
+                      'display-member' +
+                      (isCelebrant ? ' display-member--celebrant' : '')
+                    }
+                    style={{ '--member-tint': tint }}
+                    data-testid="display-member"
+                  >
+                    <span className="display-member-avatar" aria-hidden="true">
+                      {initials(m.display_name)}
+                    </span>
+                    <span className="display-member-name">
+                      {m.display_name}
+                    </span>
+                    {isCelebrant && (
+                      <span
+                        className="display-member-badge"
+                        aria-label="Birthday soon"
+                        title="Birthday soon"
+                      >
+                        🎂
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <EmptyHearth
+              tone="soft"
+              message="No family members yet."
+            />
+          )}
+        </div>
       </section>
     </div>
   );
 }
 
-function formatEventWhen(event) {
-  if (event.all_day) {
-    const d = parseLooseDate(event.starts_at);
-    return d ? d.toLocaleDateString(undefined, { weekday: 'short', day: '2-digit', month: 'short' }) : event.starts_at;
+function FocusCard({ focus }) {
+  if (!focus) {
+    return (
+      <div
+        className="display-card display-focus display-focus--empty"
+        data-testid="display-focus"
+        data-status="empty"
+      >
+        <div className="display-focus-eyebrow">Right now</div>
+        <div className="display-focus-title">All clear</div>
+        <div className="display-focus-meta">
+          Nothing on the immediate horizon — enjoy the calm.
+        </div>
+      </div>
+    );
   }
-  const d = parseLooseDate(event.starts_at);
-  if (!d) return event.starts_at;
-  return d.toLocaleString(undefined, {
-    weekday: 'short', day: '2-digit', month: 'short',
-    hour: '2-digit', minute: '2-digit',
-  });
+  const { event, status } = focus;
+  const eyebrow =
+    status === 'live'
+      ? 'Happening now'
+      : status === 'today'
+      ? "Today's focus"
+      : 'Coming up';
+  const tint = sanitizeColor(event.color);
+  return (
+    <div
+      className={`display-card display-focus display-focus--${status}`}
+      data-testid="display-focus"
+      data-status={status}
+      style={tint ? { '--focus-tint': tint } : undefined}
+    >
+      <div className="display-focus-eyebrow">{eyebrow}</div>
+      <div className="display-focus-title" title={event.title}>
+        {event.title}
+      </div>
+      <div className="display-focus-meta">
+        {formatFocusMeta(event, status)}
+      </div>
+    </div>
+  );
 }
 
-function formatBirthdayWhen(b) {
-  if (b.days_until === 0) return 'Today';
-  if (b.days_until === 1) return 'Tomorrow';
-  return `in ${b.days_until} days`;
+function CelebrationCard({ birthday }) {
+  const imminent = birthday.days_until <= 2;
+  return (
+    <div
+      className="display-celebration"
+      data-status={imminent ? 'imminent' : 'soon'}
+    >
+      <div className="display-celebration-emoji" aria-hidden="true">
+        {birthday.days_until === 0 ? '🎉' : '🎂'}
+      </div>
+      <div className="display-celebration-name">{birthday.person_name}</div>
+      <div className="display-celebration-when">
+        {formatBirthdayWhen(birthday)}
+      </div>
+    </div>
+  );
+}
+
+function AgendaRow({ event, now }) {
+  const live = isEventLive(event, now);
+  const tint = sanitizeColor(event.color);
+  return (
+    <li
+      className={
+        'display-agenda-row' + (live ? ' display-agenda-row--live' : '')
+      }
+      style={tint ? { '--row-tint': tint } : undefined}
+      data-status={live ? 'live' : 'scheduled'}
+    >
+      <span className="display-agenda-when">{formatAgendaWhen(event)}</span>
+      <span className="display-agenda-title">{event.title}</span>
+      {event.category && (
+        <span className="display-agenda-category">{event.category}</span>
+      )}
+    </li>
+  );
+}
+
+function EmptyHearth({ message, tone = 'default' }) {
+  return (
+    <div className={`display-empty display-empty--${tone}`}>
+      <span className="display-empty-glyph" aria-hidden="true">
+        ·
+      </span>
+      <span>{message}</span>
+    </div>
+  );
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const FALLBACK_TINTS = [
+  'var(--member-1)',
+  'var(--member-2)',
+  'var(--member-3)',
+  'var(--member-4)',
+];
+
+function fallbackTint(idx) {
+  return FALLBACK_TINTS[idx % FALLBACK_TINTS.length];
+}
+
+// Calendar/member colors arrive from user-editable payload fields and
+// are not validated server-side. They flow into CSS custom properties
+// via inline `style`, where React does not escape values — a stray
+// `;` or `url(...)` would let an attacker break out of the declaration
+// and inject arbitrary CSS. Allow only the shapes Tribu actually emits:
+// 3- or 6-digit hex (case-insensitive). Everything else falls back.
+const HEX_COLOR_RE = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+function sanitizeColor(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return HEX_COLOR_RE.test(trimmed) ? trimmed : null;
+}
+
+function initials(name) {
+  if (!name) return '·';
+  const parts = String(name).trim().split(/\s+/).slice(0, 2);
+  const out = parts.map((p) => p[0]?.toUpperCase() || '').join('');
+  return out || '·';
 }
 
 function parseLooseDate(value) {
   if (!value) return null;
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function startOfDay(d) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function dayKey(d) {
+  return (
+    d.getFullYear() +
+    '-' +
+    String(d.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(d.getDate()).padStart(2, '0')
+  );
+}
+
+function formatTimeOfDay(d) {
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatBigDate(d) {
+  return d.toLocaleDateString(undefined, {
+    weekday: 'long',
+    day: '2-digit',
+    month: 'long',
+  });
+}
+
+function eventEnd(event, start) {
+  const end = parseLooseDate(event.ends_at);
+  if (end) return end;
+  return new Date(start.getTime() + HOUR_MS);
+}
+
+function isEventLive(event, now) {
+  const start = parseLooseDate(event.starts_at);
+  if (!start) return false;
+  if (event.all_day) {
+    return startOfDay(start).getTime() === startOfDay(now).getTime();
+  }
+  const end = eventEnd(event, start);
+  return now.getTime() >= start.getTime() && now.getTime() <= end.getTime();
+}
+
+function pickFocusEvent(events, now) {
+  if (!Array.isArray(events) || events.length === 0) return null;
+
+  const live = events.find((e) => isEventLive(e, now));
+  if (live) return { event: live, status: 'live' };
+
+  const today = startOfDay(now).getTime();
+  const enriched = events
+    .map((e) => ({ e, t: parseLooseDate(e.starts_at) }))
+    .filter(({ t }) => !!t);
+
+  const todayUpcoming = enriched
+    .filter(
+      ({ t }) =>
+        startOfDay(t).getTime() === today && t.getTime() >= now.getTime()
+    )
+    .sort((a, b) => a.t - b.t);
+  if (todayUpcoming.length > 0)
+    return { event: todayUpcoming[0].e, status: 'today' };
+
+  const upcoming = enriched
+    .filter(({ t }) => t.getTime() >= now.getTime())
+    .sort((a, b) => a.t - b.t);
+  if (upcoming.length > 0) return { event: upcoming[0].e, status: 'upcoming' };
+
+  return null;
+}
+
+function groupEventsByDay(events, now) {
+  if (!Array.isArray(events) || events.length === 0) return [];
+  const today = startOfDay(now).getTime();
+  const enriched = events
+    .map((e) => ({ e, t: parseLooseDate(e.starts_at) }))
+    .filter(({ t }) => !!t)
+    .sort((a, b) => a.t - b.t);
+
+  const groups = new Map();
+  for (const { e, t } of enriched) {
+    const anchor = startOfDay(t);
+    const key = dayKey(anchor);
+    if (!groups.has(key)) {
+      groups.set(key, { key, anchor, events: [] });
+    }
+    groups.get(key).events.push(e);
+  }
+
+  return Array.from(groups.values()).map((g) => {
+    const diffDays = Math.round((g.anchor.getTime() - today) / DAY_MS);
+    let dayLabel;
+    if (diffDays === 0) dayLabel = 'Today';
+    else if (diffDays === 1) dayLabel = 'Tomorrow';
+    else if (diffDays > 1 && diffDays < 7) {
+      dayLabel = g.anchor.toLocaleDateString(undefined, { weekday: 'long' });
+    } else {
+      dayLabel = g.anchor.toLocaleDateString(undefined, {
+        weekday: 'long',
+      });
+    }
+    const subLabel = g.anchor.toLocaleDateString(undefined, {
+      day: '2-digit',
+      month: 'short',
+    });
+    return { ...g, dayLabel, subLabel };
+  });
+}
+
+function formatAgendaWhen(event) {
+  if (event.all_day) return 'All day';
+  const d = parseLooseDate(event.starts_at);
+  if (!d) return event.starts_at || '';
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatFocusMeta(event, status) {
+  const start = parseLooseDate(event.starts_at);
+  if (!start) return event.starts_at || '';
+  if (event.all_day) {
+    if (status === 'today' || status === 'live') return 'All day today';
+    return start.toLocaleDateString(undefined, {
+      weekday: 'long',
+      day: '2-digit',
+      month: 'short',
+    });
+  }
+  const time = start.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  if (status === 'live') {
+    const end = parseLooseDate(event.ends_at);
+    return end
+      ? `Until ${end.toLocaleTimeString(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+        })}`
+      : `Started at ${time}`;
+  }
+  if (status === 'today') return `Starts at ${time}`;
+  const day = start.toLocaleDateString(undefined, {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+  });
+  return `${day} · ${time}`;
+}
+
+function formatBirthdayWhen(b) {
+  if (b.days_until === 0) return 'Today';
+  if (b.days_until === 1) return 'Tomorrow';
+  if (b.days_until < 7) return `In ${b.days_until} days`;
+  if (b.days_until < 14) return 'Next week';
+  return `In ${b.days_until} days`;
 }

--- a/frontend/e2e/tests/display.spec.js
+++ b/frontend/e2e/tests/display.spec.js
@@ -34,7 +34,11 @@ test.describe('Display mode', () => {
 
     await expect(page.getByTestId('display-dashboard')).toBeVisible({ timeout: 15000 });
     await expect(page.getByTestId('display-device-name')).toContainText('Kitchen Tablet');
-    await expect(page.getByText('Dinner Plan')).toBeVisible();
+    // The redesign surfaces the next event in two distinct regions — the
+    // hero "focus" card and the agenda list — so scope the assertion to
+    // each region to avoid strict-mode ambiguity from the duplicate title.
+    await expect(page.getByTestId('display-focus')).toContainText('Dinner Plan');
+    await expect(page.getByTestId('display-events')).toContainText('Dinner Plan');
     await expect(page.getByText(testUser.displayName)).toBeVisible();
 
     await expect(page).toHaveURL(/\/display$/);
@@ -45,6 +49,30 @@ test.describe('Display mode', () => {
     expect(requested.some((url) => url.includes('/api/families/me'))).toBe(false);
     expect(requested.some((url) => url.includes('/api/display/me'))).toBe(true);
     expect(requested.some((url) => url.includes('/api/display/dashboard'))).toBe(true);
+
+    // Glance test: the hero clock is rendered and large enough to be
+    // legible from across a kitchen. We allow some leeway (>= 48px)
+    // so the assertion stays robust across viewport sizes.
+    const clock = page.getByTestId('display-time');
+    await expect(clock).toBeVisible();
+    const clockFontPx = await clock.evaluate((el) => {
+      const v = window.getComputedStyle(el).fontSize;
+      return parseFloat(v);
+    });
+    expect(clockFontPx).toBeGreaterThanOrEqual(48);
+
+    // Privacy audit: no e-mail-shaped strings, no `ID:` labels, and
+    // no source URLs leak into the rendered DOM.
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText).not.toMatch(/[a-z0-9._%+-]+@[a-z0-9.-]+/i);
+    expect(bodyText).not.toMatch(/\bID:\s*\d+/i);
+
+    // The redesign keeps the original section testids so a future
+    // styling change can't silently drop a privacy-relevant region.
+    await expect(page.getByTestId('display-events')).toBeVisible();
+    await expect(page.getByTestId('display-birthdays')).toBeVisible();
+    await expect(page.getByTestId('display-members')).toBeVisible();
+    await expect(page.getByTestId('display-family-name')).toBeVisible();
   });
 
   test('shows a revoked-device state instead of falling back to a user session', async ({ page, apiCtx }) => {

--- a/frontend/pages/display.js
+++ b/frontend/pages/display.js
@@ -111,8 +111,18 @@ export default function DisplayPage() {
       </Head>
       <main className="display-root" data-testid="display-root">
         {state === 'loading' && (
-          <div className="display-state" data-testid="display-state-loading">
-            <p>Loading…</p>
+          <div
+            className="display-state-loading"
+            data-testid="display-state-loading"
+            aria-busy="true"
+            aria-label="Loading display"
+          >
+            <div className="display-skeleton-card" />
+            <div className="display-skeleton-card" />
+            <div className="display-skeleton-card" />
+            <span className="visually-hidden" style={{ position: 'absolute', left: -9999 }}>
+              Loading…
+            </span>
           </div>
         )}
         {state === 'missing' && (

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2307,3 +2307,489 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .invite-next-step-num { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: var(--radius-pill); background: rgba(124, 58, 237, 0.18); color: var(--amethyst); font-weight: 600; font-size: 0.78rem; }
 .invite-role-pill { display: inline-block; margin-top: var(--space-sm); padding: 4px 10px; background: rgba(120, 130, 180, 0.1); border: 1px solid var(--glass-border); border-radius: var(--radius-pill); color: var(--text-secondary); font-size: 0.8rem; }
 .invite-role-pill strong { color: var(--text-primary); font-weight: 600; }
+
+/* ═══════════════════════════════════════════
+   Tribu Display ("The Hearth") — kiosk wall layout
+   Mounted at /display only. No global chrome.
+   ═══════════════════════════════════════════ */
+
+.display-root {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+  font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  color: var(--text-primary);
+  background:
+    radial-gradient(1200px 800px at 18% 22%, rgba(124, 58, 237, 0.22), transparent 60%),
+    radial-gradient(900px 700px at 82% 78%, rgba(59, 130, 246, 0.18), transparent 60%),
+    linear-gradient(160deg, var(--void) 0%, var(--void-deep) 60%, #03050a 100%);
+}
+.display-root::-webkit-scrollbar { width: 0; height: 0; }
+.display-root *::-webkit-scrollbar { width: 0; height: 0; }
+.display-root * { -webkit-tap-highlight-color: transparent; }
+
+[data-theme="light"] .display-root {
+  background:
+    radial-gradient(1200px 800px at 18% 22%, rgba(124, 58, 237, 0.16), transparent 60%),
+    radial-gradient(900px 700px at 82% 78%, rgba(244, 63, 94, 0.10), transparent 60%),
+    linear-gradient(160deg, #faf6ff 0%, #efe9fb 60%, #e3dbf7 100%);
+}
+
+/* ─── State screens (loading / missing / invalid / revoked) ─── */
+.display-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  padding: var(--space-2xl);
+  text-align: center;
+}
+.display-state h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: var(--grad-primary);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.display-state p {
+  margin: 0;
+  max-width: 60ch;
+  font-size: clamp(1rem, 1.4vw, 1.25rem);
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+.display-state-loading {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(420px, 2fr) minmax(260px, 1fr);
+  gap: 1.75rem;
+  padding: 1.75rem;
+}
+.display-state-loading .display-skeleton-card {
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--glass-border);
+  background: linear-gradient(110deg,
+    rgba(255, 255, 255, 0.02) 0%,
+    rgba(255, 255, 255, 0.06) 50%,
+    rgba(255, 255, 255, 0.02) 100%) var(--glass);
+  background-size: 220% 100%;
+  animation: display-shimmer 2.4s ease-in-out infinite;
+}
+@keyframes display-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (max-width: 1024px), (orientation: portrait) {
+  .display-state-loading {
+    grid-template-columns: 1fr;
+    grid-auto-rows: minmax(120px, auto);
+  }
+}
+
+.display-state-revoked,
+.display-state-invalid {
+  background: radial-gradient(800px 500px at 50% 50%, rgba(239, 68, 68, 0.12), transparent 70%);
+}
+
+/* ─── Three-column dashboard grid ─── */
+.display-dashboard {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(420px, 2fr) minmax(280px, 1fr);
+  gap: 1.5rem;
+  padding: 1.5rem;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.display-pulse,
+.display-tribe {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.display-card {
+  position: relative;
+  background: var(--glass);
+  backdrop-filter: blur(14px) saturate(1.2);
+  -webkit-backdrop-filter: blur(14px) saturate(1.2);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 30px 60px -30px rgba(0, 0, 0, 0.55);
+}
+
+@supports not ((backdrop-filter: blur(8px)) or (-webkit-backdrop-filter: blur(8px))) {
+  .display-card { background: var(--void-surface); }
+}
+
+[data-theme="light"] .display-card {
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(0, 0, 0, 0.07);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.8) inset,
+    0 1px 3px rgba(0, 0, 0, 0.04),
+    0 24px 48px -24px rgba(0, 0, 0, 0.18);
+}
+
+/* ─── PULSE column ─── */
+.display-identity { display: flex; flex-direction: column; gap: 6px; }
+.display-hearth-label {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.55ch;
+  font-size: clamp(0.95rem, 1.2vw, 1.15rem);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+.display-hearth-prefix,
+.display-hearth-suffix { color: var(--text-muted); }
+.display-hearth-name {
+  font-weight: 800;
+  font-size: clamp(1.6rem, 2.6vw, 2.4rem);
+  letter-spacing: -0.01em;
+  text-transform: none;
+  background: var(--grad-primary);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.display-device-tag {
+  align-self: flex-start;
+  margin-top: 6px;
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  background: rgba(124, 58, 237, 0.10);
+  border: 1px solid rgba(124, 58, 237, 0.25);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.display-clock-shell { display: flex; flex-direction: column; gap: 4px; }
+.display-clock {
+  font-family: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', monospace;
+  font-weight: 700;
+  font-size: clamp(3.75rem, 8vw, 6.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 8px 40px rgba(124, 58, 237, 0.30);
+}
+.display-date {
+  font-size: clamp(1rem, 1.3vw, 1.25rem);
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+}
+
+.display-focus {
+  --focus-tint: var(--amethyst);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-left: 6px solid var(--focus-tint);
+  background:
+    linear-gradient(135deg,
+      color-mix(in srgb, var(--focus-tint) 16%, transparent),
+      transparent 70%),
+    var(--glass);
+}
+.display-focus-eyebrow {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--focus-tint);
+}
+.display-focus-title {
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+.display-focus-meta {
+  font-size: clamp(1rem, 1.2vw, 1.15rem);
+  color: var(--text-secondary);
+}
+.display-focus--live {
+  animation: display-focus-pulse 3.6s ease-in-out infinite;
+}
+.display-focus--empty {
+  --focus-tint: var(--text-muted);
+}
+@keyframes display-focus-pulse {
+  0%, 100% {
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.04) inset,
+      0 30px 60px -30px rgba(0, 0, 0, 0.55),
+      0 0 0 0 rgba(16, 185, 129, 0.0);
+  }
+  50% {
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.04) inset,
+      0 30px 60px -30px rgba(0, 0, 0, 0.55),
+      0 0 0 8px rgba(16, 185, 129, 0.18);
+  }
+}
+
+/* ─── HORIZON (agenda) column ─── */
+.display-horizon {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 0;
+  overflow: hidden;
+}
+.display-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 0.25rem;
+  color: var(--text-secondary);
+}
+.display-section-header h2 {
+  margin: 0;
+  font-size: clamp(0.95rem, 1.2vw, 1.15rem);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.display-agenda {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  scrollbar-width: none;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.display-agenda::-webkit-scrollbar { display: none; }
+.display-agenda-day { display: flex; flex-direction: column; gap: 0.5rem; }
+.display-agenda-day-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 0 0.25rem;
+}
+.display-agenda-day-name {
+  font-size: clamp(1.05rem, 1.4vw, 1.3rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+.display-agenda-day-date {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+.display-agenda-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+
+.display-agenda-row {
+  --row-tint: var(--amethyst);
+  display: grid;
+  grid-template-columns: 5.5rem 1fr auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(120, 130, 180, 0.06);
+  border-left: 4px solid var(--row-tint);
+  font-size: clamp(1rem, 1.2vw, 1.15rem);
+}
+.display-agenda-row--live {
+  background: rgba(16, 185, 129, 0.10);
+  border-left-color: var(--success);
+  animation: display-row-pulse 3.6s ease-in-out infinite;
+}
+@keyframes display-row-pulse {
+  0%, 100% { background-color: rgba(16, 185, 129, 0.10); }
+  50% { background-color: rgba(16, 185, 129, 0.20); }
+}
+.display-agenda-when {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.display-agenda-title {
+  color: var(--text-primary);
+  font-weight: 500;
+  word-break: break-word;
+  min-width: 0;
+}
+.display-agenda-category {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  padding: 3px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+
+/* ─── TRIBE column ─── */
+.display-tribe {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-width: 0;
+}
+.display-card-celebration { text-align: center; }
+.display-celebration {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0 0.25rem;
+}
+.display-celebration-emoji {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  line-height: 1;
+  filter: drop-shadow(0 8px 20px rgba(244, 63, 94, 0.35));
+}
+.display-celebration-name {
+  font-size: clamp(1.25rem, 1.8vw, 1.6rem);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.display-celebration-when {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.display-member-wall {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+  gap: 1rem;
+}
+.display-member {
+  --member-tint: var(--amethyst);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+}
+.display-member-avatar {
+  width: clamp(64px, 6vw, 84px);
+  height: clamp(64px, 6vw, 84px);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(1.4rem, 2vw, 1.8rem);
+  font-weight: 700;
+  color: var(--text-on-primary);
+  background:
+    linear-gradient(135deg,
+      color-mix(in srgb, var(--member-tint) 92%, white),
+      color-mix(in srgb, var(--member-tint) 60%, black));
+  border: 3px solid color-mix(in srgb, var(--member-tint) 35%, transparent);
+  box-shadow: 0 14px 30px -10px color-mix(in srgb, var(--member-tint) 50%, transparent);
+}
+.display-member-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-align: center;
+  word-break: break-word;
+}
+.display-member--celebrant .display-member-avatar {
+  outline: 3px solid var(--warning);
+  outline-offset: 3px;
+  animation: display-celebrant-pulse 2.4s ease-in-out infinite;
+}
+@keyframes display-celebrant-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.04); }
+}
+.display-member-badge {
+  position: absolute;
+  top: -4px;
+  right: 14%;
+  font-size: 1.2rem;
+  background: var(--void-elevated);
+  border-radius: 50%;
+  padding: 2px 4px;
+  border: 1px solid var(--glass-border);
+}
+
+/* ─── Empty hearths ─── */
+.display-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 2rem 1rem;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  text-align: center;
+}
+.display-empty-glyph {
+  font-size: 2rem;
+  color: var(--text-muted);
+  line-height: 0.5;
+}
+.display-empty--soft { padding: 1rem; }
+
+/* ─── Portrait & narrow viewports ─── */
+@media (max-width: 1024px), (orientation: portrait) {
+  .display-dashboard {
+    grid-template-columns: 1fr;
+    grid-auto-rows: min-content;
+    gap: 1.25rem;
+    padding: 1.25rem;
+    overflow-y: auto;
+    height: auto;
+    min-height: 100vh;
+  }
+  .display-horizon { overflow: visible; }
+  .display-agenda { overflow: visible; max-height: none; }
+  .display-clock { font-size: clamp(3rem, 14vw, 5rem); }
+  .display-card { padding: 1.25rem; }
+}
+
+/* ─── Reduced motion (kiosk accessibility) ─── */
+@media (prefers-reduced-motion: reduce) {
+  .display-focus--live,
+  .display-agenda-row--live,
+  .display-member--celebrant .display-member-avatar,
+  .display-state-loading .display-skeleton-card {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Redesigns `/display` into a glanceable shared-home dashboard with a large clock, family identity, focus card, agenda timeline, celebrations, and member wall.
- Keeps the display surface standalone and read-only, with no normal app bootstrap or personal-account fallback.
- Sanitizes display color values before using them in CSS custom properties.

## Test Plan
- `npm test -- --runInBand`
- `npm run build`
- `npx playwright test --list` → 60 tests collected
- Resource-safe Playwright batches: 60/60 passed
