### PR TITLE
Add reusable shopping list templates

### DIFF
--- a/backend/alembic/versions/0037_add_shopping_templates.py
+++ b/backend/alembic/versions/0037_add_shopping_templates.py
@@ -1,0 +1,79 @@
+"""Add shopping list templates.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-04-28
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0037"
+down_revision: Union[str, None] = "0036"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(table: str) -> bool:
+    return table in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table: str, column: str) -> bool:
+    if not _has_table(table):
+        return False
+    return any(c["name"] == column for c in sa.inspect(op.get_bind()).get_columns(table))
+
+
+def upgrade() -> None:
+    if _has_table("shopping_items") and not _has_column("shopping_items", "category"):
+        op.add_column("shopping_items", sa.Column("category", sa.String(), nullable=True))
+
+    if not _has_table("shopping_templates"):
+        op.create_table(
+            "shopping_templates",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("family_id", sa.Integer(), nullable=False),
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(op.f("ix_shopping_templates_id"), "shopping_templates", ["id"], unique=False)
+        op.create_index(op.f("ix_shopping_templates_family_id"), "shopping_templates", ["family_id"], unique=False)
+
+    if not _has_table("shopping_template_items"):
+        op.create_table(
+            "shopping_template_items",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("template_id", sa.Integer(), nullable=False),
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("spec", sa.String(), nullable=True),
+            sa.Column("category", sa.String(), nullable=True),
+            sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(["template_id"], ["shopping_templates.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(op.f("ix_shopping_template_items_id"), "shopping_template_items", ["id"], unique=False)
+        op.create_index(op.f("ix_shopping_template_items_template_id"), "shopping_template_items", ["template_id"], unique=False)
+
+
+def downgrade() -> None:
+    if _has_table("shopping_template_items"):
+        op.drop_index(op.f("ix_shopping_template_items_template_id"), table_name="shopping_template_items")
+        op.drop_index(op.f("ix_shopping_template_items_id"), table_name="shopping_template_items")
+        op.drop_table("shopping_template_items")
+    if _has_table("shopping_templates"):
+        op.drop_index(op.f("ix_shopping_templates_family_id"), table_name="shopping_templates")
+        op.drop_index(op.f("ix_shopping_templates_id"), table_name="shopping_templates")
+        op.drop_table("shopping_templates")
+    if _has_table("shopping_items") and _has_column("shopping_items", "category"):
+        op.drop_column("shopping_items", "category")

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -51,6 +51,7 @@ INVITATION_FULLY_USED = "INVITATION_FULLY_USED"
 # ── Shopping ──────────────────────────────────────────────────
 SHOPPING_LIST_NOT_FOUND = "SHOPPING_LIST_NOT_FOUND"
 SHOPPING_ITEM_NOT_FOUND = "SHOPPING_ITEM_NOT_FOUND"
+SHOPPING_TEMPLATE_NOT_FOUND = "SHOPPING_TEMPLATE_NOT_FOUND"
 
 # ── Calendar ──────────────────────────────────────────────────
 EVENT_NOT_FOUND = "EVENT_NOT_FOUND"
@@ -174,6 +175,7 @@ _DEFAULT_MESSAGES: dict[str, str] = {
     INVITATION_FULLY_USED: "Invitation has been fully used",
     SHOPPING_LIST_NOT_FOUND: "Shopping list not found",
     SHOPPING_ITEM_NOT_FOUND: "Shopping item not found",
+    SHOPPING_TEMPLATE_NOT_FOUND: "Shopping template not found",
     EVENT_NOT_FOUND: "Event not found",
     END_BEFORE_START: "End must be after start",
     BIRTHDAY_NOT_FOUND: "Birthday not found",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -39,6 +39,7 @@ class Family(Base):
     birthdays = relationship("FamilyBirthday", back_populates="family", cascade="all, delete-orphan")
     tasks = relationship("Task", back_populates="family", cascade="all, delete-orphan")
     shopping_lists = relationship("ShoppingList", back_populates="family", cascade="all, delete-orphan")
+    shopping_templates = relationship("ShoppingTemplate", back_populates="family", cascade="all, delete-orphan")
     recipes = relationship("Recipe", back_populates="family", cascade="all, delete-orphan")
     invitations = relationship("FamilyInvitation", back_populates="family", cascade="all, delete-orphan")
     reward_currency = relationship("RewardCurrency", back_populates="family", uselist=False, cascade="all, delete-orphan")
@@ -362,6 +363,7 @@ class ShoppingItem(Base):
     list_id = Column(Integer, ForeignKey("shopping_lists.id", ondelete="CASCADE"), nullable=False, index=True)
     name = Column(String, nullable=False)
     spec = Column(String, nullable=True)
+    category = Column(String, nullable=True)
     checked = Column(Boolean, nullable=False, default=False)
     checked_at = Column(DateTime, nullable=True)
     added_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
@@ -369,6 +371,39 @@ class ShoppingItem(Base):
     position = Column(Integer, nullable=False, default=0)
 
     shopping_list = relationship("ShoppingList", back_populates="items")
+
+
+class ShoppingTemplate(Base):
+    __tablename__ = "shopping_templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String, nullable=False)
+    created_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=utcnow, onupdate=utcnow, server_default=func.now())
+
+    family = relationship("Family", back_populates="shopping_templates")
+    items = relationship(
+        "ShoppingTemplateItem",
+        back_populates="template",
+        cascade="all, delete-orphan",
+        order_by="ShoppingTemplateItem.position",
+    )
+
+
+class ShoppingTemplateItem(Base):
+    __tablename__ = "shopping_template_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    template_id = Column(Integer, ForeignKey("shopping_templates.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String, nullable=False)
+    spec = Column(String, nullable=True)
+    category = Column(String, nullable=True)
+    position = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    template = relationship("ShoppingTemplate", back_populates="items")
 
 
 class Notification(Base):

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from app.core.deps import current_user, ensure_adult, ensure_family_membership
 from app.core.scopes import require_scope
 from app.database import get_db
-from app.models import ShoppingItem, ShoppingList, User
+from app.models import ShoppingItem, ShoppingList, ShoppingTemplate, ShoppingTemplateItem, User
 from app.core.ws_broadcast import (
     broadcast_item_added,
     broadcast_item_deleted,
@@ -24,8 +24,19 @@ from app.schemas import (
     ShoppingItemUpdate,
     ShoppingListCreate,
     ShoppingListResponse,
+    ShoppingTemplateApplyRequest,
+    ShoppingTemplateApplyResponse,
+    ShoppingTemplateCreate,
+    ShoppingTemplateResponse,
+    ShoppingTemplateUpdate,
 )
-from app.core.errors import error_detail, SHOPPING_LIST_NOT_FOUND, SHOPPING_ITEM_NOT_FOUND, ADULT_REQUIRED
+from app.core.errors import (
+    error_detail,
+    SHOPPING_LIST_NOT_FOUND,
+    SHOPPING_ITEM_NOT_FOUND,
+    SHOPPING_TEMPLATE_NOT_FOUND,
+    ADULT_REQUIRED,
+)
 
 router = APIRouter(prefix="/shopping", tags=["shopping"], responses={**AUTH_RESPONSES})
 
@@ -41,6 +52,187 @@ def _list_response(sl: ShoppingList) -> ShoppingListResponse:
         created_at=sl.created_at,
         item_count=total,
         checked_count=checked,
+    )
+
+
+def _template_response(template: ShoppingTemplate) -> ShoppingTemplateResponse:
+    ordered_items = sorted(template.items, key=lambda item: item.position)
+    return ShoppingTemplateResponse(
+        id=template.id,
+        family_id=template.family_id,
+        name=template.name,
+        created_by_user_id=template.created_by_user_id,
+        created_at=template.created_at,
+        updated_at=template.updated_at,
+        item_count=len(ordered_items),
+        items=ordered_items,
+    )
+
+
+def _replace_template_items(template: ShoppingTemplate, items) -> None:
+    template.items.clear()
+    for position, item in enumerate(items):
+        template.items.append(
+            ShoppingTemplateItem(
+                name=item.name,
+                spec=item.spec,
+                category=item.category,
+                position=position,
+            )
+        )
+
+
+def _get_template_or_404(db: Session, template_id: int) -> ShoppingTemplate:
+    template = db.query(ShoppingTemplate).filter(ShoppingTemplate.id == template_id).first()
+    if not template:
+        raise HTTPException(status_code=404, detail=error_detail(SHOPPING_TEMPLATE_NOT_FOUND))
+    return template
+
+
+# ── Templates ──────────────────────────────────────────
+
+
+@router.get(
+    "/templates",
+    response_model=list[ShoppingTemplateResponse],
+    summary="List shopping templates",
+    description="Return all saved shopping templates for a family. Scope: `shopping:read`.",
+    response_description="List of saved shopping templates",
+)
+def get_templates(
+    family_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("shopping:read"),
+):
+    ensure_family_membership(db, user.id, family_id)
+    templates = (
+        db.query(ShoppingTemplate)
+        .filter(ShoppingTemplate.family_id == family_id)
+        .order_by(ShoppingTemplate.created_at, ShoppingTemplate.id)
+        .all()
+    )
+    return [_template_response(template) for template in templates]
+
+
+@router.post(
+    "/templates",
+    response_model=ShoppingTemplateResponse,
+    summary="Create a shopping template",
+    description="Create a saved shopping template. Adult only. Scope: `shopping:write`.",
+    response_description="The created shopping template",
+)
+def create_template(
+    payload: ShoppingTemplateCreate,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("shopping:write"),
+):
+    ensure_adult(db, user.id, payload.family_id)
+    template = ShoppingTemplate(
+        family_id=payload.family_id,
+        name=payload.name,
+        created_by_user_id=user.id,
+    )
+    _replace_template_items(template, payload.items)
+    db.add(template)
+    db.commit()
+    db.refresh(template)
+    return _template_response(template)
+
+
+@router.patch(
+    "/templates/{template_id}",
+    response_model=ShoppingTemplateResponse,
+    summary="Update a shopping template",
+    description="Update a saved shopping template and optionally replace its items. Adult only. Scope: `shopping:write`.",
+    response_description="The updated shopping template",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def update_template(
+    template_id: int,
+    payload: ShoppingTemplateUpdate,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("shopping:write"),
+):
+    template = _get_template_or_404(db, template_id)
+    ensure_adult(db, user.id, template.family_id)
+    if payload.name is not None:
+        template.name = payload.name
+    if payload.items is not None:
+        _replace_template_items(template, payload.items)
+    db.commit()
+    db.refresh(template)
+    return _template_response(template)
+
+
+@router.delete(
+    "/templates/{template_id}",
+    summary="Delete a shopping template",
+    description="Delete a saved shopping template. Adult only. Scope: `shopping:write`.",
+    response_description="Deletion confirmation",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def delete_template(
+    template_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("shopping:write"),
+):
+    template = _get_template_or_404(db, template_id)
+    ensure_adult(db, user.id, template.family_id)
+    db.delete(template)
+    db.commit()
+    return {"status": "deleted", "template_id": template_id}
+
+
+@router.post(
+    "/templates/{template_id}/apply",
+    response_model=ShoppingTemplateApplyResponse,
+    summary="Add a shopping template to a list",
+    description="Copy all template items to an existing shopping list. Adult only. Scope: `shopping:write`.",
+    response_description="The created shopping items",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def apply_template(
+    template_id: int,
+    payload: ShoppingTemplateApplyRequest,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("shopping:write"),
+):
+    template = _get_template_or_404(db, template_id)
+    ensure_adult(db, user.id, template.family_id)
+    sl = db.query(ShoppingList).filter(ShoppingList.id == payload.list_id).first()
+    if not sl or sl.family_id != template.family_id:
+        raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
+
+    created_items = []
+    ordered_template_items = sorted(template.items, key=lambda item: item.position)
+    max_position = max((item.position for item in sl.items), default=-1)
+    for offset, template_item in enumerate(ordered_template_items):
+        item = ShoppingItem(
+            list_id=sl.id,
+            name=template_item.name,
+            spec=template_item.spec,
+            category=template_item.category,
+            added_by_user_id=user.id,
+            position=max_position + offset + 1,
+        )
+        db.add(item)
+        created_items.append(item)
+
+    db.commit()
+    for item in created_items:
+        db.refresh(item)
+        broadcast_item_added(sl.id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
+
+    return ShoppingTemplateApplyResponse(
+        template_id=template.id,
+        list_id=sl.id,
+        added_count=len(created_items),
+        items=created_items,
     )
 
 
@@ -169,6 +361,7 @@ def add_item(
         list_id=list_id,
         name=payload.name,
         spec=payload.spec,
+        category=payload.category,
         added_by_user_id=user.id,
     )
     db.add(item)
@@ -207,6 +400,8 @@ def update_item(
         item.name = payload.name
     if payload.spec is not None:
         item.spec = payload.spec
+    if payload.category is not None:
+        item.category = payload.category
     if payload.checked is not None:
         item.checked = payload.checked
         item.checked_at = utcnow() if payload.checked else None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -597,9 +597,10 @@ class ShoppingItemCreate(BaseModel):
     """Add an item to a shopping list."""
     name: str = Field(min_length=1, max_length=200, description="Item name")
     spec: Optional[str] = Field(None, max_length=200, description="Specification (e.g. '500g', 'organic')")
+    category: Optional[str] = Field(None, max_length=100, description="Optional category or aisle label")
 
     model_config = ConfigDict(json_schema_extra={
-        "examples": [{"name": "Milk", "spec": "1L, whole"}]
+        "examples": [{"name": "Milk", "spec": "1L, whole", "category": "Dairy"}]
     })
 
 
@@ -607,6 +608,7 @@ class ShoppingItemUpdate(BaseModel):
     """Update a shopping item (partial update)."""
     name: Optional[str] = Field(None, min_length=1, max_length=200, description="Item name")
     spec: Optional[str] = Field(None, max_length=200, description="Item specification")
+    category: Optional[str] = Field(None, max_length=100, description="Optional category or aisle label")
     checked: Optional[bool] = Field(None, description="Check/uncheck the item")
 
 
@@ -618,10 +620,78 @@ class ShoppingItemResponse(BaseModel):
     list_id: int = Field(..., description="Parent list ID")
     name: str = Field(..., description="Item name")
     spec: Optional[str] = Field(None, description="Item specification")
+    category: Optional[str] = Field(None, description="Optional category or aisle label")
     checked: bool = Field(..., description="Whether the item is checked off")
     checked_at: Optional[datetime] = Field(None, description="When the item was checked")
     added_by_user_id: Optional[int] = Field(None, description="User who added the item")
     created_at: datetime = Field(..., description="Creation timestamp")
+
+
+class ShoppingTemplateItemBase(BaseModel):
+    """Reusable item stored in a shopping template."""
+    name: str = Field(min_length=1, max_length=200, description="Item name")
+    spec: Optional[str] = Field(None, max_length=200, description="Specification (e.g. '500g', 'organic')")
+    category: Optional[str] = Field(None, max_length=100, description="Optional category or aisle label")
+
+
+class ShoppingTemplateCreate(BaseModel):
+    """Create a saved shopping template."""
+    family_id: int = Field(..., description="Family ID")
+    name: str = Field(min_length=1, max_length=100, description="Template name")
+    items: list[ShoppingTemplateItemBase] = Field(default_factory=list, max_length=100, description="Template items")
+
+    model_config = ConfigDict(json_schema_extra={
+        "examples": [{
+            "family_id": 1,
+            "name": "Weekly groceries",
+            "items": [{"name": "Milk", "spec": "2 L", "category": "Dairy"}],
+        }]
+    })
+
+
+class ShoppingTemplateUpdate(BaseModel):
+    """Update a saved shopping template."""
+    name: Optional[str] = Field(None, min_length=1, max_length=100, description="Template name")
+    items: Optional[list[ShoppingTemplateItemBase]] = Field(None, max_length=100, description="Replacement item list")
+
+
+class ShoppingTemplateItemResponse(BaseModel):
+    """Saved template item."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Template item ID")
+    template_id: int = Field(..., description="Template ID")
+    name: str = Field(..., description="Item name")
+    spec: Optional[str] = Field(None, description="Item specification")
+    category: Optional[str] = Field(None, description="Optional category or aisle label")
+    position: int = Field(0, description="Item ordering position")
+
+
+class ShoppingTemplateResponse(BaseModel):
+    """Saved shopping template with items."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Template ID")
+    family_id: int = Field(..., description="Family ID")
+    name: str = Field(..., description="Template name")
+    created_by_user_id: Optional[int] = Field(None, description="Creator user ID")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+    item_count: int = Field(0, description="Number of template items")
+    items: list[ShoppingTemplateItemResponse] = Field(default_factory=list, description="Template items")
+
+
+class ShoppingTemplateApplyRequest(BaseModel):
+    """Add all template items to a shopping list."""
+    list_id: int = Field(..., description="Destination shopping list ID")
+
+
+class ShoppingTemplateApplyResponse(BaseModel):
+    """Items added from a template."""
+    template_id: int = Field(..., description="Template ID")
+    list_id: int = Field(..., description="Destination shopping list ID")
+    added_count: int = Field(0, description="Number of added items")
+    items: list[ShoppingItemResponse] = Field(default_factory=list, description="Created shopping items")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_shopping_templates.py
+++ b/backend/tests/test_shopping_templates.py
@@ -1,0 +1,220 @@
+"""Integration tests for shopping list templates."""
+
+import hashlib
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import Family, Membership, PersonalAccessToken, ShoppingList, User
+from app.security import PAT_PREFIX, hash_password
+
+
+engine = create_engine(
+    "sqlite:///./test-shopping-templates.db",
+    connect_args={"check_same_thread": False},
+)
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_member(scopes: str = "*", suffix: str = "owner", is_adult: bool = True, family_id: int | None = None) -> tuple[str, int]:
+    db = TestSession()
+    user = User(
+        email=f"shopping-template-{suffix}@example.com",
+        password_hash=hash_password("Password1"),
+        display_name="Template User",
+    )
+    db.add(user)
+    db.flush()
+
+    if family_id is None:
+        family = Family(name=f"Template Family {suffix}")
+        db.add(family)
+        db.flush()
+        family_id = family.id
+
+    db.add(Membership(user_id=user.id, family_id=family_id, role="admin" if is_adult else "member", is_adult=is_adult))
+    plain = f"{PAT_PREFIX}shopping-template-{suffix}-{scopes.replace(',', '-').replace(':', '_').replace('*', 'star')}"
+    fingerprint = hashlib.sha256(plain.encode()).hexdigest()
+    db.add(PersonalAccessToken(
+        user_id=user.id,
+        name="shopping-template-pat",
+        token_hash=fingerprint,
+        token_lookup=fingerprint,
+        scopes=scopes,
+    ))
+    db.commit()
+    db.close()
+    return plain, family_id
+
+
+def _seed_list(family_id: int, name: str = "Groceries") -> int:
+    db = TestSession()
+    shopping_list = ShoppingList(family_id=family_id, name=name)
+    db.add(shopping_list)
+    db.commit()
+    list_id = shopping_list.id
+    db.close()
+    return list_id
+
+
+def test_template_create_edit_list_delete_and_apply_to_shopping_list():
+    token, family_id = _seed_member(suffix="flow")
+    list_id = _seed_list(family_id)
+
+    created = client.post(
+        "/shopping/templates",
+        json={
+            "family_id": family_id,
+            "name": "Weekly groceries",
+            "items": [
+                {"name": "Milk", "spec": "2 L", "category": "Dairy"},
+                {"name": "Bananas", "spec": "6", "category": "Produce"},
+            ],
+        },
+        headers=_auth(token),
+    )
+    assert created.status_code == 200, created.json()
+    template = created.json()
+    assert template["name"] == "Weekly groceries"
+    assert template["item_count"] == 2
+    assert [item["name"] for item in template["items"]] == ["Milk", "Bananas"]
+    assert template["items"][0]["category"] == "Dairy"
+
+    updated = client.patch(
+        f"/shopping/templates/{template['id']}",
+        json={
+            "name": "Weekly basics",
+            "items": [
+                {"name": "Oats", "spec": "1 kg", "category": "Pantry"},
+                {"name": "Milk", "spec": "2 L", "category": "Dairy"},
+            ],
+        },
+        headers=_auth(token),
+    )
+    assert updated.status_code == 200, updated.json()
+    assert updated.json()["name"] == "Weekly basics"
+    assert [item["name"] for item in updated.json()["items"]] == ["Oats", "Milk"]
+
+    listed = client.get(f"/shopping/templates?family_id={family_id}", headers=_auth(token))
+    assert listed.status_code == 200
+    assert [(tpl["name"], tpl["item_count"]) for tpl in listed.json()] == [("Weekly basics", 2)]
+
+    applied = client.post(
+        f"/shopping/templates/{template['id']}/apply",
+        json={"list_id": list_id},
+        headers=_auth(token),
+    )
+    assert applied.status_code == 200, applied.json()
+    assert applied.json()["added_count"] == 2
+    assert [item["name"] for item in applied.json()["items"]] == ["Oats", "Milk"]
+    assert applied.json()["items"][0]["checked"] is False
+    assert applied.json()["items"][0]["category"] == "Pantry"
+
+    items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token))
+    assert items.status_code == 200
+    assert [(item["name"], item["spec"], item["category"], item["checked"]) for item in items.json()] == [
+        ("Oats", "1 kg", "Pantry", False),
+        ("Milk", "2 L", "Dairy", False),
+    ]
+
+    deleted = client.delete(f"/shopping/templates/{template['id']}", headers=_auth(token))
+    assert deleted.status_code == 200
+    assert deleted.json() == {"status": "deleted", "template_id": template["id"]}
+
+
+def test_templates_are_family_scoped_and_adult_write_only():
+    owner_token, family_id = _seed_member(suffix="owner")
+    outsider_token, outsider_family_id = _seed_member(suffix="outsider")
+    child_token, _ = _seed_member(suffix="child", is_adult=False, family_id=family_id)
+    list_id = _seed_list(family_id, "Owner Groceries")
+    outsider_list_id = _seed_list(outsider_family_id, "Other Groceries")
+
+    child_create = client.post(
+        "/shopping/templates",
+        json={"family_id": family_id, "name": "Child template", "items": [{"name": "Candy"}]},
+        headers=_auth(child_token),
+    )
+    assert child_create.status_code == 403
+
+    created = client.post(
+        "/shopping/templates",
+        json={"family_id": family_id, "name": "Owner template", "items": [{"name": "Bread"}]},
+        headers=_auth(owner_token),
+    )
+    assert created.status_code == 200, created.json()
+    template_id = created.json()["id"]
+
+    outsider_list = client.get(f"/shopping/templates?family_id={family_id}", headers=_auth(outsider_token))
+    assert outsider_list.status_code == 403
+
+    outsider_apply = client.post(
+        f"/shopping/templates/{template_id}/apply",
+        json={"list_id": list_id},
+        headers=_auth(outsider_token),
+    )
+    assert outsider_apply.status_code == 403
+
+    cross_family_apply = client.post(
+        f"/shopping/templates/{template_id}/apply",
+        json={"list_id": outsider_list_id},
+        headers=_auth(owner_token),
+    )
+    assert cross_family_apply.status_code == 404
+
+
+def test_template_endpoints_enforce_shopping_scopes():
+    read_token, family_id = _seed_member(scopes="shopping:read", suffix="read")
+    write_token, _ = _seed_member(scopes="shopping:write", suffix="write", family_id=family_id)
+
+    denied_create = client.post(
+        "/shopping/templates",
+        json={"family_id": family_id, "name": "No write", "items": [{"name": "Rice"}]},
+        headers=_auth(read_token),
+    )
+    assert denied_create.status_code == 403
+
+    allowed_create = client.post(
+        "/shopping/templates",
+        json={"family_id": family_id, "name": "Write ok", "items": [{"name": "Rice"}]},
+        headers=_auth(write_token),
+    )
+    assert allowed_create.status_code == 200
+
+    denied_list = client.get(f"/shopping/templates?family_id={family_id}", headers=_auth(write_token))
+    assert denied_list.status_code == 403

--- a/frontend/__tests__/components/ShoppingView.test.js
+++ b/frontend/__tests__/components/ShoppingView.test.js
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ShoppingView from '../../components/ShoppingView';
+
+let mockAppState = {};
+let mockShoppingState = {};
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+jest.mock('../../hooks/useShopping', () => ({
+  useShopping: () => mockShoppingState,
+}));
+
+const messages = {
+  'module.shopping.name': 'Shopping',
+  'module.shopping.new_list': 'New list',
+  'module.shopping.list_name_placeholder': 'e.g. Grocery Store',
+  'module.shopping.item_name_placeholder': 'Add an item...',
+  'module.shopping.item_spec_placeholder': 'e.g. 500g, organic',
+  'module.shopping.no_items': 'No items yet',
+  'module.shopping.add_first_item': 'Add first item',
+  'module.shopping.checked_section': 'Checked',
+  'module.shopping.clear_checked': 'Clear checked',
+  'module.shopping.clear_checked_confirm': 'Remove all checked items?',
+  'module.shopping.delete_list': 'Delete list',
+  'module.shopping.delete_list_confirm': 'Delete this list and all its items?',
+  'module.shopping.no_lists': 'No shopping lists yet',
+  'module.shopping.templates': 'Templates',
+  'module.shopping.new_template': 'New template',
+  'module.shopping.template_name_placeholder': 'e.g. Weekly groceries',
+  'module.shopping.template_item_name_placeholder': 'Template item',
+  'module.shopping.template_item_spec_placeholder': 'Amount/details',
+  'module.shopping.template_item_category_placeholder': 'Category',
+  'module.shopping.add_template_item': 'Add template item',
+  'module.shopping.save_template': 'Save template',
+  'module.shopping.cancel_template': 'Cancel',
+  'module.shopping.apply_template': 'Add to list',
+  'module.shopping.edit_template': 'Edit template',
+  'module.shopping.delete_template': 'Delete template',
+  'aria.delete_item': 'Delete item: {name}',
+  'aria.delete_list': 'Delete list: {name}',
+  'aria.delete_template': 'Delete template: {name}',
+  'aria.add_item': 'Add item',
+};
+
+function setup(overrides = {}) {
+  mockAppState = {
+    familyId: '1',
+    families: [{ family_id: 1, family_name: 'Test Family' }],
+    members: [],
+    messages,
+    isMobile: false,
+    isChild: false,
+  };
+  mockShoppingState = {
+    shoppingLists: [{ id: 10, name: 'Groceries', item_count: 0, checked_count: 0 }],
+    activeListId: 10,
+    setActiveListId: jest.fn(),
+    activeList: { id: 10, name: 'Groceries', item_count: 0, checked_count: 0 },
+    items: [],
+    uncheckedItems: [],
+    checkedItems: [],
+    newListName: '',
+    setNewListName: jest.fn(),
+    newItemName: '',
+    setNewItemName: jest.fn(),
+    newItemSpec: '',
+    setNewItemSpec: jest.fn(),
+    showCreateList: false,
+    setShowCreateList: jest.fn(),
+    itemInputRef: { current: null },
+    createList: jest.fn(),
+    deleteList: jest.fn(),
+    addItem: jest.fn((event) => event.preventDefault()),
+    toggleItem: jest.fn(),
+    deleteItem: jest.fn(),
+    clearChecked: jest.fn(),
+    wsConnected: true,
+    templates: [
+      { id: 5, name: 'Weekly groceries', item_count: 2, items: [
+        { id: 51, name: 'Milk', spec: '2 L', category: 'Dairy' },
+        { id: 52, name: 'Bananas', spec: '6', category: 'Produce' },
+      ] },
+    ],
+    createTemplate: jest.fn(),
+    updateTemplate: jest.fn(),
+    deleteTemplate: jest.fn(),
+    applyTemplate: jest.fn(),
+    ...overrides,
+  };
+  return render(<ShoppingView />);
+}
+
+describe('ShoppingView templates', () => {
+  test('renders saved templates and can apply one to the active list', () => {
+    setup();
+
+    expect(screen.getByRole('heading', { name: 'Templates' })).toBeInTheDocument();
+    expect(screen.getByText('Weekly groceries')).toBeInTheDocument();
+    expect(screen.getByText('Milk')).toBeInTheDocument();
+    expect(screen.getByText('2 L')).toBeInTheDocument();
+    expect(screen.getByText('Dairy')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to list: Weekly groceries' }));
+    expect(mockShoppingState.applyTemplate).toHaveBeenCalledWith(5);
+  });
+
+  test('creates and edits templates with name, spec, and category fields', async () => {
+    setup();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New template' }));
+    fireEvent.change(screen.getByPlaceholderText('e.g. Weekly groceries'), { target: { value: 'Weekly basics' } });
+    fireEvent.change(screen.getByPlaceholderText('Template item'), { target: { value: 'Oats' } });
+    fireEvent.change(screen.getByPlaceholderText('Amount/details'), { target: { value: '1 kg' } });
+    fireEvent.change(screen.getByPlaceholderText('Category'), { target: { value: 'Pantry' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add template item' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save template' }));
+
+    await waitFor(() => expect(mockShoppingState.createTemplate).toHaveBeenCalledWith({
+      name: 'Weekly basics',
+      items: [{ name: 'Oats', spec: '1 kg', category: 'Pantry' }],
+    }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit template: Weekly groceries' }));
+    fireEvent.change(screen.getByPlaceholderText('e.g. Weekly groceries'), { target: { value: 'Weekly restock' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save template' }));
+
+    await waitFor(() => expect(mockShoppingState.updateTemplate).toHaveBeenCalledWith(5, expect.objectContaining({ name: 'Weekly restock' })));
+  });
+});

--- a/frontend/components/ShoppingView.js
+++ b/frontend/components/ShoppingView.js
@@ -1,10 +1,22 @@
 import { useState } from 'react';
-import { Plus, Check, Trash2, X, ShoppingCart } from 'lucide-react';
+import { Plus, Check, Trash2, X, ShoppingCart, Pencil } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { useShopping } from '../hooks/useShopping';
 import { t } from '../lib/i18n';
 import MemberAvatar from './MemberAvatar';
 import ConfirmDialog from './ConfirmDialog';
+
+const EMPTY_TEMPLATE_ITEM = { name: '', spec: '', category: '' };
+
+function normaliseTemplateItems(items) {
+  return items
+    .map((item) => ({
+      name: item.name.trim(),
+      spec: item.spec?.trim() || null,
+      category: item.category?.trim() || null,
+    }))
+    .filter((item) => item.name);
+}
 
 function ShoppingItem({ item, checked, members, messages, onToggle, onDelete }) {
   const addedBy = members.find((m) => m.user_id === item.added_by_user_id);
@@ -33,6 +45,7 @@ function ShoppingItem({ item, checked, members, messages, onToggle, onDelete }) 
       <div className="shopping-item-info">
         <span className="shopping-item-name">{item.name}</span>
         {item.spec && <span className="shopping-spec">{item.spec}</span>}
+        {item.category && <span className="shopping-category-pill">{item.category}</span>}
       </div>
       {addedBy && <MemberAvatar member={addedBy} index={memberIdx} size={22} />}
       {onDelete && (
@@ -48,10 +61,169 @@ function ShoppingItem({ item, checked, members, messages, onToggle, onDelete }) 
   );
 }
 
+
+function ShoppingTemplateForm({ messages, initialTemplate, onSubmit, onCancel }) {
+  const [name, setName] = useState(initialTemplate?.name || '');
+  const [items, setItems] = useState(
+    initialTemplate?.items?.length
+      ? initialTemplate.items.map((item) => ({
+          name: item.name || '',
+          spec: item.spec || '',
+          category: item.category || '',
+        }))
+      : [{ ...EMPTY_TEMPLATE_ITEM }],
+  );
+
+  function updateDraftItem(index, field, value) {
+    setItems((prev) => prev.map((item, idx) => idx === index ? { ...item, [field]: value } : item));
+  }
+
+  function addDraftItem() {
+    setItems((prev) => [...prev, { ...EMPTY_TEMPLATE_ITEM }]);
+  }
+
+  function removeDraftItem(index) {
+    setItems((prev) => prev.length === 1 ? [{ ...EMPTY_TEMPLATE_ITEM }] : prev.filter((_, idx) => idx !== index));
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    const cleanedItems = normaliseTemplateItems(items);
+    if (!name.trim() || cleanedItems.length === 0) return;
+    onSubmit({ name: name.trim(), items: cleanedItems });
+  }
+
+  return (
+    <form className="shopping-template-form" onSubmit={handleSubmit}>
+      <input
+        className="form-input shopping-template-name-input"
+        placeholder={t(messages, 'module.shopping.template_name_placeholder')}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        autoFocus
+      />
+      <div className="shopping-template-items-editor">
+        {items.map((item, index) => (
+          <div className="shopping-template-item-row" key={index}>
+            <input
+              className="form-input"
+              placeholder={t(messages, 'module.shopping.template_item_name_placeholder')}
+              value={item.name}
+              onChange={(e) => updateDraftItem(index, 'name', e.target.value)}
+            />
+            <input
+              className="form-input"
+              placeholder={t(messages, 'module.shopping.template_item_spec_placeholder')}
+              value={item.spec}
+              onChange={(e) => updateDraftItem(index, 'spec', e.target.value)}
+            />
+            <input
+              className="form-input"
+              placeholder={t(messages, 'module.shopping.template_item_category_placeholder')}
+              value={item.category}
+              onChange={(e) => updateDraftItem(index, 'category', e.target.value)}
+            />
+            <button
+              className="btn-ghost shopping-template-remove-item"
+              type="button"
+              onClick={() => removeDraftItem(index)}
+              aria-label={t(messages, 'module.shopping.remove_template_item')}
+            >
+              <X size={14} />
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="shopping-template-form-actions">
+        <button className="btn-ghost" type="button" onClick={addDraftItem}>
+          <Plus size={14} aria-hidden="true" />
+          {t(messages, 'module.shopping.add_template_item')}
+        </button>
+        <button className="btn-ghost" type="button" onClick={onCancel}>
+          {t(messages, 'module.shopping.cancel_template')}
+        </button>
+        <button className="btn-sm" type="submit">
+          {t(messages, 'module.shopping.save_template')}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ShoppingTemplateCard({ template, messages, onApply, onEdit, onDelete }) {
+  return (
+    <article className="shopping-template-card">
+      <div className="shopping-template-card-header">
+        <div>
+          <h3 className="shopping-template-title">{template.name}</h3>
+          <div className="shopping-template-count">{template.item_count ?? template.items?.length ?? 0}</div>
+        </div>
+        <div className="shopping-template-card-actions">
+          <button
+            className="btn-ghost"
+            type="button"
+            onClick={() => onEdit(template)}
+            aria-label={`${t(messages, 'module.shopping.edit_template')}: ${template.name}`}
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            className="btn-ghost"
+            type="button"
+            onClick={() => onDelete(template.id)}
+            aria-label={t(messages, 'aria.delete_template').replace('{name}', template.name)}
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <div className="shopping-template-items">
+        {(template.items || []).map((item) => (
+          <div className="shopping-template-item" key={item.id || `${item.name}-${item.spec}-${item.category}`}>
+            <span className="shopping-template-item-name">{item.name}</span>
+            {item.spec && <span className="shopping-spec">{item.spec}</span>}
+            {item.category && <span className="shopping-category-pill">{item.category}</span>}
+          </div>
+        ))}
+      </div>
+      <button
+        className="btn-sm shopping-template-apply"
+        type="button"
+        onClick={() => onApply(template.id)}
+        aria-label={`${t(messages, 'module.shopping.apply_template')}: ${template.name}`}
+      >
+        <Plus size={14} aria-hidden="true" />
+        {t(messages, 'module.shopping.apply_template')}
+      </button>
+    </article>
+  );
+}
+
 export default function ShoppingView() {
   const { familyId, families, members, messages, isMobile, isChild } = useApp();
   const sh = useShopping();
   const [confirmAction, setConfirmAction] = useState(null);
+  const [showTemplateForm, setShowTemplateForm] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState(null);
+
+  function openTemplateForm(template = null) {
+    setEditingTemplate(template);
+    setShowTemplateForm(true);
+  }
+
+  function closeTemplateForm() {
+    setEditingTemplate(null);
+    setShowTemplateForm(false);
+  }
+
+  async function submitTemplate(payload) {
+    if (editingTemplate) {
+      await sh.updateTemplate(editingTemplate.id, payload);
+    } else {
+      await sh.createTemplate(payload);
+    }
+    closeTemplateForm();
+  }
 
   return (
     <div>
@@ -74,14 +246,22 @@ export default function ShoppingView() {
         </div>
       </div>
 
-      <div className="shopping-layout">
+      <div className={`shopping-layout${isChild ? ' shopping-layout-readonly' : ''}`}>
         {/* Lists Panel */}
         <div className={`shopping-lists-panel ${isMobile ? 'mobile' : ''}`}>
           {sh.shoppingLists.map((list) => (
-            <button
+            <div
               key={list.id}
               className={`shopping-list-card${list.id === sh.activeListId ? ' active' : ''}`}
+              role="button"
+              tabIndex={0}
               onClick={() => sh.setActiveListId(list.id)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  sh.setActiveListId(list.id);
+                }
+              }}
             >
               <div className="shopping-list-name">{list.name}</div>
               <div className="shopping-list-meta">
@@ -106,7 +286,7 @@ export default function ShoppingView() {
                   <div className="shopping-list-progress-fill" style={{ width: `${Math.round((list.checked_count / list.item_count) * 100)}%` }} />
                 </div>
               )}
-            </button>
+            </div>
           ))}
 
           {!isChild && (
@@ -137,6 +317,44 @@ export default function ShoppingView() {
             )
           )}
         </div>
+
+        {/* Templates Panel */}
+        {!isChild && (
+          <section className="shopping-templates-panel" aria-label={t(messages, 'module.shopping.templates')}>
+            <div className="shopping-templates-header">
+              <h2>{t(messages, 'module.shopping.templates')}</h2>
+              <button
+                className="shopping-add-list-btn"
+                type="button"
+                onClick={() => openTemplateForm()}
+              >
+                <Plus size={16} aria-hidden="true" />
+                <span>{t(messages, 'module.shopping.new_template')}</span>
+              </button>
+            </div>
+            {showTemplateForm && (
+              <ShoppingTemplateForm
+                key={editingTemplate?.id || 'new'}
+                messages={messages}
+                initialTemplate={editingTemplate}
+                onSubmit={submitTemplate}
+                onCancel={closeTemplateForm}
+              />
+            )}
+            <div className="shopping-template-list">
+              {(sh.templates || []).map((template) => (
+                <ShoppingTemplateCard
+                  key={template.id}
+                  template={template}
+                  messages={messages}
+                  onApply={sh.applyTemplate}
+                  onEdit={openTemplateForm}
+                  onDelete={sh.deleteTemplate}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Items Panel */}
         <div className="shopping-items-panel">

--- a/frontend/e2e/helpers/api-setup.js
+++ b/frontend/e2e/helpers/api-setup.js
@@ -75,6 +75,16 @@ async function seedShoppingItem(request, listId, name = 'Milk', spec = '') {
   return res.json();
 }
 
+async function seedShoppingTemplate(request, familyId, name = 'Weekly groceries', items = []) {
+  const res = await request.post('/api/shopping/templates', {
+    data: { family_id: familyId, name, items },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/shopping/templates failed (${res.status()}): ${await res.text()}`);
+  }
+  return res.json();
+}
+
 
 async function seedMealPlan(request, familyId, overrides = {}) {
   const res = await request.post('/api/meal-plans', {
@@ -100,5 +110,6 @@ module.exports = {
   completeTask,
   seedShoppingList,
   seedShoppingItem,
+  seedShoppingTemplate,
   seedMealPlan,
 };

--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -1,8 +1,10 @@
 const { test, expect } = require('../helpers/fixtures');
-const { getFamilyId, seedShoppingList, seedShoppingItem } = require('../helpers/api-setup');
+const { getFamilyId, seedShoppingList, seedShoppingItem, seedShoppingTemplate } = require('../helpers/api-setup');
 const { navigateTo } = require('../helpers/navigation');
 
 test.describe('Shopping', () => {
+  test.setTimeout(90000);
+
   test('create a shopping list', async ({ authedPage: page }) => {
     await navigateTo(page, 'Shopping');
 
@@ -19,7 +21,7 @@ test.describe('Shopping', () => {
 
     await navigateTo(page, 'Shopping');
     await page.reload();
-    await page.locator('#main-content').waitFor({ timeout: 10000 });
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
     await navigateTo(page, 'Shopping');
 
     await page.getByText('Item Test List').click();
@@ -38,7 +40,7 @@ test.describe('Shopping', () => {
 
     await navigateTo(page, 'Shopping');
     await page.reload();
-    await page.locator('#main-content').waitFor({ timeout: 10000 });
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
     await navigateTo(page, 'Shopping');
 
     await page.getByText('Toggle List').click();
@@ -54,13 +56,71 @@ test.describe('Shopping', () => {
     await expect(item).toHaveAttribute('aria-checked', 'false', { timeout: 5000 });
   });
 
+  test('create, edit, and apply a shopping template', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedShoppingList(apiCtx, familyId, 'Template Target List');
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
+    await navigateTo(page, 'Shopping');
+
+    await page.getByText('Template Target List').click();
+    await page.getByRole('button', { name: 'New template' }).click();
+    await page.locator('input[placeholder="e.g. Weekly groceries"]').fill('Weekly groceries');
+    await page.locator('input[placeholder="Template item"]').first().fill('Milk');
+    await page.locator('input[placeholder="Amount/details"]').first().fill('2 L');
+    await page.locator('input[placeholder="Category"]').first().fill('Dairy');
+    await page.getByRole('button', { name: 'Add template item' }).click();
+    await page.locator('input[placeholder="Template item"]').nth(1).fill('Bananas');
+    await page.locator('input[placeholder="Amount/details"]').nth(1).fill('6');
+    await page.locator('input[placeholder="Category"]').nth(1).fill('Produce');
+    await page.getByRole('button', { name: 'Save template' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Weekly groceries' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Milk')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Edit template: Weekly groceries' }).click();
+    await page.locator('input[placeholder="e.g. Weekly groceries"]').fill('Weekly basics');
+    await page.getByRole('button', { name: 'Save template' }).click();
+    await expect(page.getByRole('heading', { name: 'Weekly basics' })).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: 'Add to list: Weekly basics' }).click();
+    const milkItem = page.locator('[role="checkbox"][aria-label="Milk"]');
+    await expect(milkItem).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[role="checkbox"][aria-label="Bananas"]')).toBeVisible();
+    await expect(milkItem).toContainText('2 L');
+    await expect(milkItem).toContainText('Dairy');
+  });
+
+  test('apply a seeded shopping template to a list', async ({ authedPage: page, apiCtx }) => {
+    test.setTimeout(90000);
+    const familyId = await getFamilyId(apiCtx);
+    await seedShoppingList(apiCtx, familyId, 'Seeded Template Target');
+    await seedShoppingTemplate(apiCtx, familyId, 'Seeded weekly groceries', [
+      { name: 'Oats', spec: '1 kg', category: 'Pantry' },
+      { name: 'Eggs', spec: '12', category: 'Dairy' },
+    ]);
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
+    await navigateTo(page, 'Shopping');
+
+    await page.getByText('Seeded Template Target').click();
+    await page.getByRole('button', { name: 'Add to list: Seeded weekly groceries' }).click();
+
+    await expect(page.locator('[role="checkbox"][aria-label="Oats"]')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[role="checkbox"][aria-label="Eggs"]')).toBeVisible();
+  });
+
   test('delete a shopping list', async ({ authedPage: page, apiCtx }) => {
     const familyId = await getFamilyId(apiCtx);
     await seedShoppingList(apiCtx, familyId, 'Delete This List');
 
     await navigateTo(page, 'Shopping');
     await page.reload();
-    await page.locator('#main-content').waitFor({ timeout: 10000 });
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
     await navigateTo(page, 'Shopping');
 
     await page.getByText('Delete This List').click();

--- a/frontend/hooks/useShopping.js
+++ b/frontend/hooks/useShopping.js
@@ -18,6 +18,7 @@ export function useShopping() {
   const [newItemName, setNewItemName] = useState('');
   const [newItemSpec, setNewItemSpec] = useState('');
   const [showCreateList, setShowCreateList] = useState(false);
+  const [templates, setTemplates] = useState([]);
   const itemInputRef = useRef(null);
 
 
@@ -89,6 +90,19 @@ export function useShopping() {
       setItems([]);
     }
   }, [shoppingLists, activeListId]);
+
+  useEffect(() => {
+    if (!familyId || demoMode) { setTemplates([]); return; }
+    api.apiGetShoppingTemplates(familyId).then(({ ok, data }) => {
+      if (ok) setTemplates(data);
+    });
+  }, [familyId, demoMode]);
+
+  const loadTemplates = useCallback(async () => {
+    if (!familyId || demoMode) return;
+    const { ok, data } = await api.apiGetShoppingTemplates(familyId);
+    if (ok) setTemplates(data);
+  }, [familyId, demoMode]);
 
   useEffect(() => {
     if (!activeListId) { setItems([]); return; }
@@ -250,6 +264,94 @@ export function useShopping() {
     }
   }
 
+  async function createTemplate(payload) {
+    if (!payload.name?.trim()) return;
+    if (demoMode) {
+      const template = {
+        id: Date.now(),
+        family_id: Number(familyId),
+        name: payload.name.trim(),
+        items: payload.items || [],
+        item_count: (payload.items || []).length,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      setTemplates((prev) => [...prev, template]);
+      return;
+    }
+    const { ok, data } = await api.apiCreateShoppingTemplate({
+      family_id: Number(familyId),
+      name: payload.name.trim(),
+      items: payload.items || [],
+    });
+    if (!ok) return toastError(t(messages, 'toast.error'));
+    setTemplates((prev) => [...prev.filter((tpl) => tpl.id !== data.id), data]);
+  }
+
+  async function updateTemplate(templateId, payload) {
+    if (!payload.name?.trim()) return;
+    if (demoMode) {
+      setTemplates((prev) => prev.map((tpl) => tpl.id === templateId ? {
+        ...tpl,
+        name: payload.name.trim(),
+        items: payload.items || [],
+        item_count: (payload.items || []).length,
+        updated_at: new Date().toISOString(),
+      } : tpl));
+      return;
+    }
+    const { ok, data } = await api.apiUpdateShoppingTemplate(templateId, {
+      name: payload.name.trim(),
+      items: payload.items || [],
+    });
+    if (!ok) return toastError(t(messages, 'toast.error'));
+    setTemplates((prev) => prev.map((tpl) => tpl.id === templateId ? data : tpl));
+  }
+
+  async function deleteTemplate(templateId) {
+    if (demoMode) {
+      setTemplates((prev) => prev.filter((tpl) => tpl.id !== templateId));
+      return;
+    }
+    const previous = templates;
+    setTemplates((prev) => prev.filter((tpl) => tpl.id !== templateId));
+    const { ok } = await api.apiDeleteShoppingTemplate(templateId);
+    if (!ok) {
+      toastError(t(messages, 'toast.error'));
+      setTemplates(previous);
+    }
+  }
+
+  async function applyTemplate(templateId) {
+    if (!activeListId) return;
+    if (demoMode) {
+      const template = templates.find((tpl) => tpl.id === templateId);
+      const newItems = (template?.items || []).map((item, idx) => ({
+        id: Date.now() + idx,
+        list_id: activeListId,
+        name: item.name,
+        spec: item.spec || null,
+        category: item.category || null,
+        checked: false,
+        checked_at: null,
+        added_by_user_id: 1,
+        created_at: new Date().toISOString(),
+      }));
+      setItems((prev) => [...prev, ...newItems]);
+      setShoppingLists((prev) => prev.map((list) => list.id === activeListId
+        ? { ...list, item_count: list.item_count + newItems.length, items: [...(list.items || []), ...newItems] }
+        : list));
+      return;
+    }
+    const { ok } = await api.apiApplyShoppingTemplate(templateId, { list_id: activeListId });
+    if (!ok) {
+      toastError(t(messages, 'toast.error'));
+      return;
+    }
+    await reloadItems();
+    await loadShoppingLists();
+  }
+
   async function clearChecked() {
     if (!activeListId) return;
     if (demoMode) {
@@ -283,9 +385,11 @@ export function useShopping() {
     newItemName, setNewItemName,
     newItemSpec, setNewItemSpec,
     showCreateList, setShowCreateList,
+    templates,
     itemInputRef,
     createList, deleteList,
     addItem, toggleItem, deleteItem, clearChecked,
+    createTemplate, updateTemplate, deleteTemplate, applyTemplate, loadTemplates,
     wsConnected,
   };
 }

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -160,6 +160,7 @@
   "aria.add_item": "Artikel hinzufügen",
   "aria.delete_item": "Artikel löschen: {name}",
   "aria.delete_list": "Liste löschen: {name}",
+  "aria.delete_template": "Vorlage löschen: {name}",
   "aria.welcome": "Willkommen",
   "aria.status_messages": "Statusmeldungen",
   "aria.skip_to_content": "Zum Hauptinhalt springen",

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -160,6 +160,7 @@
   "aria.add_item": "Add item",
   "aria.delete_item": "Delete item: {name}",
   "aria.delete_list": "Delete list: {name}",
+  "aria.delete_template": "Delete template: {name}",
   "aria.welcome": "Welcome",
   "aria.status_messages": "Status messages",
   "aria.skip_to_content": "Skip to main content",

--- a/frontend/i18n/modules/shopping/de.json
+++ b/frontend/i18n/modules/shopping/de.json
@@ -19,5 +19,18 @@
   "module.shopping.clear_checked_confirm": "Alle erledigten Artikel entfernen?",
   "module.shopping.new_list": "Neue Liste",
   "module.shopping.added_by": "Hinzugefügt von",
-  "module.shopping.add_first_item": "Ersten Artikel hinzufügen"
+  "module.shopping.add_first_item": "Ersten Artikel hinzufügen",
+  "module.shopping.templates": "Vorlagen",
+  "module.shopping.new_template": "Neue Vorlage",
+  "module.shopping.template_name_placeholder": "z.B. Wocheneinkauf",
+  "module.shopping.template_item_name_placeholder": "Vorlagenartikel",
+  "module.shopping.template_item_spec_placeholder": "Menge/Details",
+  "module.shopping.template_item_category_placeholder": "Kategorie",
+  "module.shopping.add_template_item": "Vorlagenartikel hinzufügen",
+  "module.shopping.remove_template_item": "Vorlagenartikel entfernen",
+  "module.shopping.save_template": "Vorlage speichern",
+  "module.shopping.cancel_template": "Abbrechen",
+  "module.shopping.apply_template": "Zur Liste hinzufügen",
+  "module.shopping.edit_template": "Vorlage bearbeiten",
+  "module.shopping.delete_template": "Vorlage löschen"
 }

--- a/frontend/i18n/modules/shopping/en.json
+++ b/frontend/i18n/modules/shopping/en.json
@@ -19,5 +19,18 @@
   "module.shopping.clear_checked_confirm": "Remove all checked items?",
   "module.shopping.new_list": "New list",
   "module.shopping.added_by": "Added by",
-  "module.shopping.add_first_item": "Add first item"
+  "module.shopping.add_first_item": "Add first item",
+  "module.shopping.templates": "Templates",
+  "module.shopping.new_template": "New template",
+  "module.shopping.template_name_placeholder": "e.g. Weekly groceries",
+  "module.shopping.template_item_name_placeholder": "Template item",
+  "module.shopping.template_item_spec_placeholder": "Amount/details",
+  "module.shopping.template_item_category_placeholder": "Category",
+  "module.shopping.add_template_item": "Add template item",
+  "module.shopping.remove_template_item": "Remove template item",
+  "module.shopping.save_template": "Save template",
+  "module.shopping.cancel_template": "Cancel",
+  "module.shopping.apply_template": "Add to list",
+  "module.shopping.edit_template": "Edit template",
+  "module.shopping.delete_template": "Delete template"
 }

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -274,6 +274,26 @@ export function apiClearCheckedItems(listId) {
   return del(`/shopping/lists/${listId}/checked`);
 }
 
+export function apiGetShoppingTemplates(familyId) {
+  return request(`/shopping/templates?family_id=${familyId}`);
+}
+
+export function apiCreateShoppingTemplate(payload) {
+  return post('/shopping/templates', payload);
+}
+
+export function apiUpdateShoppingTemplate(templateId, payload) {
+  return patch(`/shopping/templates/${templateId}`, payload);
+}
+
+export function apiDeleteShoppingTemplate(templateId) {
+  return del(`/shopping/templates/${templateId}`);
+}
+
+export function apiApplyShoppingTemplate(templateId, payload) {
+  return post(`/shopping/templates/${templateId}/apply`, payload);
+}
+
 // Tokens
 export function apiGetTokens() {
   return request('/tokens');

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1097,8 +1097,29 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 /* ═══════════════════════════════════════════
    SHOPPING
    ═══════════════════════════════════════════ */
-.shopping-layout { display: grid; grid-template-columns: 260px 1fr; gap: var(--space-md); }
+.shopping-layout { display: grid; grid-template-columns: 260px minmax(240px, 320px) 1fr; gap: var(--space-md); align-items: start; }
+.shopping-layout-readonly { grid-template-columns: 260px 1fr; }
 .shopping-lists-panel { display: flex; flex-direction: column; gap: var(--space-sm); }
+.shopping-templates-panel { background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); padding: var(--space-md); display: flex; flex-direction: column; gap: var(--space-md); min-width: 0; }
+.shopping-templates-header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); }
+.shopping-templates-header h2 { margin: 0; font-size: 0.9rem; font-weight: 600; }
+.shopping-template-list { display: flex; flex-direction: column; gap: var(--space-sm); }
+.shopping-template-card { border: 1px solid var(--glass-border); border-radius: var(--radius-md); padding: var(--space-sm); display: flex; flex-direction: column; gap: var(--space-sm); background: rgba(255,255,255,0.03); }
+.shopping-template-card-header { display: flex; justify-content: space-between; gap: var(--space-sm); align-items: flex-start; }
+.shopping-template-title { margin: 0; font-size: 0.9rem; font-weight: 600; }
+.shopping-template-count { font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; color: var(--text-muted); margin-top: 2px; }
+.shopping-template-card-actions { display: flex; gap: 2px; }
+.shopping-template-items { display: grid; gap: 6px; }
+.shopping-template-item { display: flex; align-items: center; gap: var(--space-xs); flex-wrap: wrap; font-size: 0.82rem; }
+.shopping-template-item-name { font-weight: 500; }
+.shopping-category-pill { font-size: 0.72rem; color: var(--text-secondary); border: 1px solid var(--glass-border); border-radius: 999px; padding: 2px 8px; }
+.shopping-template-apply { justify-content: center; }
+.shopping-template-form { display: flex; flex-direction: column; gap: var(--space-sm); }
+.shopping-template-items-editor { display: flex; flex-direction: column; gap: var(--space-xs); }
+.shopping-template-item-row { display: grid; grid-template-columns: 1fr 0.8fr 0.8fr auto; gap: var(--space-xs); align-items: center; }
+.shopping-template-item-row .form-input { font-size: 0.82rem; padding: 9px 10px; min-width: 0; }
+.shopping-template-remove-item { min-width: 36px; min-height: 36px; padding: 6px; }
+.shopping-template-form-actions { display: flex; flex-wrap: wrap; gap: var(--space-xs); justify-content: flex-end; }
 .shopping-lists-panel.mobile { flex-direction: row; overflow-x: auto; padding-bottom: var(--space-sm); }
 .shopping-lists-panel.mobile .shopping-list-card { min-width: 140px; flex-shrink: 0; }
 .shopping-list-card { cursor: pointer; padding: 14px 16px; border-radius: var(--radius-md); transition: all 0.2s; display: flex; align-items: center; gap: var(--space-sm); position: relative; background: var(--void-surface); border: 1px solid var(--glass-border); }
@@ -1634,6 +1655,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .shopping-lists-panel { flex-direction: row; overflow-x: auto; padding-bottom: var(--space-sm); scrollbar-width: none; }
   .shopping-lists-panel::-webkit-scrollbar { display: none; }
   .shopping-lists-panel .shopping-list-card { min-width: 140px; flex-shrink: 0; }
+  .shopping-template-item-row { grid-template-columns: 1fr; }
   .shopping-item-delete { opacity: 1; }
   .shopping-list-delete { opacity: 1; }
   .view-title { font-size: 1.3rem; }


### PR DESCRIPTION
## Summary
- Add reusable shopping list templates for weekly grocery staples
- Let adults create, edit, delete, and apply templates to active shopping lists
- Preserve family scoping and add backend, component, and Playwright coverage

## Test plan
- Backend: `pytest -q tests/test_shopping_templates.py tests/test_meal_plans.py`
- Frontend: `npm test -- --runTestsByPath __tests__/components/ShoppingView.test.js --runInBand --silent=false`
- Frontend: `BACKEND_URL=http://127.0.0.1:8000 npm run build`
- Playwright: `npx playwright test e2e/tests/shopping.spec.js --project='Desktop Chrome'`
- Playwright: `npx playwright test e2e/tests/shopping.spec.js --project='Mobile Chrome'`

Closes #233
