### PR TITLE
feat: add e-ink display layouts

### DIFF
--- a/backend/alembic/versions/0036_add_display_config_fields.py
+++ b/backend/alembic/versions/0036_add_display_config_fields.py
@@ -1,0 +1,68 @@
+"""Add display device render config fields.
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-04-27
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0036"
+down_revision: Union[str, None] = "0035"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_HEARTH_LAYOUT_JSON = json.dumps({
+    "columns": 3,
+    "rows": 3,
+    "widgets": [
+        {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+        {"type": "clock", "x": 0, "y": 1, "w": 1, "h": 1},
+        {"type": "focus", "x": 0, "y": 2, "w": 1, "h": 1},
+        {"type": "agenda", "x": 1, "y": 0, "w": 1, "h": 3},
+        {"type": "birthdays", "x": 2, "y": 0, "w": 1, "h": 1},
+        {"type": "members", "x": 2, "y": 1, "w": 1, "h": 2},
+    ],
+})
+
+
+def _has_table(table: str) -> bool:
+    return table in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table: str, column: str) -> bool:
+    if not _has_table(table):
+        return False
+    return any(c["name"] == column for c in sa.inspect(op.get_bind()).get_columns(table))
+
+
+def upgrade() -> None:
+    if not _has_table("display_devices"):
+        return
+    if not _has_column("display_devices", "display_mode"):
+        op.add_column("display_devices", sa.Column("display_mode", sa.String(length=16), nullable=False, server_default="tablet"))
+    if not _has_column("display_devices", "refresh_interval_seconds"):
+        op.add_column("display_devices", sa.Column("refresh_interval_seconds", sa.Integer(), nullable=False, server_default="60"))
+    if not _has_column("display_devices", "layout_preset"):
+        op.add_column("display_devices", sa.Column("layout_preset", sa.String(length=64), nullable=False, server_default="hearth"))
+    if not _has_column("display_devices", "layout_config"):
+        op.add_column("display_devices", sa.Column("layout_config", sa.JSON(), nullable=True))
+    op.execute(
+        sa.text("UPDATE display_devices SET layout_config = :layout WHERE layout_config IS NULL")
+        .bindparams(layout=_HEARTH_LAYOUT_JSON)
+    )
+
+
+def downgrade() -> None:
+    if not _has_table("display_devices"):
+        return
+    for column in ("layout_config", "layout_preset", "refresh_interval_seconds", "display_mode"):
+        if _has_column("display_devices", column):
+            op.drop_column("display_devices", column)

--- a/backend/app/core/display_layouts.py
+++ b/backend/app/core/display_layouts.py
@@ -1,0 +1,160 @@
+"""Validated render configuration for Shared Home Display devices."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+MODE_TABLET = "tablet"
+MODE_EINK = "eink"
+ALLOWED_MODES = {MODE_TABLET, MODE_EINK}
+DEFAULT_MODE = MODE_TABLET
+
+REFRESH_BOUNDS = {
+    MODE_TABLET: (30, 3600),
+    MODE_EINK: (300, 86400),
+}
+DEFAULT_REFRESH = {
+    MODE_TABLET: 60,
+    MODE_EINK: 900,
+}
+
+ALLOWED_WIDGETS = {"identity", "clock", "focus", "agenda", "birthdays", "members"}
+GRID_MAX_COLUMNS = 6
+GRID_MAX_ROWS = 6
+
+PRESETS: dict[str, dict[str, Any]] = {
+    "hearth": {
+        "mode": MODE_TABLET,
+        "layout": {
+            "columns": 3,
+            "rows": 3,
+            "widgets": [
+                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+                {"type": "clock", "x": 0, "y": 1, "w": 1, "h": 1},
+                {"type": "focus", "x": 0, "y": 2, "w": 1, "h": 1},
+                {"type": "agenda", "x": 1, "y": 0, "w": 1, "h": 3},
+                {"type": "birthdays", "x": 2, "y": 0, "w": 1, "h": 1},
+                {"type": "members", "x": 2, "y": 1, "w": 1, "h": 2},
+            ],
+        },
+    },
+    "agenda_first": {
+        "mode": MODE_TABLET,
+        "layout": {
+            "columns": 3,
+            "rows": 3,
+            "widgets": [
+                {"type": "agenda", "x": 0, "y": 0, "w": 2, "h": 3},
+                {"type": "identity", "x": 2, "y": 0, "w": 1, "h": 1},
+                {"type": "clock", "x": 2, "y": 1, "w": 1, "h": 1},
+                {"type": "birthdays", "x": 2, "y": 2, "w": 1, "h": 1},
+            ],
+        },
+    },
+    "family_board": {
+        "mode": MODE_TABLET,
+        "layout": {
+            "columns": 3,
+            "rows": 3,
+            "widgets": [
+                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+                {"type": "members", "x": 1, "y": 0, "w": 2, "h": 2},
+                {"type": "clock", "x": 0, "y": 1, "w": 1, "h": 1},
+                {"type": "agenda", "x": 0, "y": 2, "w": 2, "h": 1},
+                {"type": "birthdays", "x": 2, "y": 2, "w": 1, "h": 1},
+            ],
+        },
+    },
+    "eink_compact": {
+        "mode": MODE_EINK,
+        "layout": {
+            "columns": 2,
+            "rows": 3,
+            "widgets": [
+                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+                {"type": "clock", "x": 1, "y": 0, "w": 1, "h": 1},
+                {"type": "agenda", "x": 0, "y": 1, "w": 2, "h": 1},
+                {"type": "birthdays", "x": 0, "y": 2, "w": 1, "h": 1},
+                {"type": "members", "x": 1, "y": 2, "w": 1, "h": 1},
+            ],
+        },
+    },
+    "eink_agenda": {
+        "mode": MODE_EINK,
+        "layout": {
+            "columns": 1,
+            "rows": 3,
+            "widgets": [
+                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+                {"type": "agenda", "x": 0, "y": 1, "w": 1, "h": 1},
+                {"type": "birthdays", "x": 0, "y": 2, "w": 1, "h": 1},
+            ],
+        },
+    },
+}
+DEFAULT_PRESET = {MODE_TABLET: "hearth", MODE_EINK: "eink_compact"}
+
+
+def normalize_mode(value: Any) -> str:
+    return value if isinstance(value, str) and value in ALLOWED_MODES else DEFAULT_MODE
+
+
+def normalize_preset(mode: str, value: Any) -> str:
+    mode = normalize_mode(mode)
+    if isinstance(value, str) and PRESETS.get(value, {}).get("mode") == mode:
+        return value
+    return DEFAULT_PRESET[mode]
+
+
+def normalize_refresh(mode: str, value: Any) -> int:
+    mode = normalize_mode(mode)
+    lo, hi = REFRESH_BOUNDS[mode]
+    if isinstance(value, int) and not isinstance(value, bool):
+        return min(hi, max(lo, value))
+    return DEFAULT_REFRESH[mode]
+
+
+def preset_layout(preset: str) -> dict[str, Any]:
+    return deepcopy(PRESETS.get(preset, PRESETS["hearth"])["layout"])
+
+
+def _bounded_int(value: Any, lo: int, hi: int) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and lo <= value <= hi
+
+
+def normalize_layout_config(mode: str, preset: str, value: Any) -> dict[str, Any]:
+    preset = normalize_preset(mode, preset)
+    fallback = preset_layout(preset)
+    if not isinstance(value, dict):
+        return fallback
+    columns = value.get("columns")
+    rows = value.get("rows")
+    widgets = value.get("widgets")
+    if not _bounded_int(columns, 1, GRID_MAX_COLUMNS) or not _bounded_int(rows, 1, GRID_MAX_ROWS):
+        return fallback
+    if not isinstance(widgets, list):
+        return fallback
+    cleaned: list[dict[str, int | str]] = []
+    for widget in widgets:
+        if not isinstance(widget, dict) or widget.get("type") not in ALLOWED_WIDGETS:
+            continue
+        x, y = widget.get("x"), widget.get("y")
+        w, h = widget.get("w", 1), widget.get("h", 1)
+        if not _bounded_int(x, 0, columns - 1) or not _bounded_int(y, 0, rows - 1):
+            continue
+        if not _bounded_int(w, 1, columns - x) or not _bounded_int(h, 1, rows - y):
+            continue
+        cleaned.append({"type": widget["type"], "x": x, "y": y, "w": w, "h": h})
+    return {"columns": columns, "rows": rows, "widgets": cleaned} if cleaned else fallback
+
+
+def normalize_config(mode: Any = None, refresh_interval_seconds: Any = None, layout_preset: Any = None, layout_config: Any = None) -> dict[str, Any]:
+    normalized_mode = normalize_mode(mode)
+    normalized_preset = normalize_preset(normalized_mode, layout_preset)
+    return {
+        "display_mode": normalized_mode,
+        "refresh_interval_seconds": normalize_refresh(normalized_mode, refresh_interval_seconds),
+        "layout_preset": normalized_preset,
+        "layout_config": normalize_layout_config(normalized_mode, normalized_preset, layout_config),
+    }

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -334,6 +334,10 @@ class DisplayDevice(Base):
     created_at = Column(DateTime, nullable=False, server_default=func.now())
     last_used_at = Column(DateTime, nullable=True)
     revoked_at = Column(DateTime, nullable=True)
+    display_mode = Column(String(16), nullable=False, server_default="tablet", default="tablet")
+    refresh_interval_seconds = Column(Integer, nullable=False, server_default="60", default=60)
+    layout_preset = Column(String(64), nullable=False, server_default="hearth", default="hearth")
+    layout_config = Column(JSON, nullable=True)
 
     family = relationship("Family", back_populates="display_devices")
 

--- a/backend/app/modules/display_router.py
+++ b/backend/app/modules/display_router.py
@@ -30,6 +30,7 @@ from app.core.deps import current_display_device, current_user, ensure_family_ad
 from app.core.errors import DISPLAY_DEVICE_NOT_FOUND, error_detail
 from app.core.recurrence import expand_event
 from app.core.scopes import require_scope
+from app.core.display_layouts import normalize_config
 from app.database import get_db
 from app.models import CalendarEvent, DisplayDevice, Family, FamilyBirthday, Membership, User
 from app.schemas import (
@@ -42,6 +43,8 @@ from app.schemas import (
     DisplayDeviceCreate,
     DisplayDeviceCreatedResponse,
     DisplayDeviceResponse,
+    DisplayDeviceUpdate,
+    DisplayDeviceConfig,
     DisplayMeResponse,
 )
 from app.security import generate_display_token
@@ -49,6 +52,16 @@ from app.security import generate_display_token
 
 admin_router = APIRouter(prefix="/families", tags=["display"], responses={**AUTH_RESPONSES})
 display_router = APIRouter(prefix="/display", tags=["display"], responses={**AUTH_RESPONSES})
+
+
+def _device_config(device: DisplayDevice) -> DisplayDeviceConfig:
+    config = normalize_config(
+        mode=device.display_mode,
+        refresh_interval_seconds=device.refresh_interval_seconds,
+        layout_preset=device.layout_preset,
+        layout_config=device.layout_config,
+    )
+    return DisplayDeviceConfig(**config)
 
 
 # ---------------------------------------------------------------------------
@@ -104,12 +117,22 @@ def create_display_device(
     ensure_family_admin(db, user.id, family_id)
 
     plain, token_hash, lookup_key = generate_display_token()
+    config = normalize_config(
+        mode=payload.display_mode,
+        refresh_interval_seconds=payload.refresh_interval_seconds,
+        layout_preset=payload.layout_preset,
+        layout_config=payload.layout_config,
+    )
     device = DisplayDevice(
         family_id=family_id,
         name=payload.name,
         token_hash=token_hash,
         token_lookup=lookup_key,
         created_by_user_id=user.id,
+        display_mode=config["display_mode"],
+        refresh_interval_seconds=config["refresh_interval_seconds"],
+        layout_preset=config["layout_preset"],
+        layout_config=config["layout_config"],
     )
     db.add(device)
     db.commit()
@@ -119,6 +142,54 @@ def create_display_device(
         token=plain,
         device=DisplayDeviceResponse.model_validate(device),
     )
+
+
+@admin_router.patch(
+    "/{family_id}/display-devices/{device_id}",
+    response_model=DisplayDeviceResponse,
+    summary="Update a display device",
+    response_description="Updated display device metadata (no plaintext token)",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def update_display_device(
+    family_id: int,
+    device_id: int,
+    payload: DisplayDeviceUpdate,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("families:write"),
+):
+    ensure_family_admin(db, user.id, family_id)
+    device = (
+        db.query(DisplayDevice)
+        .filter(DisplayDevice.id == device_id, DisplayDevice.family_id == family_id)
+        .first()
+    )
+    if not device:
+        raise HTTPException(status_code=404, detail=error_detail(DISPLAY_DEVICE_NOT_FOUND))
+    if device.revoked_at is not None:
+        raise HTTPException(status_code=404, detail=error_detail(DISPLAY_DEVICE_NOT_FOUND))
+
+    data = payload.model_dump(exclude_unset=True)
+    if "name" in data:
+        device.name = data["name"]
+    if {"display_mode", "refresh_interval_seconds", "layout_preset", "layout_config"} & data.keys():
+        config = normalize_config(
+            mode=data.get("display_mode", device.display_mode),
+            refresh_interval_seconds=data.get("refresh_interval_seconds", device.refresh_interval_seconds),
+            layout_preset=data.get("layout_preset", device.layout_preset),
+            layout_config=data.get(
+                "layout_config",
+                None if {"display_mode", "layout_preset"} & data.keys() else device.layout_config,
+            ),
+        )
+        device.display_mode = config["display_mode"]
+        device.refresh_interval_seconds = config["refresh_interval_seconds"]
+        device.layout_preset = config["layout_preset"]
+        device.layout_config = config["layout_config"]
+    db.commit()
+    db.refresh(device)
+    return DisplayDeviceResponse.model_validate(device)
 
 
 @admin_router.delete(
@@ -182,6 +253,7 @@ def display_me(
         family_id=device.family_id,
         family_name=family_name,
         name=device.name,
+        config=_device_config(device),
     )
 
 
@@ -284,4 +356,5 @@ def display_dashboard(
         members=members,
         next_events=next_events,
         upcoming_birthdays=upcoming_birthdays,
+        config=_device_config(device),
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1331,10 +1331,31 @@ class RecipeAddToShoppingResponse(BaseModel):
 class DisplayDeviceCreate(BaseModel):
     """Admin-only request to mint a new display device for a family."""
     name: str = Field(min_length=1, max_length=120, description="Human-readable device label (e.g. 'Kitchen Tablet')")
+    display_mode: Optional[str] = Field(None, description="Render mode: tablet or eink")
+    refresh_interval_seconds: Optional[int] = Field(None, description="Refresh cadence in seconds")
+    layout_preset: Optional[str] = Field(None, description="Layout preset key")
+    layout_config: Optional[dict] = Field(None, description="Bounded widget grid config")
 
     model_config = ConfigDict(json_schema_extra={
         "examples": [{"name": "Kitchen Tablet"}]
     })
+
+
+class DisplayDeviceUpdate(BaseModel):
+    """Admin-only update for device name and rendering config."""
+    name: Optional[str] = Field(None, min_length=1, max_length=120)
+    display_mode: Optional[str] = Field(None)
+    refresh_interval_seconds: Optional[int] = Field(None)
+    layout_preset: Optional[str] = Field(None)
+    layout_config: Optional[dict] = Field(None)
+
+
+class DisplayDeviceConfig(BaseModel):
+    """Normalized display rendering config."""
+    display_mode: str = Field(..., description="Render mode: tablet or eink")
+    refresh_interval_seconds: int = Field(..., description="Refresh cadence in seconds")
+    layout_preset: str = Field(..., description="Layout preset key")
+    layout_config: dict = Field(..., description="Resolved bounded widget grid")
 
 
 class DisplayDeviceResponse(BaseModel):
@@ -1347,6 +1368,10 @@ class DisplayDeviceResponse(BaseModel):
     created_at: datetime = Field(..., description="When the device was created")
     last_used_at: Optional[datetime] = Field(None, description="Last time the device's token authenticated")
     revoked_at: Optional[datetime] = Field(None, description="When the device was revoked (null = active)")
+    display_mode: str = Field("tablet", description="Render mode")
+    refresh_interval_seconds: int = Field(60, description="Refresh cadence in seconds")
+    layout_preset: str = Field("hearth", description="Layout preset key")
+    layout_config: Optional[dict] = Field(None, description="Resolved bounded widget grid")
 
 
 class DisplayDeviceCreatedResponse(BaseModel):
@@ -1361,6 +1386,7 @@ class DisplayMeResponse(BaseModel):
     family_id: int = Field(..., description="Family this display is bound to")
     family_name: str = Field(..., description="Family name (safe to render on the home display)")
     name: str = Field(..., description="Device name")
+    config: Optional[DisplayDeviceConfig] = Field(None, description="Display rendering config")
 
 
 class DisplayDashboardMember(BaseModel):
@@ -1416,3 +1442,4 @@ class DisplayDashboardResponse(BaseModel):
     members: list[DisplayDashboardMember] = Field(..., description="Family members (display name + color only)")
     next_events: list[DisplayDashboardEvent] = Field(..., description="Upcoming events within 14 days (display-safe fields only)")
     upcoming_birthdays: list[DisplayDashboardBirthday] = Field(..., description="Upcoming birthdays within 28 days")
+    config: DisplayDeviceConfig = Field(..., description="Resolved display render config")

--- a/backend/tests/test_display_devices.py
+++ b/backend/tests/test_display_devices.py
@@ -443,3 +443,89 @@ class TestRevocation:
             headers=_auth(admin_b),
         )
         assert cross.status_code == 404
+
+
+class TestDisplayRenderConfig:
+    def test_admin_can_create_eink_device_with_normalized_layout(self):
+        admin_token, _, family_id = _seed_member_with_pat("cfgCreate", role="admin", is_adult=True)
+        resp = client.post(
+            f"/families/{family_id}/display-devices",
+            json={
+                "name": "Kitchen E-Ink",
+                "display_mode": "eink",
+                "refresh_interval_seconds": 60,
+                "layout_preset": "eink_agenda",
+                "layout_config": {
+                    "columns": 4,
+                    "rows": 3,
+                    "widgets": [
+                        {"id": "agenda-big", "type": "agenda", "x": 0, "y": 0, "w": 4, "h": 2},
+                        {"id": "bad", "type": "admin", "x": 0, "y": 0, "w": 9, "h": 9},
+                    ],
+                },
+            },
+            headers=_auth(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        device = resp.json()["device"]
+        assert device["display_mode"] == "eink"
+        assert device["refresh_interval_seconds"] == 300
+        assert device["layout_preset"] == "eink_agenda"
+        widgets = device["layout_config"]["widgets"]
+        assert [w["type"] for w in widgets] == ["agenda"]
+        assert widgets[0]["w"] == 4
+        assert widgets[0]["h"] == 2
+
+    def test_admin_can_update_display_config_without_reminting_token(self):
+        admin_token, _, family_id = _seed_member_with_pat("cfgUpdate", role="admin", is_adult=True)
+        create = client.post(
+            f"/families/{family_id}/display-devices",
+            json={"name": "Wall"},
+            headers=_auth(admin_token),
+        )
+        body = create.json()
+        token = body["token"]
+        device_id = body["device"]["id"]
+
+        update = client.patch(
+            f"/families/{family_id}/display-devices/{device_id}",
+            json={"display_mode": "eink", "layout_preset": "eink_compact", "refresh_interval_seconds": 900},
+            headers=_auth(admin_token),
+        )
+        assert update.status_code == 200, update.text
+        assert "token" not in update.json()
+        assert update.json()["display_mode"] == "eink"
+
+        me = client.get("/display/me", headers=_auth(token))
+        assert me.status_code == 200
+        assert me.json()["config"]["display_mode"] == "eink"
+        dash = client.get("/display/dashboard", headers=_auth(token))
+        assert dash.status_code == 200
+        config = dash.json()["config"]
+        assert config["refresh_interval_seconds"] == 900
+        assert config["layout_preset"] == "eink_compact"
+        assert config["layout_config"]["columns"] == 2
+        assert [widget["type"] for widget in config["layout_config"]["widgets"]] == [
+            "identity",
+            "clock",
+            "agenda",
+            "birthdays",
+            "members",
+        ]
+        assert "email" not in dash.text
+
+    def test_non_admin_cannot_update_display_config(self):
+        admin_token, _, family_id = _seed_member_with_pat("cfgAdmin", role="admin", is_adult=True)
+        member_token, _, _ = _seed_member_with_pat("cfgMember", role="member", is_adult=True, family_id=family_id)
+        create = client.post(
+            f"/families/{family_id}/display-devices",
+            json={"name": "Wall"},
+            headers=_auth(admin_token),
+        )
+        device_id = create.json()["device"]["id"]
+        update = client.patch(
+            f"/families/{family_id}/display-devices/{device_id}",
+            json={"display_mode": "eink"},
+            headers=_auth(member_token),
+        )
+        assert update.status_code == 403

--- a/frontend/__tests__/components/DisplayDashboard.test.js
+++ b/frontend/__tests__/components/DisplayDashboard.test.js
@@ -272,3 +272,60 @@ describe('DisplayDashboard — privacy + chrome isolation', () => {
     expect(screen.queryByRole('button', { name: /quick.*add/i })).not.toBeInTheDocument();
   });
 });
+
+
+describe('DisplayDashboard — configurable display layouts', () => {
+  test('applies e-ink mode and widget slot spans from the safe config', () => {
+    renderWithFixedNow(
+      buildDashboard({
+        config: {
+          display_mode: 'eink',
+          refresh_interval_seconds: 900,
+          layout_preset: 'eink_agenda',
+          layout_config: {
+            columns: 4,
+            rows: 3,
+            widgets: [
+              { id: 'clock-wide', type: 'clock', x: 0, y: 0, w: 2, h: 1 },
+              { id: 'agenda-large', type: 'agenda', x: 0, y: 1, w: 4, h: 2 },
+            ],
+          },
+        },
+      }),
+      new Date('2026-04-27T08:00:00')
+    );
+
+    const root = screen.getByTestId('display-dashboard');
+    expect(root).toHaveAttribute('data-display-mode', 'eink');
+    expect(root).toHaveAttribute('data-layout-preset', 'eink_agenda');
+    expect(screen.getByTestId('display-layout-grid')).toHaveStyle({
+      '--display-grid-columns': '4',
+      '--display-grid-rows': '3',
+    });
+    const agenda = screen.getByTestId('display-widget-agenda');
+    expect(agenda).toHaveStyle({ gridColumn: '1 / span 4', gridRow: '2 / span 2' });
+  });
+
+  test('ignores unwhitelisted widget types from runtime payloads', () => {
+    renderWithFixedNow(
+      buildDashboard({
+        config: {
+          display_mode: 'tablet',
+          layout_preset: 'hearth',
+          layout_config: {
+            columns: 2,
+            rows: 2,
+            widgets: [
+              { id: 'identity', type: 'identity', x: 0, y: 0, w: 1, h: 1 },
+              { id: 'admin', type: 'admin', x: 1, y: 0, w: 1, h: 1 },
+            ],
+          },
+        },
+      }),
+      new Date('2026-04-27T08:00:00')
+    );
+
+    expect(screen.getByTestId('display-widget-identity')).toBeInTheDocument();
+    expect(screen.queryByTestId('display-widget-admin')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/DisplayDashboard.js
+++ b/frontend/components/DisplayDashboard.js
@@ -23,6 +23,7 @@ export default function DisplayDashboard({ me, dashboard }) {
     return () => clearInterval(id);
   }, []);
 
+  const config = normalizeDisplayConfig(dashboard?.config || me?.config);
   const timeLabel = formatTimeOfDay(now);
   const dateLabel = formatBigDate(now);
 
@@ -40,155 +41,186 @@ export default function DisplayDashboard({ me, dashboard }) {
 
   const familyName = dashboard.family_name || '';
   const deviceName = (me && me.name) || dashboard.device_name || '';
+  const widgetContext = {
+    now,
+    timeLabel,
+    dateLabel,
+    eventGroups,
+    focus,
+    celebration,
+    imminentNames,
+    familyName,
+    deviceName,
+    members: Array.isArray(dashboard.members) ? dashboard.members : [],
+  };
 
   return (
     <div
-      className="display-dashboard"
+      className={`display-dashboard display-dashboard--${config.display_mode}`}
       data-testid="display-dashboard"
+      data-display-mode={config.display_mode}
+      data-layout-preset={config.layout_preset}
       role="region"
       aria-label="Tribu shared home display"
     >
-      <section className="display-pulse" data-testid="display-pulse">
-        <div className="display-card display-identity">
-          <div className="display-hearth-label">
-            <span className="display-hearth-prefix">The</span>
-            <span
-              className="display-hearth-name"
-              data-testid="display-family-name"
-            >
-              {familyName || 'Family'}
-            </span>
-            <span className="display-hearth-suffix">Home</span>
-          </div>
-          {deviceName && (
-            <div
-              className="display-device-tag"
-              data-testid="display-device-name"
-            >
-              {deviceName}
-            </div>
-          )}
-        </div>
-
-        <div className="display-card display-clock-shell" aria-live="off">
-          <div className="display-clock" data-testid="display-time">
-            {timeLabel}
-          </div>
-          <div className="display-date" data-testid="display-date">
-            {dateLabel}
-          </div>
-        </div>
-
-        <FocusCard focus={focus} />
-      </section>
-
-      <section
-        className="display-card display-horizon"
-        data-testid="display-events"
-        aria-live="polite"
+      <div
+        className="display-layout-grid"
+        data-testid="display-layout-grid"
+        style={{
+          '--display-grid-columns': config.layout_config.columns,
+          '--display-grid-rows': config.layout_config.rows,
+        }}
       >
-        <header className="display-section-header">
-          <Calendar size={22} aria-hidden="true" />
-          <h2>Family agenda</h2>
-        </header>
-        {eventGroups.length === 0 ? (
-          <EmptyHearth message="The hearth is quiet — nothing scheduled in the next 14 days." />
-        ) : (
-          <ol className="display-agenda">
-            {eventGroups.map((group) => (
-              <li key={group.key} className="display-agenda-day">
-                <div className="display-agenda-day-head">
-                  <span className="display-agenda-day-name">
-                    {group.dayLabel}
-                  </span>
-                  <span className="display-agenda-day-date">
-                    {group.subLabel}
-                  </span>
-                </div>
-                <ul className="display-agenda-list">
-                  {group.events.map((ev, idx) => (
-                    <AgendaRow
-                      key={`${group.key}-${idx}`}
-                      event={ev}
-                      now={now}
-                    />
-                  ))}
-                </ul>
+        {config.layout_config.widgets.map((widget) => (
+          <WidgetShell key={widget.id} widget={widget}>
+            {renderWidget(widget.type, widgetContext)}
+          </WidgetShell>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WidgetShell({ widget, children }) {
+  return (
+    <section
+      className={`display-widget display-widget--${widget.type}`}
+      data-testid={`display-widget-${widget.type}`}
+      data-widget-type={widget.type}
+      style={{
+        gridColumn: `${widget.x + 1} / span ${widget.w}`,
+        gridRow: `${widget.y + 1} / span ${widget.h}`,
+      }}
+    >
+      {children}
+    </section>
+  );
+}
+
+function renderWidget(type, context) {
+  switch (type) {
+    case 'identity':
+      return <IdentityCard familyName={context.familyName} deviceName={context.deviceName} />;
+    case 'clock':
+      return <ClockCard timeLabel={context.timeLabel} dateLabel={context.dateLabel} />;
+    case 'focus':
+      return <FocusCard focus={context.focus} />;
+    case 'agenda':
+      return <AgendaCard eventGroups={context.eventGroups} now={context.now} />;
+    case 'birthdays':
+      return <BirthdaysCard celebration={context.celebration} />;
+    case 'members':
+      return <MembersCard members={context.members} imminentNames={context.imminentNames} />;
+    default:
+      return null;
+  }
+}
+
+function IdentityCard({ familyName, deviceName }) {
+  return (
+    <div className="display-card display-identity">
+      <div className="display-hearth-label">
+        <span className="display-hearth-prefix">The</span>
+        <span className="display-hearth-name" data-testid="display-family-name">
+          {familyName || 'Family'}
+        </span>
+        <span className="display-hearth-suffix">Home</span>
+      </div>
+      {deviceName && (
+        <div className="display-device-tag" data-testid="display-device-name">
+          {deviceName}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ClockCard({ timeLabel, dateLabel }) {
+  return (
+    <div className="display-card display-clock-shell" aria-live="off">
+      <div className="display-clock" data-testid="display-time">{timeLabel}</div>
+      <div className="display-date" data-testid="display-date">{dateLabel}</div>
+    </div>
+  );
+}
+
+function AgendaCard({ eventGroups, now }) {
+  return (
+    <div className="display-card display-horizon" data-testid="display-events" aria-live="polite">
+      <header className="display-section-header">
+        <Calendar size={22} aria-hidden="true" />
+        <h2>Family agenda</h2>
+      </header>
+      {eventGroups.length === 0 ? (
+        <EmptyHearth message="The hearth is quiet — nothing scheduled in the next 14 days." />
+      ) : (
+        <ol className="display-agenda">
+          {eventGroups.map((group) => (
+            <li key={group.key} className="display-agenda-day">
+              <div className="display-agenda-day-head">
+                <span className="display-agenda-day-name">{group.dayLabel}</span>
+                <span className="display-agenda-day-date">{group.subLabel}</span>
+              </div>
+              <ul className="display-agenda-list">
+                {group.events.map((ev, idx) => (
+                  <AgendaRow key={`${group.key}-${idx}`} event={ev} now={now} />
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function BirthdaysCard({ celebration }) {
+  return (
+    <div className="display-card display-card-celebration" data-testid="display-birthdays">
+      <header className="display-section-header">
+        <Cake size={22} aria-hidden="true" />
+        <h2>Celebration</h2>
+      </header>
+      {celebration ? (
+        <CelebrationCard birthday={celebration} />
+      ) : (
+        <EmptyHearth tone="soft" message="No birthdays in the next 4 weeks." />
+      )}
+    </div>
+  );
+}
+
+function MembersCard({ members, imminentNames }) {
+  return (
+    <div className="display-card display-card-members" data-testid="display-members">
+      <header className="display-section-header">
+        <Users size={22} aria-hidden="true" />
+        <h2>Family</h2>
+      </header>
+      {members.length > 0 ? (
+        <ul className="display-member-wall">
+          {members.map((m, idx) => {
+            const isCelebrant = imminentNames.has(m.display_name);
+            const tint = sanitizeColor(m.color) || fallbackTint(idx);
+            return (
+              <li
+                key={`${m.display_name}-${idx}`}
+                className={'display-member' + (isCelebrant ? ' display-member--celebrant' : '')}
+                style={{ '--member-tint': tint }}
+                data-testid="display-member"
+              >
+                <span className="display-member-avatar" aria-hidden="true">{initials(m.display_name)}</span>
+                <span className="display-member-name">{m.display_name}</span>
+                {isCelebrant && (
+                  <span className="display-member-badge" aria-label="Birthday soon" title="Birthday soon">🎂</span>
+                )}
               </li>
-            ))}
-          </ol>
-        )}
-      </section>
-
-      <section className="display-tribe">
-        <div
-          className="display-card display-card-celebration"
-          data-testid="display-birthdays"
-        >
-          <header className="display-section-header">
-            <Cake size={22} aria-hidden="true" />
-            <h2>Celebration</h2>
-          </header>
-          {celebration ? (
-            <CelebrationCard birthday={celebration} />
-          ) : (
-            <EmptyHearth
-              tone="soft"
-              message="No birthdays in the next 4 weeks."
-            />
-          )}
-        </div>
-
-        <div
-          className="display-card display-card-members"
-          data-testid="display-members"
-        >
-          <header className="display-section-header">
-            <Users size={22} aria-hidden="true" />
-            <h2>Family</h2>
-          </header>
-          {dashboard.members && dashboard.members.length > 0 ? (
-            <ul className="display-member-wall">
-              {dashboard.members.map((m, idx) => {
-                const isCelebrant = imminentNames.has(m.display_name);
-                const tint = sanitizeColor(m.color) || fallbackTint(idx);
-                return (
-                  <li
-                    key={`${m.display_name}-${idx}`}
-                    className={
-                      'display-member' +
-                      (isCelebrant ? ' display-member--celebrant' : '')
-                    }
-                    style={{ '--member-tint': tint }}
-                    data-testid="display-member"
-                  >
-                    <span className="display-member-avatar" aria-hidden="true">
-                      {initials(m.display_name)}
-                    </span>
-                    <span className="display-member-name">
-                      {m.display_name}
-                    </span>
-                    {isCelebrant && (
-                      <span
-                        className="display-member-badge"
-                        aria-label="Birthday soon"
-                        title="Birthday soon"
-                      >
-                        🎂
-                      </span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          ) : (
-            <EmptyHearth
-              tone="soft"
-              message="No family members yet."
-            />
-          )}
-        </div>
-      </section>
+            );
+          })}
+        </ul>
+      ) : (
+        <EmptyHearth tone="soft" message="No family members yet." />
+      )}
     </div>
   );
 }
@@ -282,6 +314,65 @@ function EmptyHearth({ message, tone = 'default' }) {
       <span>{message}</span>
     </div>
   );
+}
+
+const ALLOWED_WIDGETS = new Set(['identity', 'clock', 'focus', 'agenda', 'birthdays', 'members']);
+const DEFAULT_LAYOUT_CONFIG = {
+  columns: 4,
+  rows: 3,
+  widgets: [
+    { id: 'identity', type: 'identity', x: 0, y: 0, w: 1, h: 1 },
+    { id: 'clock', type: 'clock', x: 0, y: 1, w: 1, h: 1 },
+    { id: 'focus', type: 'focus', x: 0, y: 2, w: 1, h: 1 },
+    { id: 'agenda', type: 'agenda', x: 1, y: 0, w: 2, h: 3 },
+    { id: 'birthdays', type: 'birthdays', x: 3, y: 0, w: 1, h: 1 },
+    { id: 'members', type: 'members', x: 3, y: 1, w: 1, h: 2 },
+  ],
+};
+
+function normalizeDisplayConfig(config) {
+  const mode = config?.display_mode === 'eink' ? 'eink' : 'tablet';
+  const preset = typeof config?.layout_preset === 'string' && config.layout_preset.trim()
+    ? config.layout_preset.trim()
+    : mode === 'eink' ? 'eink_compact' : 'hearth';
+  return {
+    display_mode: mode,
+    refresh_interval_seconds: Number.isFinite(Number(config?.refresh_interval_seconds))
+      ? Number(config.refresh_interval_seconds)
+      : mode === 'eink' ? 900 : 60,
+    layout_preset: preset,
+    layout_config: normalizeLayoutConfig(config?.layout_config),
+  };
+}
+
+function normalizeLayoutConfig(layoutConfig) {
+  const columns = clampInt(layoutConfig?.columns, 1, 6, DEFAULT_LAYOUT_CONFIG.columns);
+  const rows = clampInt(layoutConfig?.rows, 1, 6, DEFAULT_LAYOUT_CONFIG.rows);
+  const sourceWidgets = Array.isArray(layoutConfig?.widgets)
+    ? layoutConfig.widgets
+    : DEFAULT_LAYOUT_CONFIG.widgets;
+  const widgets = sourceWidgets
+    .map((widget, idx) => normalizeWidget(widget, idx, columns, rows))
+    .filter(Boolean);
+  return { columns, rows, widgets: widgets.length ? widgets : DEFAULT_LAYOUT_CONFIG.widgets };
+}
+
+function normalizeWidget(widget, idx, columns, rows) {
+  if (!widget || !ALLOWED_WIDGETS.has(widget.type)) return null;
+  const x = clampInt(widget.x, 0, columns - 1, 0);
+  const y = clampInt(widget.y, 0, rows - 1, idx % rows);
+  const w = clampInt(widget.w, 1, columns - x, 1);
+  const h = clampInt(widget.h, 1, rows - y, 1);
+  const id = typeof widget.id === 'string' && widget.id.trim()
+    ? widget.id.trim().replace(/[^a-z0-9_-]/gi, '').slice(0, 40)
+    : `${widget.type}-${idx}`;
+  return { id: id || `${widget.type}-${idx}`, type: widget.type, x, y, w, h };
+}
+
+function clampInt(value, min, max, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
 }
 
 const HOUR_MS = 60 * 60 * 1000;

--- a/frontend/components/admin/DisplaysSection.js
+++ b/frontend/components/admin/DisplaysSection.js
@@ -24,6 +24,10 @@ export default function DisplaysSection() {
   const [devices, setDevices] = useState([]);
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
+  const [newMode, setNewMode] = useState('tablet');
+  const [newPreset, setNewPreset] = useState('hearth');
+  const [newRefresh, setNewRefresh] = useState(60);
+  const [deviceDrafts, setDeviceDrafts] = useState({});
   const [created, setCreated] = useState(null); // { token, device, displayUrl }
   const [copied, setCopied] = useState(false);
   const [confirmAction, setConfirmAction] = useState(null);
@@ -31,7 +35,10 @@ export default function DisplaysSection() {
   const load = useCallback(async () => {
     if (demoMode) return;
     const { ok, data } = await api.apiListDisplayDevices(familyId);
-    if (ok) setDevices(data);
+    if (ok) {
+      setDevices(data);
+      setDeviceDrafts(Object.fromEntries((data || []).map((device) => [device.id, deviceToDraft(device)])));
+    }
   }, [familyId, demoMode]);
 
   useEffect(() => { load(); }, [load]);
@@ -44,7 +51,12 @@ export default function DisplaysSection() {
   async function handleCreate(e) {
     e.preventDefault();
     if (!newName.trim()) return;
-    const { ok, data } = await api.apiCreateDisplayDevice(familyId, newName.trim());
+    const { ok, data } = await api.apiCreateDisplayDevice(familyId, {
+      name: newName.trim(),
+      display_mode: newMode,
+      layout_preset: newPreset,
+      refresh_interval_seconds: Number(newRefresh),
+    });
     if (!ok) {
       toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
       return;
@@ -55,8 +67,36 @@ export default function DisplaysSection() {
       displayUrl: buildDisplayUrl(data.token),
     });
     setShowCreate(false);
-    setNewName('');
+    resetCreateForm();
     setCopied(false);
+    await load();
+  }
+
+  function resetCreateForm() {
+    setNewName('');
+    setNewMode('tablet');
+    setNewPreset('hearth');
+    setNewRefresh(60);
+  }
+
+  function updateDraft(deviceId, patch) {
+    setDeviceDrafts((current) => ({
+      ...current,
+      [deviceId]: { ...(current[deviceId] || {}), ...patch },
+    }));
+  }
+
+  async function handleSaveDevice(device) {
+    const draft = deviceDrafts[device.id] || deviceToDraft(device);
+    const { ok, data } = await api.apiUpdateDisplayDevice(familyId, device.id, {
+      display_mode: draft.display_mode,
+      layout_preset: draft.layout_preset,
+      refresh_interval_seconds: Number(draft.refresh_interval_seconds),
+    });
+    if (!ok) {
+      toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
+      return;
+    }
     await load();
   }
 
@@ -164,7 +204,16 @@ export default function DisplaysSection() {
                     ? t(messages, 'display_last_used').replace('{when}', new Date(device.last_used_at).toLocaleString())
                     : t(messages, 'display_never_used')}
                   {' · '}{t(messages, 'display_created').replace('{when}', new Date(device.created_at).toLocaleDateString())}
+                  {' · '}{displayModeLabel(device.display_mode, messages)} · {layoutPresetLabel(device.layout_preset, messages)} · {device.refresh_interval_seconds || 60}s
                 </div>
+                {!device.revoked_at && (
+                  <DisplayConfigControls
+                    draft={deviceDrafts[device.id] || deviceToDraft(device)}
+                    messages={messages}
+                    onChange={(patch) => updateDraft(device.id, patch)}
+                    onSave={() => handleSaveDevice(device)}
+                  />
+                )}
               </div>
               {!device.revoked_at && (
                 <button
@@ -199,6 +248,18 @@ export default function DisplaysSection() {
                   />
                   <small className="invite-helper-text">{t(messages, 'display_name_helper')}</small>
                 </div>
+                <DisplayConfigControls
+                  draft={{ display_mode: newMode, layout_preset: newPreset, refresh_interval_seconds: newRefresh }}
+                  messages={messages}
+                  onChange={(patch) => {
+                    if (patch.display_mode) {
+                      setNewMode(patch.display_mode);
+                      if (patch.display_mode === 'eink' && newPreset === 'hearth') setNewPreset('eink_compact');
+                    }
+                    if (patch.layout_preset) setNewPreset(patch.layout_preset);
+                    if (patch.refresh_interval_seconds) setNewRefresh(Number(patch.refresh_interval_seconds));
+                  }}
+                />
                 <div className="set-btn-row">
                   <button type="submit" className="btn-sm" data-testid="display-create-submit">
                     <Monitor size={14} /> {t(messages, 'display_create')}
@@ -206,7 +267,7 @@ export default function DisplaysSection() {
                   <button
                     type="button"
                     className="btn-ghost"
-                    onClick={() => { setShowCreate(false); setNewName(''); }}
+                    onClick={() => { setShowCreate(false); resetCreateForm(); }}
                   >
                     {t(messages, 'cancel')}
                   </button>
@@ -225,5 +286,77 @@ export default function DisplaysSection() {
         </div>
       )}
     </>
+  );
+}
+
+const DISPLAY_MODES = ['tablet', 'eink'];
+const LAYOUT_PRESETS = ['hearth', 'agenda_first', 'family_board', 'eink_compact', 'eink_agenda'];
+
+function deviceToDraft(device) {
+  return {
+    display_mode: device.display_mode || 'tablet',
+    layout_preset: device.layout_preset || 'hearth',
+    refresh_interval_seconds: device.refresh_interval_seconds || (device.display_mode === 'eink' ? 900 : 60),
+  };
+}
+
+function displayModeLabel(mode, messages) {
+  return mode === 'eink' ? t(messages, 'display_mode_eink') : t(messages, 'display_mode_tablet');
+}
+
+function layoutPresetLabel(preset, messages) {
+  return t(messages, `display_layout_${preset || 'hearth'}`);
+}
+
+function DisplayConfigControls({ draft, messages, onChange, onSave = null }) {
+  return (
+    <div className="adm-form-grid" data-testid="display-config-controls">
+      <div className="form-field">
+        <label>{t(messages, 'display_mode_label')}</label>
+        <select
+          className="form-input"
+          value={draft.display_mode}
+          onChange={(e) => onChange({ display_mode: e.target.value })}
+          data-testid="display-mode-select"
+        >
+          {DISPLAY_MODES.map((mode) => (
+            <option key={mode} value={mode}>{displayModeLabel(mode, messages)}</option>
+          ))}
+        </select>
+      </div>
+      <div className="form-field">
+        <label>{t(messages, 'display_layout_label')}</label>
+        <select
+          className="form-input"
+          value={draft.layout_preset}
+          onChange={(e) => onChange({ layout_preset: e.target.value })}
+          data-testid="display-layout-select"
+        >
+          {LAYOUT_PRESETS.map((preset) => (
+            <option key={preset} value={preset}>{layoutPresetLabel(preset, messages)}</option>
+          ))}
+        </select>
+      </div>
+      <div className="form-field">
+        <label>{t(messages, 'display_refresh_label')}</label>
+        <input
+          className="form-input"
+          type="number"
+          min={draft.display_mode === 'eink' ? 300 : 30}
+          max={draft.display_mode === 'eink' ? 86400 : 3600}
+          value={draft.refresh_interval_seconds}
+          onChange={(e) => onChange({ refresh_interval_seconds: e.target.value })}
+          data-testid="display-refresh-input"
+        />
+        <small className="invite-helper-text">{t(messages, 'display_refresh_helper')}</small>
+      </div>
+      {onSave && (
+        <div className="set-btn-row">
+          <button type="button" className="btn-sm" onClick={onSave} data-testid="display-save-config">
+            {t(messages, 'save')}
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/e2e/tests/display.spec.js
+++ b/frontend/e2e/tests/display.spec.js
@@ -1,9 +1,9 @@
 const { test, expect } = require('../helpers/fixtures');
 const { getFamilyId, seedCalendarEvent } = require('../helpers/api-setup');
 
-async function createDisplayDevice(request, familyId, name = 'Kitchen Display') {
+async function createDisplayDevice(request, familyId, name = 'Kitchen Display', config = {}) {
   const res = await request.post(`/api/families/${familyId}/display-devices`, {
-    data: { name },
+    data: { name, ...config },
   });
   if (!res.ok()) {
     throw new Error(`POST /api/families/${familyId}/display-devices failed (${res.status()}): ${await res.text()}`);
@@ -15,6 +15,14 @@ async function revokeDisplayDevice(request, familyId, deviceId) {
   const res = await request.delete(`/api/families/${familyId}/display-devices/${deviceId}`);
   if (!res.ok()) {
     throw new Error(`DELETE /api/families/${familyId}/display-devices/${deviceId} failed (${res.status()}): ${await res.text()}`);
+  }
+}
+
+async function gotoDisplayWithToken(page, token) {
+  try {
+    await page.goto(`/display?token=${encodeURIComponent(token)}`, { waitUntil: 'domcontentloaded' });
+  } catch (error) {
+    if (!String(error).includes('ERR_ABORTED')) throw error;
   }
 }
 
@@ -30,7 +38,7 @@ test.describe('Display mode', () => {
       if (url.includes('/api/')) requested.push(url);
     });
 
-    await page.goto(`/display?token=${encodeURIComponent(created.token)}`);
+    await gotoDisplayWithToken(page, created.token);
 
     await expect(page.getByTestId('display-dashboard')).toBeVisible({ timeout: 15000 });
     await expect(page.getByTestId('display-device-name')).toContainText('Kitchen Tablet');
@@ -75,6 +83,33 @@ test.describe('Display mode', () => {
     await expect(page.getByTestId('display-family-name')).toBeVisible();
   });
 
+  test('renders an e-ink display with the configured layout preset', async ({ page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedCalendarEvent(apiCtx, familyId, { title: 'Morning Agenda' });
+    const created = await createDisplayDevice(apiCtx, familyId, 'Kitchen E-Ink', {
+      display_mode: 'eink',
+      layout_preset: 'eink_agenda',
+      refresh_interval_seconds: 900,
+      layout_config: {
+        columns: 4,
+        rows: 3,
+        widgets: [
+          { id: 'identity', type: 'identity', x: 0, y: 0, w: 2, h: 1 },
+          { id: 'agenda-large', type: 'agenda', x: 0, y: 1, w: 4, h: 2 },
+        ],
+      },
+    });
+
+    await gotoDisplayWithToken(page, created.token);
+
+    const dashboard = page.getByTestId('display-dashboard');
+    await expect(dashboard).toBeVisible({ timeout: 15000 });
+    await expect(dashboard).toHaveAttribute('data-display-mode', 'eink');
+    await expect(dashboard).toHaveAttribute('data-layout-preset', 'eink_agenda');
+    await expect(page.getByTestId('display-widget-agenda')).toHaveCSS('grid-column-start', '1');
+    await expect(page.getByTestId('display-events')).toContainText('Morning Agenda');
+  });
+
   test('shows a revoked-device state instead of falling back to a user session', async ({ page, apiCtx }) => {
     const familyId = await getFamilyId(apiCtx);
     const created = await createDisplayDevice(apiCtx, familyId, 'Hallway Display');
@@ -86,7 +121,7 @@ test.describe('Display mode', () => {
       if (url.includes('/api/auth/me')) authMeRequests.push(url);
     });
 
-    await page.goto(`/display?token=${encodeURIComponent(created.token)}`);
+    await gotoDisplayWithToken(page, created.token);
 
     await expect(page.getByTestId('display-state-revoked')).toBeVisible({ timeout: 15000 });
     await expect(page.getByText('This display has been removed by an admin.')).toBeVisible();

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -543,5 +543,16 @@
   "display_revoke_confirm": "Display \"{name}\" wirklich entfernen? Die Anzeige wird sofort beendet.",
   "display_last_used": "Zuletzt aktiv: {when}",
   "display_never_used": "Noch nicht genutzt",
-  "display_created": "Hinzugefügt: {when}"
+  "display_created": "Hinzugefügt: {when}",
+  "display_mode_label": "Display-Modus",
+  "display_mode_tablet": "Tablet",
+  "display_mode_eink": "E-Ink",
+  "display_layout_label": "Layout-Vorlage",
+  "display_layout_hearth": "Hearth",
+  "display_layout_agenda_first": "Agenda zuerst",
+  "display_layout_family_board": "Family Board",
+  "display_layout_eink_compact": "E-Ink kompakt",
+  "display_layout_eink_agenda": "E-Ink Agenda",
+  "display_refresh_label": "Aktualisierungsintervall",
+  "display_refresh_helper": "Sekunden. E-Ink wird auf schonende, langsamere Aktualisierung begrenzt."
 }

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -543,5 +543,16 @@
   "display_revoke_confirm": "Remove the display \"{name}\"? It will stop showing your dashboard immediately.",
   "display_last_used": "Last used: {when}",
   "display_never_used": "Never used",
-  "display_created": "Added: {when}"
+  "display_created": "Added: {when}",
+  "display_mode_label": "Display mode",
+  "display_mode_tablet": "Tablet",
+  "display_mode_eink": "E-Ink",
+  "display_layout_label": "Layout preset",
+  "display_layout_hearth": "Hearth",
+  "display_layout_agenda_first": "Agenda first",
+  "display_layout_family_board": "Family board",
+  "display_layout_eink_compact": "E-Ink compact",
+  "display_layout_eink_agenda": "E-Ink agenda",
+  "display_refresh_label": "Refresh interval",
+  "display_refresh_helper": "Seconds. E-Ink mode is clamped to slower, panel-friendly refreshes."
 }

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -605,8 +605,13 @@ export function apiListDisplayDevices(familyId) {
   return request(`/families/${familyId}/display-devices`);
 }
 
-export function apiCreateDisplayDevice(familyId, name) {
-  return post(`/families/${familyId}/display-devices`, { name });
+export function apiCreateDisplayDevice(familyId, payload) {
+  const body = typeof payload === 'string' ? { name: payload } : payload;
+  return post(`/families/${familyId}/display-devices`, body);
+}
+
+export function apiUpdateDisplayDevice(familyId, deviceId, payload) {
+  return patch(`/families/${familyId}/display-devices/${deviceId}`, payload);
 }
 
 export function apiRevokeDisplayDevice(familyId, deviceId) {

--- a/frontend/pages/display.js
+++ b/frontend/pages/display.js
@@ -5,7 +5,9 @@ import DisplayDashboard from '../components/DisplayDashboard';
 import { apiDisplayMe, apiDisplayDashboard } from '../lib/api';
 
 const TOKEN_STORAGE_KEY = 'tribu_display_token';
-const REFRESH_INTERVAL_MS = 60 * 1000;
+const DEFAULT_REFRESH_INTERVAL_MS = 60 * 1000;
+const MIN_REFRESH_INTERVAL_MS = 30 * 1000;
+const MAX_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Shared-home display page (issue #172).
@@ -96,12 +98,14 @@ export default function DisplayPage() {
     setState('ready');
   }, []);
 
+  const refreshIntervalMs = getRefreshIntervalMs(dashboard?.config || me?.config);
+
   useEffect(() => {
     if (!token) return undefined;
     refresh(token);
-    const id = setInterval(() => { refresh(token); }, REFRESH_INTERVAL_MS);
+    const id = setInterval(() => { refresh(token); }, refreshIntervalMs);
     return () => clearInterval(id);
-  }, [token, refresh]);
+  }, [token, refresh, refreshIntervalMs]);
 
   return (
     <>
@@ -149,4 +153,11 @@ export default function DisplayPage() {
       </main>
     </>
   );
+}
+
+function getRefreshIntervalMs(config) {
+  const seconds = Number(config?.refresh_interval_seconds);
+  if (!Number.isFinite(seconds)) return DEFAULT_REFRESH_INTERVAL_MS;
+  const ms = Math.round(seconds * 1000);
+  return Math.min(MAX_REFRESH_INTERVAL_MS, Math.max(MIN_REFRESH_INTERVAL_MS, ms));
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2402,15 +2402,33 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   background: radial-gradient(800px 500px at 50% 50%, rgba(239, 68, 68, 0.12), transparent 70%);
 }
 
-/* ─── Three-column dashboard grid ─── */
+/* ─── Configurable dashboard grid ─── */
 .display-dashboard {
-  display: grid;
-  grid-template-columns: minmax(280px, 1fr) minmax(420px, 2fr) minmax(280px, 1fr);
-  gap: 1.5rem;
   padding: 1.5rem;
   height: 100%;
   width: 100%;
   box-sizing: border-box;
+}
+
+.display-layout-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--display-grid-columns, 4), minmax(0, 1fr));
+  grid-template-rows: repeat(var(--display-grid-rows, 3), minmax(0, 1fr));
+  gap: 1.5rem;
+  height: 100%;
+  width: 100%;
+}
+
+.display-widget {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+}
+
+.display-widget > .display-card {
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
 }
 
 .display-pulse,
@@ -2770,18 +2788,84 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 /* ─── Portrait & narrow viewports ─── */
 @media (max-width: 1024px), (orientation: portrait) {
   .display-dashboard {
-    grid-template-columns: 1fr;
-    grid-auto-rows: min-content;
-    gap: 1.25rem;
     padding: 1.25rem;
     overflow-y: auto;
     height: auto;
     min-height: 100vh;
   }
+  .display-layout-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    height: auto;
+  }
+  .display-widget {
+    display: flex;
+  }
   .display-horizon { overflow: visible; }
   .display-agenda { overflow: visible; max-height: none; }
   .display-clock { font-size: clamp(3rem, 14vw, 5rem); }
   .display-card { padding: 1.25rem; }
+}
+
+/* ─── E-ink mode: high contrast, static, no glass/gradient dependency ─── */
+.display-dashboard--eink {
+  background: #fff;
+  color: #000;
+}
+.display-dashboard--eink .display-layout-grid {
+  gap: 1rem;
+}
+.display-dashboard--eink .display-card {
+  background: #fff;
+  border: 2px solid #000;
+  border-radius: 8px;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+.display-dashboard--eink .display-hearth-name,
+.display-dashboard--eink .display-clock,
+.display-dashboard--eink .display-date,
+.display-dashboard--eink .display-focus-title,
+.display-dashboard--eink .display-agenda-day-name,
+.display-dashboard--eink .display-agenda-when,
+.display-dashboard--eink .display-agenda-title,
+.display-dashboard--eink .display-member-name,
+.display-dashboard--eink .display-celebration-name {
+  color: #000;
+  background: none;
+  text-shadow: none;
+  -webkit-background-clip: initial;
+  background-clip: initial;
+}
+.display-dashboard--eink .display-section-header,
+.display-dashboard--eink .display-section-header h2,
+.display-dashboard--eink .display-date,
+.display-dashboard--eink .display-focus-meta,
+.display-dashboard--eink .display-agenda-day-date,
+.display-dashboard--eink .display-agenda-category,
+.display-dashboard--eink .display-device-tag,
+.display-dashboard--eink .display-empty,
+.display-dashboard--eink .display-celebration-when {
+  color: #111;
+}
+.display-dashboard--eink .display-focus,
+.display-dashboard--eink .display-agenda-row,
+.display-dashboard--eink .display-agenda-row--live {
+  background: #fff;
+  border-left-color: #000;
+}
+.display-dashboard--eink .display-member-avatar {
+  color: #fff;
+  background: #000;
+  border-color: #000;
+  box-shadow: none;
+}
+.display-dashboard--eink .display-focus--live,
+.display-dashboard--eink .display-agenda-row--live,
+.display-dashboard--eink .display-member--celebrant .display-member-avatar {
+  animation: none;
 }
 
 /* ─── Reduced motion (kiosk accessibility) ─── */


### PR DESCRIPTION
## Summary
- Adds per-device Shared Home Display configuration for tablet and e-ink modes
- Adds validated layout presets with bounded, whitelisted widget slots
- Lets family admins configure display mode, layout preset, and refresh cadence without exposing a personal account on shared hardware

## Validation
- Backend display tests: `18 passed`
- Targeted frontend Jest: `3 suites passed`, `23 tests passed`
- Frontend build: successful
- Resource-safe Playwright by spec file: `62 passed`
- Claude review: approved
- Codex review: approved
