### PR TITLE
Add weekly meal plan shopping list push

### DIFF
--- a/backend/app/modules/meal_plans_router.py
+++ b/backend/app/modules/meal_plans_router.py
@@ -36,6 +36,7 @@ from app.schemas import (
     IngredientItem,
     MealPlanAddToShoppingRequest,
     MealPlanAddToShoppingResponse,
+    MealPlanWeekAddToShoppingRequest,
     MealPlanCreate,
     MealPlanIngredientsResponse,
     MealPlanResponse,
@@ -204,6 +205,42 @@ def _format_spec(amount: Optional[float], unit: Optional[str]) -> Optional[str]:
     if unit:
         parts.append(unit)
     return " ".join(parts) if parts else None
+
+
+def _aggregation_key(entry: NormalizedIngredient) -> tuple[str, str | None] | None:
+    """Return a safe key for combining quantities across meals.
+
+    We only merge rows that have the same ingredient name and the same unit
+    shape. Unitless items are mergeable with each other as checklist items;
+    rows with an amount but no unit are kept separate because the meaning can
+    be ambiguous across recipes.
+    """
+    name_key = entry["name"].strip().lower()
+    amount = entry["amount"]
+    unit = entry["unit"]
+    if amount is None and unit is None:
+        return (name_key, None)
+    if amount is not None and unit:
+        return (name_key, unit.strip().lower())
+    return None
+
+
+def _aggregate_week_ingredients(plans: list[MealPlan]) -> list[NormalizedIngredient]:
+    """Aggregate ingredients from multiple meal-plan rows for one week."""
+    aggregated: list[NormalizedIngredient] = []
+    index: dict[tuple[str, str | None], int] = {}
+    for plan in plans:
+        for entry in _normalize_stored_ingredients(plan.ingredients):
+            key = _aggregation_key(entry)
+            if key is None or key not in index:
+                if key is not None:
+                    index[key] = len(aggregated)
+                aggregated.append(dict(entry))
+                continue
+            existing = aggregated[index[key]]
+            if existing["amount"] is not None and entry["amount"] is not None:
+                existing["amount"] += entry["amount"]
+    return aggregated
 
 
 def _slot_taken(db: Session, family_id: int, plan_date: date, slot: str, exclude_id: Optional[int] = None) -> bool:
@@ -383,6 +420,60 @@ def delete_meal_plan(
     db.delete(plan)
     db.commit()
     return {"status": "deleted", "meal_plan_id": plan_id}
+
+
+@router.post(
+    "/week/add-to-shopping",
+    response_model=MealPlanAddToShoppingResponse,
+    summary="Push a week's meal ingredients onto a shopping list",
+    description=(
+        "Collect all meal-plan ingredients for the selected family week and "
+        "append them to the target shopping list. Compatible duplicates are "
+        "merged by ingredient name and unit. Scope: `meal_plans:write`."
+    ),
+    responses={**NOT_FOUND_RESPONSE},
+)
+def add_week_ingredients_to_shopping(
+    payload: MealPlanWeekAddToShoppingRequest,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("meal_plans:write"),
+):
+    ensure_family_membership(db, user.id, payload.family_id)
+    shopping_list = db.query(ShoppingList).filter(ShoppingList.id == payload.shopping_list_id).first()
+    if shopping_list is None or shopping_list.family_id != payload.family_id:
+        raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
+
+    week_end = date.fromordinal(payload.week_start.toordinal() + 6)
+    plans = (
+        db.query(MealPlan)
+        .filter(
+            MealPlan.family_id == payload.family_id,
+            MealPlan.plan_date >= payload.week_start,
+            MealPlan.plan_date <= week_end,
+        )
+        .order_by(MealPlan.plan_date, MealPlan.slot, MealPlan.id)
+        .all()
+    )
+
+    created: list[ShoppingItem] = []
+    for entry in _aggregate_week_ingredients(plans):
+        item = ShoppingItem(
+            list_id=shopping_list.id,
+            name=entry["name"].strip(),
+            spec=_format_spec(entry["amount"], entry["unit"]),
+            added_by_user_id=user.id,
+        )
+        db.add(item)
+        created.append(item)
+    db.commit()
+    for item in created:
+        db.refresh(item)
+        broadcast_item_added(
+            shopping_list.id,
+            ShoppingItemResponse.model_validate(item).model_dump(mode="json"),
+        )
+    return MealPlanAddToShoppingResponse(added_count=len(created))
 
 
 @router.post(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1241,6 +1241,12 @@ class MealPlanIngredientsResponse(BaseModel):
     items: list[str]
 
 
+class MealPlanWeekAddToShoppingRequest(BaseModel):
+    family_id: int = Field(..., description="Family ID")
+    week_start: date = Field(..., description="First day of the week to push")
+    shopping_list_id: int = Field(..., description="Target shopping list ID")
+
+
 class MealPlanAddToShoppingRequest(BaseModel):
     shopping_list_id: int = Field(..., description="Target shopping list ID")
     ingredient_names: Optional[list[str]] = Field(

--- a/backend/tests/test_meal_plans.py
+++ b/backend/tests/test_meal_plans.py
@@ -408,6 +408,102 @@ class TestMealPlanIngredients:
         assert items == ["Basilikum", "Kaese", "Mehl", "Olivenoel", "Tomaten"]
 
 
+class TestWeeklyMealPlanShoppingIntegration:
+    def test_push_week_merges_compatible_duplicates_and_preserves_unsafe_items(self):
+        token, family_id = _seed_member("*", "week-shop")
+        list_id = _seed_shopping_list(family_id)
+
+        meals = [
+            ("2026-04-13", "morning", "Pancakes", [_ing("Flour", 500, "g"), _ing("Milk", 1, "l"), _ing("Basil")]),
+            ("2026-04-14", "noon", "Pasta", [_ing("flour", 250, "g"), _ing("Milk", 500, "ml"), _ing("basil")]),
+            ("2026-04-15", "evening", "Cake", [_ing("Sugar", 2, "tbsp"), _ing("Sugar")]),
+        ]
+        for plan_date, slot, meal_name, ingredients in meals:
+            resp = client.post(
+                "/meal-plans",
+                json={
+                    "family_id": family_id,
+                    "plan_date": plan_date,
+                    "slot": slot,
+                    "meal_name": meal_name,
+                    "ingredients": ingredients,
+                },
+                headers=_auth(token),
+            )
+            assert resp.status_code == 200, resp.json()
+
+        push = client.post(
+            "/meal-plans/week/add-to-shopping",
+            json={
+                "family_id": family_id,
+                "week_start": "2026-04-13",
+                "shopping_list_id": list_id,
+            },
+            headers=_auth(token),
+        )
+        assert push.status_code == 200, push.json()
+        assert push.json()["added_count"] == 5
+
+        items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
+        pairs = sorted((item["name"], item["spec"]) for item in items)
+        assert pairs == sorted([
+            ("Basil", None),
+            ("Flour", "750 g"),
+            ("Milk", "1 l"),
+            ("Milk", "500 ml"),
+            ("Sugar", "2 tbsp"),
+        ])
+
+    def test_push_week_only_uses_selected_family_week_and_target_list_family(self):
+        token, family_id = _seed_member("*", "week-scope")
+        list_id = _seed_shopping_list(family_id)
+
+        in_week = client.post(
+            "/meal-plans",
+            json={
+                "family_id": family_id,
+                "plan_date": "2026-04-13",
+                "slot": "noon",
+                "meal_name": "Soup",
+                "ingredients": [_ing("Carrot", 2, "pcs")],
+            },
+            headers=_auth(token),
+        )
+        assert in_week.status_code == 200
+        out_of_week = client.post(
+            "/meal-plans",
+            json={
+                "family_id": family_id,
+                "plan_date": "2026-04-20",
+                "slot": "noon",
+                "meal_name": "Next soup",
+                "ingredients": [_ing("Potato", 3, "pcs")],
+            },
+            headers=_auth(token),
+        )
+        assert out_of_week.status_code == 200
+
+        push = client.post(
+            "/meal-plans/week/add-to-shopping",
+            json={"family_id": family_id, "week_start": "2026-04-13", "shopping_list_id": list_id},
+            headers=_auth(token),
+        )
+        assert push.status_code == 200
+        assert push.json()["added_count"] == 1
+        items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
+        assert [(item["name"], item["spec"]) for item in items] == [("Carrot", "2 pcs")]
+
+        _, other_family_id = _seed_member("*", "week-other")
+        other_list = _seed_shopping_list(other_family_id)
+        bad = client.post(
+            "/meal-plans/week/add-to-shopping",
+            json={"family_id": family_id, "week_start": "2026-04-13", "shopping_list_id": other_list},
+            headers=_auth(token),
+        )
+        assert bad.status_code == 404
+        assert "SHOPPING_LIST_NOT_FOUND" in str(bad.json())
+
+
 class TestMealPlanShoppingIntegration:
     def test_push_all_ingredients_formats_spec(self):
         token, family_id = _seed_member("*", "shop-a")

--- a/frontend/__tests__/components/MealPlansView.test.js
+++ b/frontend/__tests__/components/MealPlansView.test.js
@@ -16,6 +16,7 @@ const apiListMealPlanIngredients = jest.fn();
 const apiListRecipes = jest.fn();
 const apiCreateMealPlan = jest.fn();
 const apiDeleteMealPlan = jest.fn();
+const apiAddWeekMealIngredientsToShopping = jest.fn();
 jest.mock('../../lib/api', () => ({
   apiListMealPlans: (...args) => apiListMealPlans(...args),
   apiListMealPlanIngredients: (...args) => apiListMealPlanIngredients(...args),
@@ -24,6 +25,7 @@ jest.mock('../../lib/api', () => ({
   apiUpdateMealPlan: jest.fn(),
   apiDeleteMealPlan: (...args) => apiDeleteMealPlan(...args),
   apiAddMealIngredientsToShopping: jest.fn(),
+  apiAddWeekMealIngredientsToShopping: (...args) => apiAddWeekMealIngredientsToShopping(...args),
 }));
 
 const messages = {
@@ -74,6 +76,11 @@ const messages = {
   'module.meal_plans.ingredients_summary_one': '1 Zutat',
   'module.meal_plans.ingredients_summary': '{count} Zutaten',
   'module.meal_plans.drag_aria': 'Ziehen {name}',
+  'module.meal_plans.push_to_shopping': 'In Einkaufsliste',
+  'module.meal_plans.push_week_to_shopping': 'Woche zur Einkaufsliste hinzufügen',
+  'module.meal_plans.push_week_to_shopping_aria': 'Alle Zutaten dieser Woche in Einkaufsliste schieben',
+  'module.meal_plans.pushed_one': '1 Zutat auf die Einkaufsliste geschoben',
+  'module.meal_plans.pushed_many': '{count} Zutaten auf die Einkaufsliste geschoben',
   confirm: 'Bestätigen',
   cancel: 'Abbrechen',
 };
@@ -95,11 +102,13 @@ describe('MealPlansView', () => {
     apiListRecipes.mockReset();
     apiCreateMealPlan.mockReset();
     apiDeleteMealPlan.mockReset();
+    apiAddWeekMealIngredientsToShopping.mockReset();
     apiListMealPlans.mockResolvedValue({ ok: true, data: [] });
     apiListMealPlanIngredients.mockResolvedValue({ ok: true, data: { items: [] } });
     apiListRecipes.mockResolvedValue({ ok: true, data: [] });
     apiCreateMealPlan.mockResolvedValue({ ok: true, data: {} });
     apiDeleteMealPlan.mockResolvedValue({ ok: true, data: {} });
+    apiAddWeekMealIngredientsToShopping.mockResolvedValue({ ok: true, data: { added_count: 2 } });
   });
 
   test('renders the add button, fetches the week, and the grid has 7 day headers + 3 slots', async () => {
@@ -172,6 +181,51 @@ describe('MealPlansView', () => {
       ],
     });
   });
+
+  test('pushes the visible week ingredients to the selected shopping list', async () => {
+    mockAppState = baseState({ shoppingLists: [{ id: 55, name: 'Groceries' }] });
+    apiListMealPlans.mockResolvedValueOnce({
+      ok: true,
+      data: [
+        {
+          id: 11,
+          family_id: 1,
+          plan_date: '2099-01-05',
+          slot: 'noon',
+          meal_name: 'Weekly Pasta',
+          ingredients: [{ name: 'Flour', amount: 500, unit: 'g' }],
+          notes: null,
+          created_by_user_id: null,
+          created_at: '2099-01-05T00:00:00',
+          updated_at: '2099-01-05T00:00:00',
+        },
+      ],
+    });
+
+    const realDate = global.Date;
+    global.Date = class extends realDate {
+      constructor(...args) {
+        if (args.length === 0) {
+          super('2099-01-05T12:00:00Z');
+        } else {
+          super(...args);
+        }
+      }
+      static now() { return new realDate('2099-01-05T12:00:00Z').getTime(); }
+    };
+
+    try {
+      render(<MealPlansView />);
+      await waitFor(() => expect(screen.getByText('Weekly Pasta')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Alle Zutaten dieser Woche in Einkaufsliste schieben' }));
+
+      await waitFor(() => expect(apiAddWeekMealIngredientsToShopping).toHaveBeenCalledWith(1, '2099-01-05', 55));
+    } finally {
+      global.Date = realDate;
+    }
+  });
+
 
   test('409 on create surfaces the translated slot-taken toast', async () => {
     mockAppState = baseState();

--- a/frontend/components/MealPlansView.js
+++ b/frontend/components/MealPlansView.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ChevronLeft, ChevronRight, UtensilsCrossed, Plus, Edit2, CalendarDays, GripVertical } from 'lucide-react';
+import { ChevronLeft, ChevronRight, UtensilsCrossed, Plus, Edit2, CalendarDays, GripVertical, ShoppingCart } from 'lucide-react';
 import {
   DndContext,
   DragOverlay,
@@ -116,7 +116,7 @@ function DroppableEmptyCell({ date, slot, messages, onClick }) {
 }
 
 export default function MealPlansView() {
-  const { familyId, families, messages, demoMode, shoppingLists } = useApp();
+  const { familyId, families, messages, demoMode, shoppingLists = [] } = useApp();
   const hook = useMealPlans();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState(null);
@@ -124,6 +124,8 @@ export default function MealPlansView() {
   const [confirmAction, setConfirmAction] = useState(null);
   const [activeDrag, setActiveDrag] = useState(null);
   const [recipes, setRecipes] = useState([]);
+  const [selectedWeekListId, setSelectedWeekListId] = useState('');
+  const [pushingWeek, setPushingWeek] = useState(false);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -141,6 +143,13 @@ export default function MealPlansView() {
     });
     return () => { active = false; };
   }, [familyId, demoMode]);
+
+
+  useEffect(() => {
+    if ((shoppingLists || []).length > 0 && !selectedWeekListId) {
+      setSelectedWeekListId(String(shoppingLists[0].id));
+    }
+  }, [shoppingLists, selectedWeekListId]);
 
   if (demoMode) {
     return (
@@ -222,6 +231,17 @@ export default function MealPlansView() {
     setActiveDrag(null);
   }
 
+  async function handlePushWeekToShopping() {
+    if (!selectedWeekListId) return;
+    setPushingWeek(true);
+    try {
+      await hook.pushWeekToShopping(Number(selectedWeekListId));
+    } finally {
+      setPushingWeek(false);
+    }
+  }
+
+
   async function handlePushToShopping(shoppingListId, ingredientNames) {
     if (editingId == null) return { ok: false };
     return hook.pushToShopping(editingId, shoppingListId, ingredientNames);
@@ -288,6 +308,31 @@ export default function MealPlansView() {
               <ChevronRight size={16} />
             </button>
           </div>
+
+          {shoppingLists.length > 0 && (
+            <div className="meal-week-shopping" role="group" aria-label={t(messages, 'module.meal_plans.push_week_to_shopping')}>
+              <select
+                className="form-input meal-week-shopping-list"
+                value={selectedWeekListId}
+                onChange={(e) => setSelectedWeekListId(e.target.value)}
+                aria-label={t(messages, 'module.meal_plans.push_to_shopping')}
+              >
+                {shoppingLists.map((list) => (
+                  <option key={list.id} value={list.id}>{list.name}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={handlePushWeekToShopping}
+                disabled={pushingWeek || !selectedWeekListId}
+                aria-label={t(messages, 'module.meal_plans.push_week_to_shopping_aria')}
+              >
+                <ShoppingCart size={16} aria-hidden="true" />
+                {t(messages, 'module.meal_plans.push_week_to_shopping')}
+              </button>
+            </div>
+          )}
           <button
             type="button"
             className="btn btn-primary"

--- a/frontend/e2e/helpers/api-setup.js
+++ b/frontend/e2e/helpers/api-setup.js
@@ -75,6 +75,24 @@ async function seedShoppingItem(request, listId, name = 'Milk', spec = '') {
   return res.json();
 }
 
+
+async function seedMealPlan(request, familyId, overrides = {}) {
+  const res = await request.post('/api/meal-plans', {
+    data: {
+      family_id: familyId,
+      plan_date: overrides.plan_date,
+      slot: overrides.slot || 'noon',
+      meal_name: overrides.meal_name || 'Test meal',
+      ingredients: overrides.ingredients || [],
+      notes: overrides.notes ?? null,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/meal-plans failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
 module.exports = {
   getFamilyId,
   seedCalendarEvent,
@@ -82,4 +100,5 @@ module.exports = {
   completeTask,
   seedShoppingList,
   seedShoppingItem,
+  seedMealPlan,
 };

--- a/frontend/e2e/tests/meal-plans.spec.js
+++ b/frontend/e2e/tests/meal-plans.spec.js
@@ -1,0 +1,82 @@
+const { test, expect, request } = require('@playwright/test');
+const { getFamilyId, seedShoppingList, seedMealPlan } = require('../helpers/api-setup');
+const { navigateTo } = require('../helpers/navigation');
+
+function formatIsoDate(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+async function registerWorkerUser(baseURL, browserName) {
+  const api = await request.newContext({ baseURL });
+  const suffix = `${browserName}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const response = await api.post('/api/auth/register', {
+    data: {
+      email: `weekly-meal-${suffix}@example.com`,
+      password: 'Password123!',
+      display_name: 'Weekly Meal E2E',
+      family_name: 'Weekly Meal Family',
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Register worker user failed (${response.status()}): ${await response.text()}`);
+  }
+
+  const storageState = await api.storageState();
+  return { api, cookies: storageState.cookies };
+}
+
+test.describe('Meal plan', () => {
+  test('pushes the current week ingredients to a shopping list', async ({ page, baseURL, browserName }) => {
+    const workerUser = await registerWorkerUser(baseURL, browserName);
+    await page.context().addCookies(workerUser.cookies);
+
+    try {
+      const familyId = await getFamilyId(workerUser.api);
+      await seedShoppingList(workerUser.api, familyId, 'Weekly Groceries');
+      const today = formatIsoDate(new Date());
+
+      await seedMealPlan(workerUser.api, familyId, {
+        plan_date: today,
+        slot: 'morning',
+        meal_name: 'Pancakes',
+        ingredients: [
+          { name: 'Flour', amount: 500, unit: 'g' },
+          { name: 'Milk', amount: 1, unit: 'l' },
+        ],
+      });
+      await seedMealPlan(workerUser.api, familyId, {
+        plan_date: today,
+        slot: 'noon',
+        meal_name: 'Pasta',
+        ingredients: [
+          { name: 'flour', amount: 250, unit: 'g' },
+          { name: 'Basil', amount: null, unit: null },
+        ],
+      });
+
+      await page.goto('/#meal_plans', { waitUntil: 'domcontentloaded', timeout: 90000 }).catch((error) => {
+        if (!String(error).includes('ERR_ABORTED')) throw error;
+      });
+      await page.locator('#main-content').waitFor({ state: 'attached', timeout: 90000 });
+
+      await expect(page.getByText('Pancakes')).toBeVisible({ timeout: 90000 });
+      await expect(page.getByText('Pasta')).toBeVisible({ timeout: 90000 });
+      await page
+        .getByRole('button', { name: 'Push all ingredients from this week to a shopping list' })
+        .click();
+
+      await navigateTo(page, 'Shopping');
+
+      await expect(page.getByText('Weekly Groceries')).toBeVisible({ timeout: 90000 });
+      await page.locator('.shopping-list-card', { hasText: 'Weekly Groceries' }).click();
+      await expect(page.getByText('Flour')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByText('750 g')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByText('Milk')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByText('1 l')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByText('Basil')).toBeVisible({ timeout: 30000 });
+    } finally {
+      await workerUser.api.dispose();
+    }
+  });
+});

--- a/frontend/hooks/useMealPlans.js
+++ b/frontend/hooks/useMealPlans.js
@@ -191,6 +191,27 @@ export function useMealPlans() {
     return { ok: true, added };
   }
 
+  async function pushWeekToShopping(shoppingListId) {
+    const { ok, data } = await api.apiAddWeekMealIngredientsToShopping(
+      Number(familyId),
+      formatIsoDate(weekStart),
+      shoppingListId,
+    );
+    if (!ok) {
+      toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
+      return { ok: false };
+    }
+    const added = data?.added_count ?? 0;
+    const template = added === 1
+      ? t(messages, 'module.meal_plans.pushed_one')
+      : t(messages, 'module.meal_plans.pushed_many');
+    const msg = template.replace('{count}', String(added));
+    toastSuccess(msg);
+    announce(msg);
+    return { ok: true, added };
+  }
+
+
   function populateFormFromMeal(meal) {
     return {
       plan_date: meal.plan_date,
@@ -225,6 +246,7 @@ export function useMealPlans() {
     deleteMeal,
     moveMeal,
     pushToShopping,
+    pushWeekToShopping,
     populateFormFromMeal,
     emptyFormFor,
   };

--- a/frontend/i18n/modules/meal_plans/de.json
+++ b/frontend/i18n/modules/meal_plans/de.json
@@ -48,6 +48,8 @@
   "module.meal_plans.delete_confirm": "\"{name}\" wirklich entfernen?",
   "module.meal_plans.edit_aria": "Mahlzeit \"{name}\" bearbeiten",
   "module.meal_plans.add_for_slot_aria": "Mahlzeit für {slot} am {date} hinzufügen",
+  "module.meal_plans.push_week_to_shopping": "Woche zur Einkaufsliste hinzufügen",
+  "module.meal_plans.push_week_to_shopping_aria": "Alle Zutaten dieser Woche in Einkaufsliste schieben",
   "module.meal_plans.push_to_shopping": "In Einkaufsliste",
   "module.meal_plans.drag_aria": "\"{name}\" auf einen anderen Slot ziehen",
   "module.meal_plans.pushed_one": "1 Zutat auf die Einkaufsliste geschoben",

--- a/frontend/i18n/modules/meal_plans/en.json
+++ b/frontend/i18n/modules/meal_plans/en.json
@@ -48,6 +48,8 @@
   "module.meal_plans.delete_confirm": "Really remove \"{name}\"?",
   "module.meal_plans.edit_aria": "Edit meal \"{name}\"",
   "module.meal_plans.add_for_slot_aria": "Add meal for {slot} on {date}",
+  "module.meal_plans.push_week_to_shopping": "Add week to shopping list",
+  "module.meal_plans.push_week_to_shopping_aria": "Push all ingredients from this week to a shopping list",
   "module.meal_plans.push_to_shopping": "To shopping list",
   "module.meal_plans.drag_aria": "Drag \"{name}\" to another slot",
   "module.meal_plans.pushed_one": "1 ingredient pushed to the shopping list",

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -563,6 +563,15 @@ export function apiAddMealIngredientsToShopping(planId, shoppingListId, ingredie
   return post(`/meal-plans/${planId}/add-to-shopping`, body);
 }
 
+export function apiAddWeekMealIngredientsToShopping(familyId, weekStart, shoppingListId) {
+  return post('/meal-plans/week/add-to-shopping', {
+    family_id: Number(familyId),
+    week_start: weekStart,
+    shopping_list_id: shoppingListId,
+  });
+}
+
+
 // Recipes
 export function apiListRecipes(familyId) {
   const params = new URLSearchParams({ family_id: String(familyId) });


### PR DESCRIPTION
## Summary
- Add a week-level meal plan action that sends all planned ingredients to a selected shopping list
- Merge duplicate ingredients conservatively when names and units match
- Keep existing single-meal shopping list behavior covered

## Test plan
- `DATABASE_URL=sqlite:///./test-meal-plans.db JWT_SECRET=test-secret PYTHONPATH=$PWD pytest -q tests/test_meal_plans.py`
- `npm test -- --runTestsByPath __tests__/components/MealPlansView.test.js --runInBand`
- `npm run build`
- `BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/tests/meal-plans.spec.js --project="Desktop Chrome" --reporter=line --timeout=90000 --global-timeout=180000`
- `BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/tests/meal-plans.spec.js --project="Mobile Chrome" --reporter=line --timeout=90000 --global-timeout=180000`

Closes #232
