### PR TITLE
chore(release): harden frontend dependencies and image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,34 +1,48 @@
+FROM node:22-alpine AS deps
+
+WORKDIR /app
+
+# Deterministic install: copy the lockfile and use `npm ci`, which
+# refuses to run if package.json and package-lock.json disagree. This
+# pins the audit posture of the build to whatever was committed.
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund --include=dev
+
+
 FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
+ENV NEXT_TELEMETRY_DISABLED=1
 
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
 RUN npm run build
 
-FROM node:22-alpine
+
+FROM node:22-alpine AS runner
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
 RUN addgroup -S tribu && adduser -S tribu -G tribu
 
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/next.config.js ./next.config.js
-COPY --from=builder /app/i18n ./i18n
-COPY --from=builder /app/lib ./lib
-COPY --from=builder /app/themes ./themes
-COPY --from=builder /app/contexts ./contexts
-COPY --from=builder /app/hooks ./hooks
-COPY --from=builder /app/components ./components
-COPY --from=builder /app/public ./public
+# Next standalone output ships only the prod deps it traced as
+# reachable (.next/standalone/node_modules), so the dev/test surface
+# never lands in the runtime image. `static` and `public` must be
+# copied alongside it because Next's standalone server expects them
+# at fixed paths.
+COPY --from=builder --chown=tribu:tribu /app/public ./public
+COPY --from=builder --chown=tribu:tribu /app/.next/standalone ./
+COPY --from=builder --chown=tribu:tribu /app/.next/static ./.next/static
 
-RUN chown -R tribu:tribu /app
 USER tribu
 
 EXPOSE 3000
 
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/frontend/__tests__/pages/ErrorBoundary.test.js
+++ b/frontend/__tests__/pages/ErrorBoundary.test.js
@@ -1,0 +1,110 @@
+/**
+ * ErrorBoundary visibility test (issue #225).
+ *
+ * The original `_app.js` ErrorBoundary rendered `error.message` and
+ * `error.stack` for every visitor. That leaks file paths, internal
+ * symbols, and library versions to anyone who can trip a render-time
+ * exception. The fix gates those details behind NODE_ENV !== 'production'
+ * and replaces the user-visible UI with a generic apology.
+ *
+ * These tests pin the contract:
+ *   - production: no message, no stack, generic copy with role="alert"
+ *   - development: message + stack visible (developers still need them)
+ *   - happy path: children render unchanged
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// React logs error boundary catches via console.error. Silence those to
+// keep the Jest run clean — the boundary's *rendered* output is what
+// these tests assert on.
+let errorSpy;
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+const SECRET_MESSAGE = 'kaboom: /secret/path/leak.js';
+
+function Boom() {
+  throw new Error(SECRET_MESSAGE);
+}
+
+function loadBoundaryWith(env) {
+  const previous = process.env.NODE_ENV;
+  jest.resetModules();
+  // process.env.NODE_ENV is read inside the boundary's render() so the
+  // override must be in place before the component is required AND
+  // before render runs. Restore it after the test to keep Jest's
+  // default of 'test' for unrelated suites.
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value: env,
+    configurable: true,
+  });
+  const mod = require('../../pages/_app');
+  return {
+    ErrorBoundary: mod.ErrorBoundary,
+    restore: () => {
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: previous,
+        configurable: true,
+      });
+    },
+  };
+}
+
+describe('ErrorBoundary visibility (issue #225)', () => {
+  test('production: hides error message and stack from end users', () => {
+    const { ErrorBoundary, restore } = loadBoundaryWith('production');
+    try {
+      render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>,
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toBeInTheDocument();
+      expect(alert.textContent).not.toContain(SECRET_MESSAGE);
+      expect(alert.textContent).not.toContain('/secret/path');
+      // No stack frame markers like "at Boom" should be visible either.
+      expect(alert.textContent).not.toMatch(/\bat\s+Boom\b/);
+    } finally {
+      restore();
+    }
+  });
+
+  test('development: surfaces message and stack so developers can debug', () => {
+    const { ErrorBoundary, restore } = loadBoundaryWith('development');
+    try {
+      render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>,
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain(SECRET_MESSAGE);
+    } finally {
+      restore();
+    }
+  });
+
+  test('happy path: renders children when nothing throws', () => {
+    const { ErrorBoundary, restore } = loadBoundaryWith('production');
+    try {
+      render(
+        <ErrorBoundary>
+          <div data-testid="child">ok</div>
+        </ErrorBoundary>,
+      );
+      expect(screen.getByTestId('child')).toHaveTextContent('ok');
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Standalone output emits a self-contained server (.next/standalone)
+  // with only the production deps Next traced as reachable. The Docker
+  // runtime image copies that bundle instead of the full node_modules,
+  // dropping the dev/test dependency surface from production images.
+  output: 'standalone',
   reactStrictMode: true,
   skipTrailingSlashRedirect: true,
   async rewrites() {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5097,6 +5097,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5108,9 +5109,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5127,9 +5128,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
   },
   "overrides": {
     "minimatch": "^10.2.4",
-    "glob": "^11.0.2"
+    "glob": "^11.0.2",
+    "postcss": "^8.5.10"
   },
   "devDependencies": {
     "@playwright/test": "^1.51.1",

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -37,7 +37,12 @@ const DISPLAY_MODE_BOOTSTRAP = `
 })();
 `;
 
-class ErrorBoundary extends ReactComponent {
+// Top-level ErrorBoundary. Detail is gated by NODE_ENV: a stack trace
+// in front of an end user leaks file paths, internal symbols, and
+// library versions, which is exactly the kind of fingerprint a
+// scanner uses to pick the next exploit. Developers still need the
+// full message + stack, so dev keeps them.
+export class ErrorBoundary extends ReactComponent {
   constructor(props) {
     super(props);
     this.state = { error: null };
@@ -47,11 +52,36 @@ class ErrorBoundary extends ReactComponent {
   }
   render() {
     if (this.state.error) {
+      const isDev = process.env.NODE_ENV !== 'production';
       return (
-        <div style={{ padding: 40, fontFamily: 'monospace', color: '#ff6b6b', background: '#1a1a2e', minHeight: '100vh' }}>
-          <h1>Client Error</h1>
-          <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{this.state.error.message}</pre>
-          <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', opacity: 0.7, fontSize: 12, marginTop: 16 }}>{this.state.error.stack}</pre>
+        <div
+          role="alert"
+          style={{
+            padding: 40,
+            fontFamily: 'monospace',
+            color: '#ff6b6b',
+            background: '#1a1a2e',
+            minHeight: '100vh',
+          }}
+        >
+          <h1>Something went wrong</h1>
+          <p>The page failed to load. Please reload, and contact your admin if the problem persists.</p>
+          {isDev && (
+            <>
+              <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{this.state.error.message}</pre>
+              <pre
+                style={{
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  opacity: 0.7,
+                  fontSize: 12,
+                  marginTop: 16,
+                }}
+              >
+                {this.state.error.stack}
+              </pre>
+            </>
+          )}
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- make the frontend Docker build deterministic with `npm ci` and run the image from Next standalone output instead of the full build-time `node_modules`
- pin the PostCSS transitive dependency override so the production npm audit is clean
- hide client error messages/stacks from production users while keeping development diagnostics available
- add ErrorBoundary coverage for production redaction and development visibility

## Tests
- `cd frontend && rm -rf .next test-results playwright-report && npm test -- --runInBand`
- `cd frontend && npm run build`
- `cd frontend && npm audit --omit=dev --audit-level=moderate`
- `git diff --check`
- standalone smoke: `PORT=3010 HOSTNAME=127.0.0.1 node frontend/.next/standalone/server.js` served `/`

Note: Docker daemon is not installed on dev30, so the container image itself was not built locally. The standalone runtime was smoke-tested from the generated build output.

Closes #225
