### PR TITLE
feat(display): add shared display layout composer

### DIFF
--- a/backend/app/core/display_layouts.py
+++ b/backend/app/core/display_layouts.py
@@ -19,7 +19,10 @@ DEFAULT_REFRESH = {
     MODE_EINK: 900,
 }
 
-ALLOWED_WIDGETS = {"identity", "clock", "focus", "agenda", "birthdays", "members"}
+# `home_header` is a combined home-title/clock/date widget. The legacy
+# `identity` and `clock` widgets stay whitelisted so devices configured
+# before the composer keep rendering exactly as they did.
+ALLOWED_WIDGETS = {"home_header", "identity", "clock", "focus", "agenda", "birthdays", "members"}
 GRID_MAX_COLUMNS = 6
 GRID_MAX_ROWS = 6
 
@@ -30,8 +33,7 @@ PRESETS: dict[str, dict[str, Any]] = {
             "columns": 3,
             "rows": 3,
             "widgets": [
-                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
-                {"type": "clock", "x": 0, "y": 1, "w": 1, "h": 1},
+                {"type": "home_header", "x": 0, "y": 0, "w": 1, "h": 2},
                 {"type": "focus", "x": 0, "y": 2, "w": 1, "h": 1},
                 {"type": "agenda", "x": 1, "y": 0, "w": 1, "h": 3},
                 {"type": "birthdays", "x": 2, "y": 0, "w": 1, "h": 1},
@@ -46,8 +48,7 @@ PRESETS: dict[str, dict[str, Any]] = {
             "rows": 3,
             "widgets": [
                 {"type": "agenda", "x": 0, "y": 0, "w": 2, "h": 3},
-                {"type": "identity", "x": 2, "y": 0, "w": 1, "h": 1},
-                {"type": "clock", "x": 2, "y": 1, "w": 1, "h": 1},
+                {"type": "home_header", "x": 2, "y": 0, "w": 1, "h": 2},
                 {"type": "birthdays", "x": 2, "y": 2, "w": 1, "h": 1},
             ],
         },
@@ -58,9 +59,8 @@ PRESETS: dict[str, dict[str, Any]] = {
             "columns": 3,
             "rows": 3,
             "widgets": [
-                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+                {"type": "home_header", "x": 0, "y": 0, "w": 1, "h": 2},
                 {"type": "members", "x": 1, "y": 0, "w": 2, "h": 2},
-                {"type": "clock", "x": 0, "y": 1, "w": 1, "h": 1},
                 {"type": "agenda", "x": 0, "y": 2, "w": 2, "h": 1},
                 {"type": "birthdays", "x": 2, "y": 2, "w": 1, "h": 1},
             ],
@@ -72,8 +72,7 @@ PRESETS: dict[str, dict[str, Any]] = {
             "columns": 2,
             "rows": 3,
             "widgets": [
-                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
-                {"type": "clock", "x": 1, "y": 0, "w": 1, "h": 1},
+                {"type": "home_header", "x": 0, "y": 0, "w": 2, "h": 1},
                 {"type": "agenda", "x": 0, "y": 1, "w": 2, "h": 1},
                 {"type": "birthdays", "x": 0, "y": 2, "w": 1, "h": 1},
                 {"type": "members", "x": 1, "y": 2, "w": 1, "h": 1},
@@ -86,7 +85,7 @@ PRESETS: dict[str, dict[str, Any]] = {
             "columns": 1,
             "rows": 3,
             "widgets": [
-                {"type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+                {"type": "home_header", "x": 0, "y": 0, "w": 1, "h": 1},
                 {"type": "agenda", "x": 0, "y": 1, "w": 1, "h": 1},
                 {"type": "birthdays", "x": 0, "y": 2, "w": 1, "h": 1},
             ],

--- a/backend/tests/test_display_devices.py
+++ b/backend/tests/test_display_devices.py
@@ -506,8 +506,7 @@ class TestDisplayRenderConfig:
         assert config["layout_preset"] == "eink_compact"
         assert config["layout_config"]["columns"] == 2
         assert [widget["type"] for widget in config["layout_config"]["widgets"]] == [
-            "identity",
-            "clock",
+            "home_header",
             "agenda",
             "birthdays",
             "members",
@@ -529,3 +528,128 @@ class TestDisplayRenderConfig:
             headers=_auth(member_token),
         )
         assert update.status_code == 403
+
+
+class TestHomeHeaderWidget:
+    """`home_header` is a combined identity+clock widget that adapts to slot size.
+
+    Whitelisting it server-side is the boundary that keeps invalid layout
+    payloads from reaching the wall display. Existing devices configured with
+    the legacy ``clock`` widget must keep rendering — backward compatibility
+    is preserved through normalization, not silent stripping.
+    """
+
+    def test_home_header_is_an_allowed_widget_type(self):
+        """A custom layout posted by an admin must keep `home_header` widgets."""
+        admin_token, _, family_id = _seed_member_with_pat("hhAllow", role="admin", is_adult=True)
+        resp = client.post(
+            f"/families/{family_id}/display-devices",
+            json={
+                "name": "Hero",
+                "display_mode": "tablet",
+                "layout_preset": "hearth",
+                "layout_config": {
+                    "columns": 3,
+                    "rows": 3,
+                    "widgets": [
+                        {"id": "hdr", "type": "home_header", "x": 0, "y": 0, "w": 2, "h": 1},
+                        {"id": "agenda", "type": "agenda", "x": 0, "y": 1, "w": 3, "h": 2},
+                    ],
+                },
+            },
+            headers=_auth(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        widgets = resp.json()["device"]["layout_config"]["widgets"]
+        assert {w["type"] for w in widgets} == {"home_header", "agenda"}
+        header = next(w for w in widgets if w["type"] == "home_header")
+        assert (header["w"], header["h"]) == (2, 1)
+
+    def test_home_header_replaces_identity_and_clock_in_default_presets(self):
+        """The default tablet preset (hearth) merges identity+clock into one home_header."""
+        admin_token, _, family_id = _seed_member_with_pat("hhPreset", role="admin", is_adult=True)
+        create = client.post(
+            f"/families/{family_id}/display-devices",
+            json={"name": "Wall", "layout_preset": "hearth"},
+            headers=_auth(admin_token),
+        )
+        assert create.status_code == 200, create.text
+        widgets = create.json()["device"]["layout_config"]["widgets"]
+        widget_types = [w["type"] for w in widgets]
+        assert "home_header" in widget_types, widget_types
+        # identity/clock are no longer separate widgets in the default tablet preset.
+        assert "identity" not in widget_types
+        assert "clock" not in widget_types
+
+    def test_legacy_clock_and_identity_widgets_are_still_accepted(self):
+        """Devices configured before home_header (with clock/identity) keep rendering."""
+        admin_token, _, family_id = _seed_member_with_pat("hhLegacy", role="admin", is_adult=True)
+        resp = client.post(
+            f"/families/{family_id}/display-devices",
+            json={
+                "name": "Legacy",
+                "layout_preset": "hearth",
+                "layout_config": {
+                    "columns": 2,
+                    "rows": 2,
+                    "widgets": [
+                        {"id": "id", "type": "identity", "x": 0, "y": 0, "w": 1, "h": 1},
+                        {"id": "ck", "type": "clock", "x": 1, "y": 0, "w": 1, "h": 1},
+                        {"id": "ag", "type": "agenda", "x": 0, "y": 1, "w": 2, "h": 1},
+                    ],
+                },
+            },
+            headers=_auth(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        widgets = resp.json()["device"]["layout_config"]["widgets"]
+        widget_types = {w["type"] for w in widgets}
+        # All three legacy types pass normalization unchanged.
+        assert widget_types == {"identity", "clock", "agenda"}
+
+    def test_unknown_widget_types_are_still_dropped(self):
+        """Adding home_header must not loosen the widget whitelist."""
+        admin_token, _, family_id = _seed_member_with_pat("hhStrict", role="admin", is_adult=True)
+        resp = client.post(
+            f"/families/{family_id}/display-devices",
+            json={
+                "name": "Strict",
+                "layout_preset": "hearth",
+                "layout_config": {
+                    "columns": 2,
+                    "rows": 2,
+                    "widgets": [
+                        {"id": "ok", "type": "home_header", "x": 0, "y": 0, "w": 2, "h": 1},
+                        {"id": "bad", "type": "iframe", "x": 0, "y": 1, "w": 1, "h": 1},
+                        {"id": "evil", "type": "<script>", "x": 1, "y": 1, "w": 1, "h": 1},
+                    ],
+                },
+            },
+            headers=_auth(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        types = [w["type"] for w in resp.json()["device"]["layout_config"]["widgets"]]
+        assert types == ["home_header"]
+
+    def test_home_header_out_of_bounds_widget_is_dropped(self):
+        """home_header with a span exceeding the grid is dropped, not clamped."""
+        admin_token, _, family_id = _seed_member_with_pat("hhBounds", role="admin", is_adult=True)
+        resp = client.post(
+            f"/families/{family_id}/display-devices",
+            json={
+                "name": "OOB",
+                "layout_preset": "hearth",
+                "layout_config": {
+                    "columns": 2,
+                    "rows": 2,
+                    "widgets": [
+                        {"id": "oob", "type": "home_header", "x": 0, "y": 0, "w": 99, "h": 99},
+                        {"id": "ag", "type": "agenda", "x": 0, "y": 0, "w": 2, "h": 2},
+                    ],
+                },
+            },
+            headers=_auth(admin_token),
+        )
+        assert resp.status_code == 200, resp.text
+        types = [w["type"] for w in resp.json()["device"]["layout_config"]["widgets"]]
+        assert types == ["agenda"]

--- a/frontend/__tests__/components/DisplayDashboard.test.js
+++ b/frontend/__tests__/components/DisplayDashboard.test.js
@@ -274,6 +274,101 @@ describe('DisplayDashboard — privacy + chrome isolation', () => {
 });
 
 
+describe('DisplayDashboard — home_header widget', () => {
+  function fixedTime() {
+    return new Date('2026-04-27T08:30:00');
+  }
+
+  function withHomeHeader(extra = {}, w = 1, h = 2, columns = 3, rows = 3) {
+    return buildDashboard({
+      ...extra,
+      config: {
+        display_mode: 'tablet',
+        layout_preset: 'hearth',
+        layout_config: {
+          columns,
+          rows,
+          widgets: [
+            { id: 'hdr', type: 'home_header', x: 0, y: 0, w, h },
+          ],
+        },
+      },
+    });
+  }
+
+  test('renders the family hearth name and a clock inside one widget', () => {
+    renderWithFixedNow(withHomeHeader(), fixedTime());
+
+    const header = screen.getByTestId('display-widget-home_header');
+    expect(within(header).getByTestId('display-family-name')).toHaveTextContent('Mueller');
+    expect(within(header).getByTestId('display-time').textContent).toMatch(/\d{1,2}:\d{2}/);
+    // The standalone identity/clock widgets must NOT appear when only home_header is configured.
+    expect(screen.queryByTestId('display-widget-identity')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('display-widget-clock')).not.toBeInTheDocument();
+  });
+
+  test('compact density (single-cell slot) shows only the time + date', () => {
+    renderWithFixedNow(withHomeHeader({}, 1, 1, 4, 4), fixedTime());
+
+    const header = screen.getByTestId('display-widget-home_header');
+    expect(header).toHaveAttribute('data-density', 'compact');
+    // Compact suppresses the family hearth name to keep the slot legible.
+    expect(within(header).queryByTestId('display-family-name')).not.toBeInTheDocument();
+    expect(within(header).getByTestId('display-time')).toBeInTheDocument();
+    expect(within(header).getByTestId('display-date')).toBeInTheDocument();
+    // Compact does NOT render the today event list.
+    expect(within(header).queryByTestId('display-home-header-events')).not.toBeInTheDocument();
+  });
+
+  test('standard density shows title + time + date + a today count cue', () => {
+    const today = new Date('2026-04-27T18:00:00');
+    const dashboard = {
+      ...withHomeHeader({
+        next_events: [
+          { title: 'Soccer', starts_at: isoLocal(today), ends_at: null, all_day: false, color: null, category: null },
+          { title: 'Dinner', starts_at: isoLocal(new Date('2026-04-27T20:00:00')), ends_at: null, all_day: false, color: null, category: null },
+        ],
+      }, 1, 2, 4, 4),
+    };
+    renderWithFixedNow(dashboard, fixedTime());
+
+    const header = screen.getByTestId('display-widget-home_header');
+    expect(header).toHaveAttribute('data-density', 'standard');
+    expect(within(header).getByTestId('display-family-name')).toHaveTextContent('Mueller');
+    expect(within(header).getByTestId('display-time').textContent).toMatch(/\d{1,2}:\d{2}/);
+    // Today cue is the count, not a full event list.
+    const cue = within(header).getByTestId('display-home-header-today-cue');
+    expect(cue).toHaveTextContent(/2/);
+    expect(within(header).queryByTestId('display-home-header-events')).not.toBeInTheDocument();
+  });
+
+  test('expanded density shows the next-up event list inside the header', () => {
+    const dashboard = withHomeHeader({
+      next_events: [
+        { title: 'Soccer practice', starts_at: isoLocal(new Date('2026-04-27T18:00:00')), ends_at: null, all_day: false, color: null, category: null },
+        { title: 'Dentist', starts_at: isoLocal(new Date('2026-04-28T09:00:00')), ends_at: null, all_day: false, color: null, category: null },
+      ],
+    }, 2, 3, 4, 4);
+    renderWithFixedNow(dashboard, fixedTime());
+
+    const header = screen.getByTestId('display-widget-home_header');
+    expect(header).toHaveAttribute('data-density', 'expanded');
+    const events = within(header).getByTestId('display-home-header-events');
+    expect(within(events).getByText('Soccer practice')).toBeInTheDocument();
+    expect(within(events).getByText('Dentist')).toBeInTheDocument();
+  });
+
+  test('expanded density with no events shows a quiet message', () => {
+    renderWithFixedNow(withHomeHeader({ next_events: [] }, 2, 3, 4, 4), fixedTime());
+
+    const header = screen.getByTestId('display-widget-home_header');
+    expect(header).toHaveAttribute('data-density', 'expanded');
+    const events = within(header).getByTestId('display-home-header-events');
+    expect(events).toHaveTextContent(/no events/i);
+  });
+});
+
+
 describe('DisplayDashboard — configurable display layouts', () => {
   test('applies e-ink mode and widget slot spans from the safe config', () => {
     renderWithFixedNow(

--- a/frontend/__tests__/components/DisplaysSection.test.js
+++ b/frontend/__tests__/components/DisplaysSection.test.js
@@ -24,6 +24,7 @@ jest.mock('../../components/ConfirmDialog', () => (props) => (
 jest.mock('../../lib/api', () => ({
   apiListDisplayDevices: jest.fn(),
   apiCreateDisplayDevice: jest.fn(),
+  apiUpdateDisplayDevice: jest.fn(),
   apiRevokeDisplayDevice: jest.fn(),
 }));
 
@@ -48,6 +49,31 @@ const messages = {
   display_last_used: 'Last used: {when}',
   display_never_used: 'Never used',
   display_created: 'Added: {when}',
+  display_mode_label: 'Display mode',
+  display_mode_tablet: 'Tablet',
+  display_mode_eink: 'E-Ink',
+  display_layout_label: 'Layout preset',
+  display_layout_hearth: 'Hearth',
+  display_layout_agenda_first: 'Agenda first',
+  display_layout_family_board: 'Family board',
+  display_layout_eink_compact: 'E-Ink compact',
+  display_layout_eink_agenda: 'E-Ink agenda',
+  display_refresh_label: 'Refresh interval',
+  display_refresh_helper: 'Seconds. E-Ink mode is clamped to slower, panel-friendly refreshes.',
+  display_live_preview_label: 'Live preview',
+  display_slot_editor_label: 'Slot editor',
+  display_slot_widget_label: 'Widget',
+  display_slot_x_label: 'Column',
+  display_slot_y_label: 'Row',
+  display_slot_w_label: 'Width',
+  display_slot_h_label: 'Height',
+  display_widget_home_header: 'Home header',
+  display_widget_identity: 'Home title',
+  display_widget_clock: 'Clock',
+  display_widget_focus: 'Focus',
+  display_widget_agenda: 'Agenda',
+  display_widget_birthdays: 'Birthdays',
+  display_widget_members: 'Family members',
   cancel: 'Cancel',
   dismiss: 'Dismiss',
   token_copied: 'Copied',
@@ -173,5 +199,231 @@ describe('DisplaysSection', () => {
     const row = await screen.findByTestId('display-row-9');
     expect(row).toHaveTextContent('Revoked');
     expect(within(row).queryByTestId('display-revoke-9')).not.toBeInTheDocument();
+  });
+});
+
+describe('DisplaysSection layout composer', () => {
+  const PRESETS = ['hearth', 'agenda_first', 'family_board', 'eink_compact', 'eink_agenda'];
+  const WHITELIST = ['home_header', 'identity', 'clock', 'focus', 'agenda', 'birthdays', 'members'];
+
+  async function openCreateForm() {
+    await act(async () => { render(<DisplaysSection />); });
+    await flushAsync();
+    fireEvent.click(screen.getByTestId('display-create-toggle'));
+  }
+
+  test('renders a card and mini preview for every layout preset inside the controls', async () => {
+    await openCreateForm();
+
+    const controls = screen.getByTestId('display-config-controls');
+    for (const preset of PRESETS) {
+      const card = within(controls).getByTestId(`display-layout-card-${preset}`);
+      expect(card).toBeInTheDocument();
+      expect(within(card).getByTestId(`display-layout-preview-${preset}`)).toBeInTheDocument();
+    }
+    // The default mode is `tablet`, so the default preset is `hearth`.
+    expect(screen.getByTestId('display-layout-card-hearth')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('display-layout-card-agenda_first')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('clicking a preset card switches the selection and updates the live preview', async () => {
+    await openCreateForm();
+
+    const livePreview = screen.getByTestId('display-live-preview');
+    expect(livePreview).toHaveTextContent(/hearth/i);
+
+    fireEvent.click(screen.getByTestId('display-layout-card-agenda_first'));
+
+    expect(screen.getByTestId('display-layout-card-agenda_first')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('display-layout-card-hearth')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('display-live-preview')).toHaveTextContent(/Agenda first/i);
+  });
+
+  test('slot editor lists draft slots and constrains widget type to whitelisted values', async () => {
+    await openCreateForm();
+
+    // Hearth has 5 widgets on a 3x3 grid.
+    const row0 = screen.getByTestId('display-slot-editor-row-0');
+    expect(row0).toBeInTheDocument();
+    expect(screen.getByTestId('display-slot-editor-row-4')).toBeInTheDocument();
+
+    const typeSelect = within(row0).getByTestId('display-slot-editor-row-0-type');
+    const optionValues = Array.from(typeSelect.querySelectorAll('option')).map((o) => o.value);
+    expect(new Set(optionValues)).toEqual(new Set(WHITELIST));
+
+    const xInput = within(row0).getByTestId('display-slot-editor-row-0-x');
+    expect(xInput).toHaveAttribute('type', 'number');
+    expect(xInput).toHaveAttribute('min', '0');
+    expect(xInput).toHaveAttribute('max', '2'); // hearth has 3 columns → max x is 2
+
+    const yInput = within(row0).getByTestId('display-slot-editor-row-0-y');
+    expect(yInput).toHaveAttribute('max', '2');
+  });
+
+  test('editing a slot type updates the live preview before save', async () => {
+    await openCreateForm();
+
+    const row0 = screen.getByTestId('display-slot-editor-row-0');
+    fireEvent.change(within(row0).getByTestId('display-slot-editor-row-0-type'), {
+      target: { value: 'members' },
+    });
+
+    const livePreview = screen.getByTestId('display-live-preview');
+    expect(livePreview).toHaveTextContent(/members/);
+  });
+
+  test('create payload includes layout_config when the slot editor was touched', async () => {
+    api.apiCreateDisplayDevice.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        token: 'tribu_display_xyz',
+        device: {
+          id: 1, family_id: 7, name: 'Wall',
+          created_at: '2026-04-27T08:00:00', last_used_at: null, revoked_at: null,
+        },
+      },
+    });
+
+    await openCreateForm();
+    fireEvent.change(screen.getByTestId('display-create-name'), { target: { value: 'Wall' } });
+
+    const row0 = screen.getByTestId('display-slot-editor-row-0');
+    fireEvent.change(within(row0).getByTestId('display-slot-editor-row-0-type'), {
+      target: { value: 'members' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('display-create-submit'));
+    });
+    await flushAsync();
+
+    expect(api.apiCreateDisplayDevice).toHaveBeenCalledTimes(1);
+    const [familyArg, payload] = api.apiCreateDisplayDevice.mock.calls[0];
+    expect(familyArg).toBe(7);
+    expect(payload).toMatchObject({
+      name: 'Wall',
+      display_mode: 'tablet',
+      layout_preset: 'hearth',
+      refresh_interval_seconds: 60,
+    });
+    expect(payload.layout_config).toBeDefined();
+    expect(payload.layout_config.columns).toBe(3);
+    expect(payload.layout_config.rows).toBe(3);
+    expect(payload.layout_config.widgets[0].type).toBe('members');
+  });
+
+  test('save payload for an existing device includes the modified layout_config', async () => {
+    api.apiListDisplayDevices.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 11, family_id: 7, name: 'Hallway',
+        display_mode: 'tablet', layout_preset: 'hearth',
+        refresh_interval_seconds: 60,
+        created_at: '2026-04-20T08:00:00', last_used_at: null, revoked_at: null,
+      }],
+    });
+    api.apiUpdateDisplayDevice.mockResolvedValue({ ok: true, data: {} });
+
+    await act(async () => { render(<DisplaysSection />); });
+    await flushAsync();
+
+    const row = await screen.findByTestId('display-row-11');
+    const slotRow = within(row).getByTestId('display-slot-editor-row-0');
+    // Hearth's home_header starts with w=1; bumping to 2 forces a real onChange.
+    fireEvent.change(within(slotRow).getByTestId('display-slot-editor-row-0-w'), {
+      target: { value: '2' },
+    });
+
+    await act(async () => {
+      fireEvent.click(within(row).getByTestId('display-save-config'));
+    });
+    await flushAsync();
+
+    expect(api.apiUpdateDisplayDevice).toHaveBeenCalledTimes(1);
+    const [familyArg, deviceArg, payload] = api.apiUpdateDisplayDevice.mock.calls[0];
+    expect(familyArg).toBe(7);
+    expect(deviceArg).toBe(11);
+    expect(payload).toMatchObject({
+      display_mode: 'tablet',
+      layout_preset: 'hearth',
+      refresh_interval_seconds: 60,
+    });
+    expect(payload.layout_config).toBeDefined();
+    expect(payload.layout_config.widgets[0].w).toBe(2);
+  });
+
+
+
+  test('changing display mode on an existing device clears stale custom layout_config before save', async () => {
+    api.apiListDisplayDevices.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 12, family_id: 7, name: 'Kitchen',
+        display_mode: 'tablet', layout_preset: 'hearth',
+        refresh_interval_seconds: 60,
+        layout_config: {
+          columns: 3,
+          rows: 3,
+          widgets: [{ type: 'home_header', x: 0, y: 0, w: 3, h: 1 }],
+        },
+        created_at: '2026-04-20T08:00:00', last_used_at: null, revoked_at: null,
+      }],
+    });
+    api.apiUpdateDisplayDevice.mockResolvedValue({ ok: true, data: {} });
+
+    await act(async () => { render(<DisplaysSection />); });
+    await flushAsync();
+
+    const row = await screen.findByTestId('display-row-12');
+    fireEvent.change(within(row).getByTestId('display-mode-select'), {
+      target: { value: 'eink' },
+    });
+
+    await act(async () => {
+      fireEvent.click(within(row).getByTestId('display-save-config'));
+    });
+    await flushAsync();
+
+    const [, , payload] = api.apiUpdateDisplayDevice.mock.calls[0];
+    expect(payload).toMatchObject({
+      display_mode: 'eink',
+      layout_preset: 'hearth',
+      refresh_interval_seconds: 60,
+      layout_config: null,
+    });
+  });
+
+  test('slot size controls are bounded by the current slot origin so slots stay inside the grid', async () => {
+    await openCreateForm();
+
+    const row0 = screen.getByTestId('display-slot-editor-row-0');
+    fireEvent.change(within(row0).getByTestId('display-slot-editor-row-0-x'), {
+      target: { value: '2' },
+    });
+
+    const wInput = within(row0).getByTestId('display-slot-editor-row-0-w');
+    expect(wInput).toHaveAttribute('max', '1');
+
+    fireEvent.change(wInput, { target: { value: '3' } });
+    expect(screen.getByTestId('display-live-preview')).toHaveTextContent(/1×2 @ \(2,0\)/);
+  });
+
+  test('layout composer labels use localized display messages instead of raw keys', async () => {
+    await openCreateForm();
+
+    expect(screen.getByText('Live preview')).toBeInTheDocument();
+    expect(screen.getByText('Slot editor')).toBeInTheDocument();
+    expect(screen.getAllByText('Home header').length).toBeGreaterThan(0);
+    expect(screen.queryByText('display_live_preview_label')).not.toBeInTheDocument();
+  });
+
+  test('does not allow arbitrary widget strings: invalid types are rejected from the select options', async () => {
+    await openCreateForm();
+    const typeSelect = within(screen.getByTestId('display-slot-editor-row-0'))
+      .getByTestId('display-slot-editor-row-0-type');
+    const optionValues = Array.from(typeSelect.querySelectorAll('option')).map((o) => o.value);
+    expect(optionValues).not.toContain('arbitrary_widget');
+    expect(optionValues).not.toContain('script');
+    expect(optionValues.every((v) => WHITELIST.includes(v))).toBe(true);
   });
 });

--- a/frontend/components/DisplayDashboard.js
+++ b/frontend/components/DisplayDashboard.js
@@ -30,6 +30,10 @@ export default function DisplayDashboard({ me, dashboard }) {
   const events = Array.isArray(dashboard.next_events) ? dashboard.next_events : [];
   const eventGroups = useMemo(() => groupEventsByDay(events, now), [events, now]);
   const focus = useMemo(() => pickFocusEvent(events, now), [events, now]);
+  const { todayEvents, upcomingEvents } = useMemo(
+    () => partitionEvents(events, now),
+    [events, now]
+  );
 
   const birthdays = Array.isArray(dashboard.upcoming_birthdays)
     ? dashboard.upcoming_birthdays
@@ -51,6 +55,8 @@ export default function DisplayDashboard({ me, dashboard }) {
     imminentNames,
     familyName,
     deviceName,
+    todayEvents,
+    upcomingEvents,
     members: Array.isArray(dashboard.members) ? dashboard.members : [],
   };
 
@@ -71,22 +77,26 @@ export default function DisplayDashboard({ me, dashboard }) {
           '--display-grid-rows': config.layout_config.rows,
         }}
       >
-        {config.layout_config.widgets.map((widget) => (
-          <WidgetShell key={widget.id} widget={widget}>
-            {renderWidget(widget.type, widgetContext)}
-          </WidgetShell>
-        ))}
+        {config.layout_config.widgets.map((widget) => {
+          const density = widgetDensity(widget);
+          return (
+            <WidgetShell key={widget.id} widget={widget} density={density}>
+              {renderWidget(widget.type, widgetContext, density)}
+            </WidgetShell>
+          );
+        })}
       </div>
     </div>
   );
 }
 
-function WidgetShell({ widget, children }) {
+function WidgetShell({ widget, children, density }) {
   return (
     <section
       className={`display-widget display-widget--${widget.type}`}
       data-testid={`display-widget-${widget.type}`}
       data-widget-type={widget.type}
+      data-density={density || undefined}
       style={{
         gridColumn: `${widget.x + 1} / span ${widget.w}`,
         gridRow: `${widget.y + 1} / span ${widget.h}`,
@@ -97,8 +107,20 @@ function WidgetShell({ widget, children }) {
   );
 }
 
-function renderWidget(type, context) {
+function renderWidget(type, context, density) {
   switch (type) {
+    case 'home_header':
+      return (
+        <HomeHeaderCard
+          familyName={context.familyName}
+          deviceName={context.deviceName}
+          timeLabel={context.timeLabel}
+          dateLabel={context.dateLabel}
+          density={density}
+          todayEvents={context.todayEvents}
+          upcomingEvents={context.upcomingEvents}
+        />
+      );
     case 'identity':
       return <IdentityCard familyName={context.familyName} deviceName={context.deviceName} />;
     case 'clock':
@@ -114,6 +136,61 @@ function renderWidget(type, context) {
     default:
       return null;
   }
+}
+
+function HomeHeaderCard({ familyName, deviceName, timeLabel, dateLabel, density, todayEvents, upcomingEvents }) {
+  const showHearth = density !== 'compact';
+  const showTodayCue = density === 'standard';
+  const showEventList = density === 'expanded';
+  const todayCount = Array.isArray(todayEvents) ? todayEvents.length : 0;
+  const upcoming = Array.isArray(upcomingEvents) ? upcomingEvents.slice(0, 4) : [];
+  return (
+    <div
+      className={`display-card display-home-header display-home-header--${density}`}
+      data-testid="display-home-header"
+    >
+      {showHearth && (
+        <div className="display-hearth-label">
+          <span className="display-hearth-prefix">The</span>
+          <span className="display-hearth-name" data-testid="display-family-name">
+            {familyName || 'Family'}
+          </span>
+          <span className="display-hearth-suffix">Home</span>
+        </div>
+      )}
+      {showHearth && deviceName && (
+        <div className="display-device-tag" data-testid="display-device-name">
+          {deviceName}
+        </div>
+      )}
+      <div className="display-clock" data-testid="display-time">{timeLabel}</div>
+      <div className="display-date" data-testid="display-date">{dateLabel}</div>
+      {showTodayCue && (
+        <div className="display-home-header-cue" data-testid="display-home-header-today-cue">
+          {todayCount > 0
+            ? `${todayCount} today`
+            : 'Nothing today'}
+        </div>
+      )}
+      {showEventList && (
+        <ul
+          className="display-home-header-events"
+          data-testid="display-home-header-events"
+        >
+          {upcoming.length === 0 ? (
+            <li className="display-home-header-empty">No events on the horizon.</li>
+          ) : (
+            upcoming.map((ev, idx) => (
+              <li key={idx} className="display-home-header-event">
+                <span className="display-home-header-when">{formatAgendaWhen(ev)}</span>
+                <span className="display-home-header-title">{ev.title}</span>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
 }
 
 function IdentityCard({ familyName, deviceName }) {
@@ -316,7 +393,15 @@ function EmptyHearth({ message, tone = 'default' }) {
   );
 }
 
-const ALLOWED_WIDGETS = new Set(['identity', 'clock', 'focus', 'agenda', 'birthdays', 'members']);
+const ALLOWED_WIDGETS = new Set([
+  'home_header',
+  'identity',
+  'clock',
+  'focus',
+  'agenda',
+  'birthdays',
+  'members',
+]);
 const DEFAULT_LAYOUT_CONFIG = {
   columns: 4,
   rows: 3,
@@ -367,6 +452,32 @@ function normalizeWidget(widget, idx, columns, rows) {
     ? widget.id.trim().replace(/[^a-z0-9_-]/gi, '').slice(0, 40)
     : `${widget.type}-${idx}`;
   return { id: id || `${widget.type}-${idx}`, type: widget.type, x, y, w, h };
+}
+
+function widgetDensity(widget) {
+  if (!widget || widget.type !== 'home_header') return undefined;
+  const area = (Number(widget.w) || 1) * (Number(widget.h) || 1);
+  if (area <= 1) return 'compact';
+  if (area < 4) return 'standard';
+  return 'expanded';
+}
+
+function partitionEvents(events, now) {
+  if (!Array.isArray(events) || events.length === 0) {
+    return { todayEvents: [], upcomingEvents: [] };
+  }
+  const today = startOfDay(now).getTime();
+  const enriched = events
+    .map((e) => ({ e, t: parseLooseDate(e.starts_at) }))
+    .filter(({ t }) => !!t)
+    .sort((a, b) => a.t - b.t);
+  const todayEvents = enriched
+    .filter(({ t }) => startOfDay(t).getTime() === today)
+    .map(({ e }) => e);
+  const upcomingEvents = enriched
+    .filter(({ t }) => t.getTime() >= today)
+    .map(({ e }) => e);
+  return { todayEvents, upcomingEvents };
 }
 
 function clampInt(value, min, max, fallback) {

--- a/frontend/components/admin/DisplaysSection.js
+++ b/frontend/components/admin/DisplaysSection.js
@@ -27,6 +27,7 @@ export default function DisplaysSection() {
   const [newMode, setNewMode] = useState('tablet');
   const [newPreset, setNewPreset] = useState('hearth');
   const [newRefresh, setNewRefresh] = useState(60);
+  const [newLayout, setNewLayout] = useState(null);
   const [deviceDrafts, setDeviceDrafts] = useState({});
   const [created, setCreated] = useState(null); // { token, device, displayUrl }
   const [copied, setCopied] = useState(false);
@@ -51,12 +52,14 @@ export default function DisplaysSection() {
   async function handleCreate(e) {
     e.preventDefault();
     if (!newName.trim()) return;
-    const { ok, data } = await api.apiCreateDisplayDevice(familyId, {
+    const payload = {
       name: newName.trim(),
       display_mode: newMode,
       layout_preset: newPreset,
       refresh_interval_seconds: Number(newRefresh),
-    });
+    };
+    if (newLayout) payload.layout_config = newLayout;
+    const { ok, data } = await api.apiCreateDisplayDevice(familyId, payload);
     if (!ok) {
       toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
       return;
@@ -77,22 +80,33 @@ export default function DisplaysSection() {
     setNewMode('tablet');
     setNewPreset('hearth');
     setNewRefresh(60);
+    setNewLayout(null);
   }
 
-  function updateDraft(deviceId, patch) {
-    setDeviceDrafts((current) => ({
-      ...current,
-      [deviceId]: { ...(current[deviceId] || {}), ...patch },
-    }));
+  function updateDraft(deviceId, patch, device = null) {
+    setDeviceDrafts((current) => {
+      const previous = current[deviceId] || (device ? deviceToDraft(device) : {});
+      const next = { ...previous, ...patch };
+      // Picking a different preset or mode must also drop stale layout_config so
+      // the slot editor reflects the freshly chosen preset/mode grid.
+      const presetChanged = patch.layout_preset && patch.layout_preset !== previous.layout_preset;
+      const modeChanged = patch.display_mode && patch.display_mode !== previous.display_mode;
+      if ((presetChanged || modeChanged) && !Object.prototype.hasOwnProperty.call(patch, 'layout_config')) {
+        next.layout_config = null;
+      }
+      return { ...current, [deviceId]: next };
+    });
   }
 
   async function handleSaveDevice(device) {
     const draft = deviceDrafts[device.id] || deviceToDraft(device);
-    const { ok, data } = await api.apiUpdateDisplayDevice(familyId, device.id, {
+    const payload = {
       display_mode: draft.display_mode,
       layout_preset: draft.layout_preset,
       refresh_interval_seconds: Number(draft.refresh_interval_seconds),
-    });
+    };
+    if (Object.prototype.hasOwnProperty.call(draft, 'layout_config')) payload.layout_config = draft.layout_config;
+    const { ok, data } = await api.apiUpdateDisplayDevice(familyId, device.id, payload);
     if (!ok) {
       toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
       return;
@@ -210,7 +224,7 @@ export default function DisplaysSection() {
                   <DisplayConfigControls
                     draft={deviceDrafts[device.id] || deviceToDraft(device)}
                     messages={messages}
-                    onChange={(patch) => updateDraft(device.id, patch)}
+                    onChange={(patch) => updateDraft(device.id, patch, device)}
                     onSave={() => handleSaveDevice(device)}
                   />
                 )}
@@ -249,15 +263,28 @@ export default function DisplaysSection() {
                   <small className="invite-helper-text">{t(messages, 'display_name_helper')}</small>
                 </div>
                 <DisplayConfigControls
-                  draft={{ display_mode: newMode, layout_preset: newPreset, refresh_interval_seconds: newRefresh }}
+                  draft={{
+                    display_mode: newMode,
+                    layout_preset: newPreset,
+                    refresh_interval_seconds: newRefresh,
+                    layout_config: newLayout,
+                  }}
                   messages={messages}
                   onChange={(patch) => {
                     if (patch.display_mode) {
                       setNewMode(patch.display_mode);
                       if (patch.display_mode === 'eink' && newPreset === 'hearth') setNewPreset('eink_compact');
+                      setNewLayout(null);
                     }
-                    if (patch.layout_preset) setNewPreset(patch.layout_preset);
+                    if (patch.layout_preset) {
+                      setNewPreset(patch.layout_preset);
+                      // Resetting layout_config keeps the slot editor in sync with the freshly chosen preset.
+                      setNewLayout(null);
+                    }
                     if (patch.refresh_interval_seconds) setNewRefresh(Number(patch.refresh_interval_seconds));
+                    if (Object.prototype.hasOwnProperty.call(patch, 'layout_config')) {
+                      setNewLayout(patch.layout_config);
+                    }
                   }}
                 />
                 <div className="set-btn-row">
@@ -292,11 +319,65 @@ export default function DisplaysSection() {
 const DISPLAY_MODES = ['tablet', 'eink'];
 const LAYOUT_PRESETS = ['hearth', 'agenda_first', 'family_board', 'eink_compact', 'eink_agenda'];
 
+// Mirrors the canonical preset definitions in backend/app/core/display_layouts.py
+// so the composer can render mini-previews and seed the slot editor without an
+// extra API round-trip. The backend remains the source of truth and re-validates
+// every saved layout, so any drift here is corrected server-side.
+const PRESET_LAYOUTS = {
+  hearth: {
+    columns: 3, rows: 3,
+    widgets: [
+      { type: 'home_header', x: 0, y: 0, w: 1, h: 2 },
+      { type: 'focus', x: 0, y: 2, w: 1, h: 1 },
+      { type: 'agenda', x: 1, y: 0, w: 1, h: 3 },
+      { type: 'birthdays', x: 2, y: 0, w: 1, h: 1 },
+      { type: 'members', x: 2, y: 1, w: 1, h: 2 },
+    ],
+  },
+  agenda_first: {
+    columns: 3, rows: 3,
+    widgets: [
+      { type: 'agenda', x: 0, y: 0, w: 2, h: 3 },
+      { type: 'home_header', x: 2, y: 0, w: 1, h: 2 },
+      { type: 'birthdays', x: 2, y: 2, w: 1, h: 1 },
+    ],
+  },
+  family_board: {
+    columns: 3, rows: 3,
+    widgets: [
+      { type: 'home_header', x: 0, y: 0, w: 1, h: 2 },
+      { type: 'members', x: 1, y: 0, w: 2, h: 2 },
+      { type: 'agenda', x: 0, y: 2, w: 2, h: 1 },
+      { type: 'birthdays', x: 2, y: 2, w: 1, h: 1 },
+    ],
+  },
+  eink_compact: {
+    columns: 2, rows: 3,
+    widgets: [
+      { type: 'home_header', x: 0, y: 0, w: 2, h: 1 },
+      { type: 'agenda', x: 0, y: 1, w: 2, h: 1 },
+      { type: 'birthdays', x: 0, y: 2, w: 1, h: 1 },
+      { type: 'members', x: 1, y: 2, w: 1, h: 1 },
+    ],
+  },
+  eink_agenda: {
+    columns: 1, rows: 3,
+    widgets: [
+      { type: 'home_header', x: 0, y: 0, w: 1, h: 1 },
+      { type: 'agenda', x: 0, y: 1, w: 1, h: 1 },
+      { type: 'birthdays', x: 0, y: 2, w: 1, h: 1 },
+    ],
+  },
+};
+
+const ALLOWED_WIDGETS = ['home_header', 'identity', 'clock', 'focus', 'agenda', 'birthdays', 'members'];
+
 function deviceToDraft(device) {
   return {
     display_mode: device.display_mode || 'tablet',
     layout_preset: device.layout_preset || 'hearth',
     refresh_interval_seconds: device.refresh_interval_seconds || (device.display_mode === 'eink' ? 900 : 60),
+    layout_config: device.layout_config || null,
   };
 }
 
@@ -308,7 +389,53 @@ function layoutPresetLabel(preset, messages) {
   return t(messages, `display_layout_${preset || 'hearth'}`);
 }
 
+function widgetLabel(widget, messages) {
+  return t(messages, `display_widget_${widget}`);
+}
+
+function effectiveLayout(draft) {
+  if (draft.layout_config && Array.isArray(draft.layout_config.widgets)) return draft.layout_config;
+  return PRESET_LAYOUTS[draft.layout_preset] || PRESET_LAYOUTS.hearth;
+}
+
+function PresetMiniPreview({ preset, layout }) {
+  return (
+    <div
+      className="display-layout-preview"
+      data-testid={`display-layout-preview-${preset}`}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${layout.columns}, 1fr)`,
+        gridTemplateRows: `repeat(${layout.rows}, 1fr)`,
+        gap: 2,
+      }}
+    >
+      {layout.widgets.map((widget, idx) => (
+        <span
+          key={`${widget.type}-${idx}`}
+          className="display-layout-preview-cell"
+          data-widget-type={widget.type}
+          style={{
+            gridColumn: `${widget.x + 1} / span ${widget.w}`,
+            gridRow: `${widget.y + 1} / span ${widget.h}`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
 function DisplayConfigControls({ draft, messages, onChange, onSave = null }) {
+  const layout = effectiveLayout(draft);
+
+  function updateSlot(index, patch) {
+    const nextWidgets = layout.widgets.map((widget, i) => {
+      if (i !== index) return widget;
+      return normalizeSlot({ ...widget, ...patch }, layout);
+    });
+    onChange({ layout_config: { columns: layout.columns, rows: layout.rows, widgets: nextWidgets } });
+  }
+
   return (
     <div className="adm-form-grid" data-testid="display-config-controls">
       <div className="form-field">
@@ -324,19 +451,47 @@ function DisplayConfigControls({ draft, messages, onChange, onSave = null }) {
           ))}
         </select>
       </div>
+
       <div className="form-field">
         <label>{t(messages, 'display_layout_label')}</label>
+        <div
+          className="display-layout-card-grid"
+          role="radiogroup"
+          aria-label={t(messages, 'display_layout_label')}
+        >
+          {LAYOUT_PRESETS.map((preset) => {
+            const presetLayout = PRESET_LAYOUTS[preset];
+            const selected = draft.layout_preset === preset;
+            return (
+              <button
+                key={preset}
+                type="button"
+                className={`display-layout-card${selected ? ' display-layout-card--selected' : ''}`}
+                aria-pressed={selected ? 'true' : 'false'}
+                data-testid={`display-layout-card-${preset}`}
+                onClick={() => onChange({ layout_preset: preset })}
+              >
+                <PresetMiniPreview preset={preset} layout={presetLayout} />
+                <span className="display-layout-card-label">{layoutPresetLabel(preset, messages)}</span>
+              </button>
+            );
+          })}
+        </div>
+        {/* Backward-compatible select for screen readers and keyboard-only flows.
+            The card grid above mirrors its state. */}
         <select
-          className="form-input"
+          className="form-input display-layout-select-fallback"
           value={draft.layout_preset}
           onChange={(e) => onChange({ layout_preset: e.target.value })}
           data-testid="display-layout-select"
+          aria-label={t(messages, 'display_layout_label')}
         >
           {LAYOUT_PRESETS.map((preset) => (
             <option key={preset} value={preset}>{layoutPresetLabel(preset, messages)}</option>
           ))}
         </select>
       </div>
+
       <div className="form-field">
         <label>{t(messages, 'display_refresh_label')}</label>
         <input
@@ -350,6 +505,87 @@ function DisplayConfigControls({ draft, messages, onChange, onSave = null }) {
         />
         <small className="invite-helper-text">{t(messages, 'display_refresh_helper')}</small>
       </div>
+
+      <div className="form-field" data-testid="display-live-preview">
+        <label>{t(messages, 'display_live_preview_label')}</label>
+        <div className="display-live-preview-body">
+          <strong className="display-live-preview-title">{layoutPresetLabel(draft.layout_preset, messages)}</strong>
+          <PresetMiniPreview preset={`live-${draft.layout_preset}`} layout={layout} />
+          <ul className="display-live-preview-slots">
+            {layout.widgets.map((widget, idx) => (
+              <li key={`${widget.type}-${idx}`}>
+                {widgetLabel(widget.type, messages)} · {widget.w}×{widget.h} @ ({widget.x},{widget.y})
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="form-field">
+        <label>{t(messages, 'display_slot_editor_label')}</label>
+        <div className="display-slot-editor">
+          {layout.widgets.map((widget, idx) => (
+            <div
+              key={idx}
+              className="display-slot-editor-row"
+              data-testid={`display-slot-editor-row-${idx}`}
+            >
+              <select
+                className="form-input"
+                value={ALLOWED_WIDGETS.includes(widget.type) ? widget.type : ALLOWED_WIDGETS[0]}
+                onChange={(e) => updateSlot(idx, { type: e.target.value })}
+                data-testid={`display-slot-editor-row-${idx}-type`}
+                aria-label={t(messages, 'display_slot_widget_label')}
+              >
+                {ALLOWED_WIDGETS.map((kind) => (
+                  <option key={kind} value={kind}>{widgetLabel(kind, messages)}</option>
+                ))}
+              </select>
+              <input
+                type="number"
+                className="form-input"
+                min={0}
+                max={Math.max(0, layout.columns - 1)}
+                value={widget.x}
+                onChange={(e) => updateSlot(idx, { x: clampNum(e.target.value, 0, layout.columns - 1, widget.x) })}
+                data-testid={`display-slot-editor-row-${idx}-x`}
+                aria-label={`${t(messages, 'display_slot_x_label')} ${idx + 1}`}
+              />
+              <input
+                type="number"
+                className="form-input"
+                min={0}
+                max={Math.max(0, layout.rows - 1)}
+                value={widget.y}
+                onChange={(e) => updateSlot(idx, { y: clampNum(e.target.value, 0, layout.rows - 1, widget.y) })}
+                data-testid={`display-slot-editor-row-${idx}-y`}
+                aria-label={`${t(messages, 'display_slot_y_label')} ${idx + 1}`}
+              />
+              <input
+                type="number"
+                className="form-input"
+                min={1}
+                max={Math.max(1, layout.columns - widget.x)}
+                value={widget.w}
+                onChange={(e) => updateSlot(idx, { w: clampNum(e.target.value, 1, Math.max(1, layout.columns - widget.x), widget.w) })}
+                data-testid={`display-slot-editor-row-${idx}-w`}
+                aria-label={`${t(messages, 'display_slot_w_label')} ${idx + 1}`}
+              />
+              <input
+                type="number"
+                className="form-input"
+                min={1}
+                max={Math.max(1, layout.rows - widget.y)}
+                value={widget.h}
+                onChange={(e) => updateSlot(idx, { h: clampNum(e.target.value, 1, Math.max(1, layout.rows - widget.y), widget.h) })}
+                data-testid={`display-slot-editor-row-${idx}-h`}
+                aria-label={`${t(messages, 'display_slot_h_label')} ${idx + 1}`}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
       {onSave && (
         <div className="set-btn-row">
           <button type="button" className="btn-sm" onClick={onSave} data-testid="display-save-config">
@@ -359,4 +595,24 @@ function DisplayConfigControls({ draft, messages, onChange, onSave = null }) {
       )}
     </div>
   );
+}
+
+function normalizeSlot(widget, layout) {
+  const x = clampNum(widget.x, 0, Math.max(0, layout.columns - 1), 0);
+  const y = clampNum(widget.y, 0, Math.max(0, layout.rows - 1), 0);
+  const w = clampNum(widget.w, 1, Math.max(1, layout.columns - x), 1);
+  const h = clampNum(widget.h, 1, Math.max(1, layout.rows - y), 1);
+  return {
+    type: ALLOWED_WIDGETS.includes(widget.type) ? widget.type : ALLOWED_WIDGETS[0],
+    x,
+    y,
+    w,
+    h,
+  };
+}
+
+function clampNum(raw, lo, hi, fallback) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(hi, Math.max(lo, Math.trunc(n)));
 }

--- a/frontend/e2e/tests/display.spec.js
+++ b/frontend/e2e/tests/display.spec.js
@@ -41,7 +41,8 @@ test.describe('Display mode', () => {
     await gotoDisplayWithToken(page, created.token);
 
     await expect(page.getByTestId('display-dashboard')).toBeVisible({ timeout: 15000 });
-    await expect(page.getByTestId('display-device-name')).toContainText('Kitchen Tablet');
+    await expect(page.getByTestId('display-widget-home_header')).toBeVisible();
+    await expect(page.getByTestId('display-home-header')).toBeVisible();
     // The redesign surfaces the next event in two distinct regions — the
     // hero "focus" card and the agenda list — so scope the assertion to
     // each region to avoid strict-mode ambiguity from the duplicate title.

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -554,5 +554,19 @@
   "display_layout_eink_compact": "E-Ink kompakt",
   "display_layout_eink_agenda": "E-Ink Agenda",
   "display_refresh_label": "Aktualisierungsintervall",
-  "display_refresh_helper": "Sekunden. E-Ink wird auf schonende, langsamere Aktualisierung begrenzt."
+  "display_refresh_helper": "Sekunden. E-Ink wird auf schonende, langsamere Aktualisierung begrenzt.",
+  "display_live_preview_label": "Live-Vorschau",
+  "display_slot_editor_label": "Slot-Editor",
+  "display_slot_widget_label": "Widget",
+  "display_slot_x_label": "Spalte",
+  "display_slot_y_label": "Zeile",
+  "display_slot_w_label": "Breite",
+  "display_slot_h_label": "Höhe",
+  "display_widget_home_header": "Home-Header",
+  "display_widget_identity": "Home-Titel",
+  "display_widget_clock": "Uhr",
+  "display_widget_focus": "Fokus",
+  "display_widget_agenda": "Agenda",
+  "display_widget_birthdays": "Geburtstage",
+  "display_widget_members": "Familienmitglieder"
 }

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -554,5 +554,19 @@
   "display_layout_eink_compact": "E-Ink compact",
   "display_layout_eink_agenda": "E-Ink agenda",
   "display_refresh_label": "Refresh interval",
-  "display_refresh_helper": "Seconds. E-Ink mode is clamped to slower, panel-friendly refreshes."
+  "display_refresh_helper": "Seconds. E-Ink mode is clamped to slower, panel-friendly refreshes.",
+  "display_live_preview_label": "Live preview",
+  "display_slot_editor_label": "Slot editor",
+  "display_slot_widget_label": "Widget",
+  "display_slot_x_label": "Column",
+  "display_slot_y_label": "Row",
+  "display_slot_w_label": "Width",
+  "display_slot_h_label": "Height",
+  "display_widget_home_header": "Home header",
+  "display_widget_identity": "Home title",
+  "display_widget_clock": "Clock",
+  "display_widget_focus": "Focus",
+  "display_widget_agenda": "Agenda",
+  "display_widget_birthdays": "Birthdays",
+  "display_widget_members": "Family members"
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2541,7 +2541,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   letter-spacing: 0.14em;
 }
 .display-home-header--standard .display-clock {
-  font-size: clamp(2.7rem, 5.8vw, 4.6rem);
+  font-size: clamp(3rem, 5.8vw, 4.6rem);
 }
 .display-home-header-cue {
   align-self: flex-start;

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2521,6 +2521,78 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   letter-spacing: 0.22em;
 }
 
+.display-home-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  overflow: hidden;
+}
+.display-home-header--compact {
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 1rem;
+}
+.display-home-header--compact .display-clock {
+  font-size: clamp(2.1rem, 4.4vw, 3.4rem);
+  line-height: 1;
+}
+.display-home-header--compact .display-date {
+  font-size: clamp(0.75rem, 0.95vw, 0.95rem);
+  letter-spacing: 0.14em;
+}
+.display-home-header--standard .display-clock {
+  font-size: clamp(2.7rem, 5.8vw, 4.6rem);
+}
+.display-home-header-cue {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--glass-border);
+  color: var(--text-secondary);
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+.display-home-header--expanded {
+  gap: 0.75rem;
+}
+.display-home-header--expanded .display-clock {
+  font-size: clamp(2.6rem, 5vw, 4.2rem);
+}
+.display-home-header-events {
+  list-style: none;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+  overflow: hidden;
+}
+.display-home-header-event {
+  display: grid;
+  grid-template-columns: 4.75rem 1fr;
+  gap: 0.6rem;
+  align-items: baseline;
+  min-width: 0;
+}
+.display-home-header-when {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: var(--text-secondary);
+  font-size: 0.86rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.display-home-header-title {
+  color: var(--text-primary);
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.display-home-header-empty {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
 .display-focus {
   --focus-tint: var(--amethyst);
   display: flex;


### PR DESCRIPTION
## Summary
- Adds a shared display home header that combines home title, clock, date, and responsive agenda cues
- Adds visual layout preset cards, live preview, and a bounded slot editor for display configuration
- Keeps display layouts server-normalized with whitelisted widgets and legacy identity/clock compatibility

## Validation
- Backend display tests passed
- Frontend targeted Jest tests passed
- Frontend production build passed
- Display Playwright E2E passed
