### PR TITLE
fix: correct version update display

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,16 @@ jobs:
         with:
           fetch-depth: 0
 
+
+      - name: Detect stable release tag
+        id: release_tag
+        run: |
+          stable=false
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            stable=true
+          fi
+          echo "stable=${stable}" >> "$GITHUB_OUTPUT"
+
       - name: Derive app version
         id: app_version
         run: |
@@ -61,7 +71,7 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ steps.release_tag.outputs.stable == 'true' || github.ref_name == github.event.repository.default_branch }}
             type=ref,event=branch
 
       - uses: docker/build-push-action@v6
@@ -88,6 +98,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect stable release tag
+        id: release_tag
+        run: |
+          stable=false
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            stable=true
+          fi
+          echo "stable=${stable}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
@@ -107,7 +126,7 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ steps.release_tag.outputs.stable == 'true' || github.ref_name == github.event.repository.default_branch }}
             type=ref,event=branch
 
       - uses: docker/build-push-action@v6

--- a/frontend/__tests__/components/AboutTab.test.js
+++ b/frontend/__tests__/components/AboutTab.test.js
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AboutTab from '../../components/settings/AboutTab';
+import { buildMessages } from '../../lib/i18n';
+import * as api from '../../lib/api';
+
+jest.mock('../../lib/api');
+jest.mock('../../contexts/AppContext', () => ({ useApp: jest.fn() }));
+
+const { useApp } = require('../../contexts/AppContext');
+
+function renderAboutTab() {
+  useApp.mockReturnValue({ messages: buildMessages('en'), isAdmin: true });
+  return render(<AboutTab />);
+}
+
+describe('AboutTab version update check', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+    api.apiGetHealth.mockResolvedValue({ ok: true, data: { version: '2026-04-24.131' } });
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({
+        tag_name: 'v2026-04-27.1',
+        html_url: 'https://github.com/itsDNNS/tribu/releases/tag/v2026-04-27.1',
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.fetch;
+  });
+
+  test('shows the full latest release with a single v prefix', async () => {
+    renderAboutTab();
+
+    await screen.findByText('Version: v2026-04-24.131');
+    await waitFor(() => {
+      expect(screen.getByText(/v2026-04-27\.1 available/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/vv2026-04-27/)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View release notes/i })).toHaveAttribute(
+      'href',
+      'https://github.com/itsDNNS/tribu/releases/tag/v2026-04-27.1',
+    );
+  });
+});

--- a/frontend/__tests__/lib/version.test.js
+++ b/frontend/__tests__/lib/version.test.js
@@ -30,6 +30,8 @@ describe('version helpers', () => {
   test('hasNewerRelease ignores older or equal release bases for latest builds', () => {
     expect(hasNewerRelease('2026-04-24.412', 'v2026-04-24')).toBe(false);
     expect(hasNewerRelease('2026-04-24.412', 'v2026-04-25')).toBe(true);
+    expect(hasNewerRelease('2026-04-24.131', 'v2026-04-27.1')).toBe(true);
+    expect(hasNewerRelease('2026-04-27.1', 'v2026-04-27.1')).toBe(false);
     expect(hasNewerRelease('1.4.0-2-g7fd2bc4', '1.4.0')).toBe(false);
     expect(hasNewerRelease('1.4.1-3-gabcdef0', '1.4.0')).toBe(false);
     expect(hasNewerRelease('1.3.0-9-g1234567', '1.4.0')).toBe(true);
@@ -37,7 +39,9 @@ describe('version helpers', () => {
 
   test('formatDisplayedVersion prefixes product and legacy release versions', () => {
     expect(formatDisplayedVersion('2026-04-24.412')).toBe('v2026-04-24.412');
+    expect(formatDisplayedVersion('2026-04-27.1')).toBe('v2026-04-27.1');
     expect(formatDisplayedVersion('v2026-04-24')).toBe('v2026-04-24');
+    expect(formatDisplayedVersion('v2026-04-27.1')).toBe('v2026-04-27.1');
     expect(formatDisplayedVersion('1.4.0-2-g7fd2bc4+build.412')).toBe('v1.4.0-2-g7fd2bc4+build.412');
     expect(formatDisplayedVersion('v1.4.1')).toBe('v1.4.1');
     expect(formatDisplayedVersion('build.412-gabcdef1')).toBe('build.412-gabcdef1');

--- a/frontend/components/settings/AboutTab.js
+++ b/frontend/components/settings/AboutTab.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { ShieldCheck, Heart, Bug, ExternalLink } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { t } from '../../lib/i18n';
-import { extractReleaseVersion, formatDisplayedVersion, hasNewerRelease } from '../../lib/version';
+import { formatDisplayedVersion, hasNewerRelease } from '../../lib/version';
 import * as api from '../../lib/api';
 
 export default function AboutTab() {
@@ -38,7 +38,7 @@ export default function AboutTab() {
           if (cancelled || !data.tag_name) return;
           const latest = data.tag_name.replace(/^v/, '');
           const result = hasNewerRelease(current, latest)
-            ? { version: formatDisplayedVersion(extractReleaseVersion(latest) || latest), url: data.html_url }
+            ? { version: formatDisplayedVersion(latest), url: data.html_url }
             : 'up_to_date';
           setUpdateInfo(result);
           try { sessionStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), data: result })); } catch {}

--- a/frontend/e2e/tests/about-version.spec.js
+++ b/frontend/e2e/tests/about-version.spec.js
@@ -12,6 +12,13 @@ function json(route, data) {
 
 test.describe('About version', () => {
   test('shows date-based build versions with the product prefix', async ({ page }) => {
+    await page.route(/https:\/\/api\.github\.com\/repos\/itsDNNS\/tribu\/releases\/latest.*/, async (route) => {
+      return json(route, {
+        tag_name: 'v2026-04-27.1',
+        html_url: 'https://github.com/itsDNNS/tribu/releases/tag/v2026-04-27.1',
+      });
+    });
+
     await page.route(/\/api\//, async (route) => {
       const request = route.request();
       const url = new URL(request.url());
@@ -28,7 +35,7 @@ test.describe('About version', () => {
         });
       }
       if (path === '/families/me') {
-        return json(route, [{ family_id: 7, family_name: 'Test Family', role: 'member', is_adult: true }]);
+        return json(route, [{ family_id: 7, family_name: 'Test Family', role: 'admin', is_adult: true }]);
       }
       if (path === '/health') return json(route, { status: 'ok', service: 'tribu-api', version: '2026-04-24.412' });
       if (path === '/dashboard/summary') return json(route, { next_events: [], upcoming_birthdays: [] });
@@ -57,6 +64,12 @@ test.describe('About version', () => {
     }
 
     await expect(page.getByText('Version: v2026-04-24.412')).toBeVisible();
+    await expect(page.getByText(/v2026-04-27\.1 available/)).toBeVisible();
+    await expect(page.getByText(/vv2026-04-27/)).toHaveCount(0);
+    await expect(page.getByRole('link', { name: /View release notes/ })).toHaveAttribute(
+      'href',
+      'https://github.com/itsDNNS/tribu/releases/tag/v2026-04-27.1',
+    );
     const href = await page.getByRole('link', { name: /Report a bug/ }).getAttribute('href');
     expect(decodeURIComponent(href)).toContain('**Tribu Version:** v2026-04-24.412');
   });

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -388,7 +388,7 @@
   "sub_setup_contacts_hint": "Kontakte-Feed-URL im Browser öffnen, um eine VCF-Datei herunterzuladen, die in jede Kontakte-App importiert werden kann.",
   "sub_token_missing": "Erstelle zuerst ein Abo-Token, um Feed-URLs zu generieren.",
   "version": "Version",
-  "update_available": "v{version} verfügbar",
+  "update_available": "{version} verfügbar",
   "view_release": "Release-Notes anzeigen",
   "up_to_date": "Aktuell",
   "version_check_label": "Update-Prüfung",

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -388,7 +388,7 @@
   "sub_setup_contacts_hint": "Open the contacts feed URL in your browser to download a VCF file that can be imported into any contacts app.",
   "sub_token_missing": "Create a subscription token first to generate feed URLs.",
   "version": "Version",
-  "update_available": "v{version} available",
+  "update_available": "{version} available",
   "view_release": "View release notes",
   "up_to_date": "Up to date",
   "version_check_label": "Update check",

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+
+
+STABLE_RELEASE_TAG_RE = re.compile(r'^v([0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+)$')
+
+
+def test_stable_release_tag_builds_publish_latest_images():
+    workflow = Path('.github/workflows/docker.yml').read_text()
+    expected = "type=raw,value=latest,enable=${{ steps.release_tag.outputs.stable == 'true' || github.ref_name == github.event.repository.default_branch }}"
+
+    assert workflow.count('id: release_tag') == 2
+    assert workflow.count(expected) == 2
+    assert 'type=raw,value=latest,enable={{is_default_branch}}' not in workflow
+
+
+def test_stable_release_tag_detection_covers_date_patch_tags():
+    assert STABLE_RELEASE_TAG_RE.fullmatch('v2026-04-27')
+    assert STABLE_RELEASE_TAG_RE.fullmatch('v2026-04-27.1')
+    assert STABLE_RELEASE_TAG_RE.fullmatch('v1.2.3')
+    assert not STABLE_RELEASE_TAG_RE.fullmatch('v2026-04-27.1-rc1')
+    assert not STABLE_RELEASE_TAG_RE.fullmatch('v1.2.3-rc1')


### PR DESCRIPTION
## Summary
- Fix the About version update label so release tags keep their full patch suffix and render with a single `v` prefix
- Let stable release tag builds publish `latest` for both backend and frontend images
- Add unit, component, E2E, and workflow coverage for the version display and Docker tag behavior

## Test Plan
- `npm test -- --runTestsByPath __tests__/lib/version.test.js __tests__/components/AboutTab.test.js --runInBand`
- `npm run build`
- `npx playwright test e2e/tests/about-version.spec.js --project="Desktop Chrome" --project="Mobile Chrome"`
- `python3 -m pytest -q tests/test_docker_workflow.py`
