### PR TITLE
fix(settings): use frontend build version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,6 +97,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect stable release tag
         id: release_tag
@@ -106,6 +108,24 @@ jobs:
             stable=true
           fi
           echo "stable=${stable}" >> "$GITHUB_OUTPUT"
+
+      - name: Derive frontend app version
+        id: frontend_app_version
+        run: |
+          raw="$(git describe --tags --abbrev=7 --match 'v[0-9]*' --always)"
+          cleaned="${raw#v}"
+          build_date="$(date -u +%F)"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v?[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${cleaned}"
+          elif [[ "${cleaned}" =~ ^([0-9]{4}-[0-9]{2}-[0-9]{2})(-|$) ]]; then
+            version="${BASH_REMATCH[1]}.${GITHUB_RUN_NUMBER}"
+          else
+            version="${build_date}.${GITHUB_RUN_NUMBER}"
+          fi
+          echo "value=${version}" >> "$GITHUB_OUTPUT"
+          echo "date=${build_date}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
 
@@ -136,5 +156,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_APP_VERSION=${{ steps.frontend_app_version.outputs.value }}
+            NEXT_PUBLIC_APP_BUILD_NUMBER=${{ github.run_number }}
+            NEXT_PUBLIC_APP_GIT_SHA=${{ github.sha }}
+            NEXT_PUBLIC_APP_BUILD_DATE=${{ steps.frontend_app_version.outputs.date }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,20 @@ WORKDIR /app
 
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# NEXT_PUBLIC_* vars must be present during `next build` because Next.js
+# substitutes them into the client bundle at compile time. The CI
+# workflow passes the same value the backend gets for APP_VERSION, so
+# the running frontend reports its own build instead of the backend's
+# /health version when the two images ship independently.
+ARG NEXT_PUBLIC_APP_VERSION=""
+ARG NEXT_PUBLIC_APP_BUILD_NUMBER=""
+ARG NEXT_PUBLIC_APP_GIT_SHA=""
+ARG NEXT_PUBLIC_APP_BUILD_DATE=""
+ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
+ENV NEXT_PUBLIC_APP_BUILD_NUMBER=$NEXT_PUBLIC_APP_BUILD_NUMBER
+ENV NEXT_PUBLIC_APP_GIT_SHA=$NEXT_PUBLIC_APP_GIT_SHA
+ENV NEXT_PUBLIC_APP_BUILD_DATE=$NEXT_PUBLIC_APP_BUILD_DATE
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 

--- a/frontend/__tests__/components/AboutTab.test.js
+++ b/frontend/__tests__/components/AboutTab.test.js
@@ -29,7 +29,40 @@ describe('AboutTab version update check', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+    delete process.env.NEXT_PUBLIC_TRIBU_VERSION;
     delete global.fetch;
+  });
+
+  test('uses the frontend build version when it is newer than the backend health version', async () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = '2026-04-28.181';
+
+    renderAboutTab();
+
+    await screen.findByText('Version: v2026-04-28.181');
+    await waitFor(() => {
+      expect(screen.getByText(/Up to date/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/v2026-04-27\.1 available/)).not.toBeInTheDocument();
+  });
+
+  test('does not reuse a cached update result from an older effective version', async () => {
+    sessionStorage.setItem('tribu_update_check:2026-04-24.131', JSON.stringify({
+      ts: Date.now(),
+      data: {
+        version: 'v2026-04-27.1',
+        url: 'https://github.com/itsDNNS/tribu/releases/tag/v2026-04-27.1',
+      },
+    }));
+    process.env.NEXT_PUBLIC_APP_VERSION = '2026-04-28.181';
+
+    renderAboutTab();
+
+    await screen.findByText('Version: v2026-04-28.181');
+    await waitFor(() => {
+      expect(screen.getByText(/Up to date/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/v2026-04-27\.1 available/)).not.toBeInTheDocument();
   });
 
   test('shows the full latest release with a single v prefix', async () => {

--- a/frontend/components/settings/AboutTab.js
+++ b/frontend/components/settings/AboutTab.js
@@ -7,46 +7,59 @@ import * as api from '../../lib/api';
 
 export default function AboutTab() {
   const { messages, isAdmin } = useApp();
-  const [version, setVersion] = useState(null);
+  // The frontend build version is baked in by the Docker build (Next.js
+  // inlines NEXT_PUBLIC_* at build time). When backend and frontend
+  // images are released independently, the backend's /health version
+  // can lag behind the running frontend bundle, so prefer the frontend
+  // build version for both the displayed version and the update check.
+  const buildVersion = process.env.NEXT_PUBLIC_APP_VERSION || null;
+  const [healthVersion, setHealthVersion] = useState(null);
   const [updateInfo, setUpdateInfo] = useState(null);
-  const displayedVersion = formatDisplayedVersion(version);
+  const effectiveVersion = buildVersion || healthVersion;
+  const displayedVersion = formatDisplayedVersion(effectiveVersion);
 
   useEffect(() => {
+    if (buildVersion) return undefined;
     let cancelled = false;
-    api.apiGetHealth().then(res => {
-      if (cancelled || !res.ok || !res.data?.version) return;
-      const current = res.data.version;
-      setVersion(current);
-
-      if (!isAdmin) return;
-      if (typeof navigator !== 'undefined' && navigator.onLine === false) return;
-      const CACHE_KEY = 'tribu_update_check';
-      const CACHE_TTL = 60 * 60 * 1000;
-      try {
-        const cached = JSON.parse(sessionStorage.getItem(CACHE_KEY) || 'null');
-        if (cached && Date.now() - cached.ts < CACHE_TTL) {
-          setUpdateInfo(cached.data);
-          return;
-        }
-      } catch {}
-      const ctrl = new AbortController();
-      const timer = setTimeout(() => ctrl.abort(), 3000);
-      fetch('https://api.github.com/repos/itsDNNS/tribu/releases/latest', { signal: ctrl.signal })
-        .then(r => r.json())
-        .then(data => {
-          clearTimeout(timer);
-          if (cancelled || !data.tag_name) return;
-          const latest = data.tag_name.replace(/^v/, '');
-          const result = hasNewerRelease(current, latest)
-            ? { version: formatDisplayedVersion(latest), url: data.html_url }
-            : 'up_to_date';
-          setUpdateInfo(result);
-          try { sessionStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), data: result })); } catch {}
-        })
-        .catch(() => clearTimeout(timer));
-    }).catch(() => null);
+    api.apiGetHealth()
+      .then(res => {
+        if (cancelled || !res.ok || !res.data?.version) return;
+        setHealthVersion(res.data.version);
+      })
+      .catch(() => null);
     return () => { cancelled = true; };
-  }, [isAdmin]);
+  }, [buildVersion]);
+
+  useEffect(() => {
+    if (!effectiveVersion || !isAdmin) return undefined;
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) return undefined;
+    let cancelled = false;
+    const CACHE_KEY = `tribu_update_check:${effectiveVersion}`;
+    const CACHE_TTL = 60 * 60 * 1000;
+    try {
+      const cached = JSON.parse(sessionStorage.getItem(CACHE_KEY) || 'null');
+      if (cached && Date.now() - cached.ts < CACHE_TTL) {
+        setUpdateInfo(cached.data);
+        return undefined;
+      }
+    } catch {}
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 3000);
+    fetch('https://api.github.com/repos/itsDNNS/tribu/releases/latest', { signal: ctrl.signal })
+      .then(r => r.json())
+      .then(data => {
+        clearTimeout(timer);
+        if (cancelled || !data.tag_name) return;
+        const latest = data.tag_name.replace(/^v/, '');
+        const result = hasNewerRelease(effectiveVersion, latest)
+          ? { version: formatDisplayedVersion(latest), url: data.html_url }
+          : 'up_to_date';
+        setUpdateInfo(result);
+        try { sessionStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), data: result })); } catch {}
+      })
+      .catch(() => clearTimeout(timer));
+    return () => { cancelled = true; };
+  }, [effectiveVersion, isAdmin]);
 
   return (
     <div className="settings-grid">
@@ -56,7 +69,7 @@ export default function AboutTab() {
         <p className="set-about-desc">
           {t(messages, 'privacy_note')}
         </p>
-        {version && (
+        {effectiveVersion && (
           <div className="set-about-version">
             <span>{t(messages, 'version')}: {displayedVersion}</span>
             {isAdmin && updateInfo === 'up_to_date' && (

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -20,3 +20,12 @@ def test_stable_release_tag_detection_covers_date_patch_tags():
     assert STABLE_RELEASE_TAG_RE.fullmatch('v1.2.3')
     assert not STABLE_RELEASE_TAG_RE.fullmatch('v2026-04-27.1-rc1')
     assert not STABLE_RELEASE_TAG_RE.fullmatch('v1.2.3-rc1')
+
+
+def test_frontend_image_receives_same_build_version_as_backend():
+    workflow = Path('.github/workflows/docker.yml').read_text()
+
+    assert 'id: frontend_app_version' in workflow
+    assert 'NEXT_PUBLIC_APP_VERSION=${{ steps.frontend_app_version.outputs.value }}' in workflow
+    assert 'NEXT_PUBLIC_APP_BUILD_NUMBER=${{ github.run_number }}' in workflow
+    assert 'NEXT_PUBLIC_APP_GIT_SHA=${{ github.sha }}' in workflow


### PR DESCRIPTION
## Summary
- use the frontend build version for Settings/About when it is baked into the frontend image
- pass the derived app version into the frontend Docker build so split frontend/backend deployments show the active frontend build
- scope the release-check cache by the displayed version to avoid stale update banners after upgrades

## Tests
- `cd frontend && npm test -- --runTestsByPath __tests__/lib/version.test.js __tests__/components/AboutTab.test.js --runInBand`
- `python3 -m pytest -q tests/test_docker_workflow.py`
- `cd frontend && npm run build`
- `BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/tests/about-version.spec.js --project="Desktop Chrome" --project="Mobile Chrome" --reporter=line`
- `git diff --check`
