### PR TITLE
fix(frontend): support standalone launch script

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -4,7 +4,8 @@ const createJestConfig = nextJest({ dir: './' });
 
 module.exports = createJestConfig({
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/', '/.next/'],
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000",
+    "start": "node -e \"const fs=require('fs'); require(fs.existsSync('server.js') ? './server.js' : './.next/standalone/server.js')\"",
     "test": "jest",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed",


### PR DESCRIPTION
## Summary
- Make the frontend package launch script compatible with the standalone runtime image
- Keep the existing standalone `node server.js` path working for Docker
- Ignore generated Next build output in Jest module discovery

## Root cause
The frontend image now runs from Next standalone output. The image itself starts with `node server.js`, but deployments that override the command with the package launch script still used the old Next CLI command. Standalone runtime images do not ship that CLI on the normal PATH, so the container exited during startup.

## Tests
- `cd frontend && npm test -- --runInBand`
- `cd frontend && npm run build`
- `cd frontend && npm audit --omit=dev --audit-level=moderate`
- `git diff --check`
- Standalone runtime smoke on `127.0.0.1:3012`
