### PR TITLE
Fix desktop calendar time inputs

### DIFF
--- a/frontend/e2e/tests/calendar.spec.js
+++ b/frontend/e2e/tests/calendar.spec.js
@@ -27,6 +27,34 @@ test.describe('Calendar', () => {
     await expect(page.getByText('E2E Test Event')).toBeVisible({ timeout: 10000 });
   });
 
+  test('desktop event form gives date-time fields enough room for time entry', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await navigateTo(page, 'Calendar');
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+
+    await page.locator('.calendar-day:not(.other-month)', { hasText: /^15$/ }).first().click();
+
+    const form = page.locator('.day-detail-panel .quick-add-form');
+    await expect(form).toBeVisible({ timeout: 5000 });
+    const startInput = form.locator('input[type="datetime-local"]').first();
+    const endInput = form.locator('input[type="datetime-local"]').nth(1);
+    await expect(startInput).toBeVisible();
+    await expect(endInput).toBeVisible();
+
+    const [formBox, startBox, endBox] = await Promise.all([
+      form.boundingBox(),
+      startInput.boundingBox(),
+      endInput.boundingBox(),
+    ]);
+    expect(formBox).not.toBeNull();
+    expect(startBox).not.toBeNull();
+    expect(endBox).not.toBeNull();
+
+    expect(startBox.width).toBeGreaterThan(250);
+    expect(endBox.width).toBeGreaterThan(250);
+    expect(endBox.y).toBeGreaterThan(startBox.y + startBox.height - 1);
+  });
+
   test('delete an event', async ({ authedPage: page, apiCtx }) => {
     const familyId = await getFamilyId(apiCtx);
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -999,6 +999,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .cal-form-label { font-size: 0.75rem; color: var(--text-muted); margin-bottom: 4px; }
 .cal-form-section-title { font-size: 0.78rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: var(--space-md); }
 .cal-form-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-sm); }
+.day-detail-panel .cal-form-row { grid-template-columns: 1fr; }
 .cal-form-actions { display: flex; gap: var(--space-sm); }
 .cal-empty-day { color: var(--text-muted); font-size: 0.88rem; }
 .cal-onboard { margin-top: var(--space-md); padding: var(--space-md); border-radius: var(--radius-sm); background: rgba(124, 58, 237, 0.06); border: 1px solid rgba(124, 58, 237, 0.12); }


### PR DESCRIPTION
## Summary
- Stacks the calendar side-panel date/time fields on desktop so the time portion stays usable.
- Keeps the generic two-column form row layout outside the event side panel.
- Adds a Playwright regression for the desktop calendar event form.

## Tests
- `npm run build`
- `npx playwright test e2e/tests/calendar.spec.js --project="Desktop Chrome" --project="Mobile Chrome" --reporter=line`
- `git diff --check`
