### PR TITLE
Add recipe favorites and serving scaling

### DIFF
--- a/backend/alembic/versions/0038_add_recipe_qol_fields.py
+++ b/backend/alembic/versions/0038_add_recipe_qol_fields.py
@@ -1,0 +1,46 @@
+"""Add recipe quality-of-life fields.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-04-28
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0038"
+down_revision: Union[str, None] = "0037"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(table: str) -> bool:
+    return table in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table: str, column: str) -> bool:
+    if not _has_table(table):
+        return False
+    return any(c["name"] == column for c in sa.inspect(op.get_bind()).get_columns(table))
+
+
+def upgrade() -> None:
+    if _has_table("recipes") and not _has_column("recipes", "is_favorite"):
+        op.add_column(
+            "recipes",
+            sa.Column("is_favorite", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if _has_table("recipes") and not _has_column("recipes", "last_used_at"):
+        op.add_column("recipes", sa.Column("last_used_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    if _has_table("recipes") and _has_column("recipes", "last_used_at"):
+        op.drop_column("recipes", "last_used_at")
+    if _has_table("recipes") and _has_column("recipes", "is_favorite"):
+        op.drop_column("recipes", "is_favorite")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -676,6 +676,8 @@ class Recipe(Base):
     description = Column(Text, nullable=True)
     source_url = Column(String(500), nullable=True)
     servings = Column(Integer, nullable=True)
+    is_favorite = Column(Boolean, nullable=False, default=False, server_default="false")
+    last_used_at = Column(DateTime, nullable=True)
     tags = Column(JSON, nullable=False, default=list, server_default="[]")
     ingredients = Column(JSON, nullable=False, default=list, server_default="[]")
     instructions = Column(Text, nullable=True)

--- a/backend/app/modules/recipes_router.py
+++ b/backend/app/modules/recipes_router.py
@@ -6,6 +6,7 @@ copy operation, and pushing recipe ingredients to shopping lists can use
 the same item formatting as meal plans.
 """
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from typing import Optional, TypeAlias, TypedDict
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -161,6 +162,8 @@ def _serialize(recipe: Recipe) -> RecipeResponse:
         "description": recipe.description,
         "source_url": recipe.source_url,
         "servings": recipe.servings,
+        "is_favorite": bool(recipe.is_favorite),
+        "last_used_at": recipe.last_used_at,
         "tags": recipe.tags or [],
         "ingredients": _normalize_stored_ingredients(recipe.ingredients),
         "instructions": recipe.instructions,
@@ -199,7 +202,7 @@ def list_recipes(
     rows = (
         db.query(Recipe)
         .filter(Recipe.family_id == family_id)
-        .order_by(Recipe.title.asc(), Recipe.id.asc())
+        .order_by(Recipe.is_favorite.desc(), Recipe.last_used_at.desc().nullslast(), Recipe.title.asc(), Recipe.id.asc())
         .all()
     )
     return [_serialize(recipe) for recipe in rows]
@@ -224,6 +227,7 @@ def create_recipe(
         description=_clean_text(payload.description),
         source_url=_clean_text(payload.source_url),
         servings=payload.servings,
+        is_favorite=payload.is_favorite,
         tags=_sanitize_tags(payload.tags),
         ingredients=_sanitize_ingredients(payload.ingredients),
         instructions=_clean_text(payload.instructions),
@@ -363,6 +367,7 @@ def add_recipe_ingredients_to_shopping(
         )
         db.add(item)
         created.append(item)
+    recipe.last_used_at = datetime.now(timezone.utc)
     db.commit()
     for item in created:
         db.refresh(item)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1355,6 +1355,7 @@ class RecipeBase(BaseModel):
     description: Optional[str] = Field(None, max_length=2000, description="Optional recipe summary or notes")
     source_url: Optional[str] = Field(None, max_length=500, description="Optional recipe source URL")
     servings: Optional[int] = Field(None, ge=1, le=999, description="Optional serving count")
+    is_favorite: bool = Field(False, description="Whether the recipe is pinned as a family favorite")
     tags: list[str] = Field(default_factory=list, description="Short recipe tags")
     ingredients: list[IngredientItem] = Field(default_factory=list, description="Structured ingredient list, order preserved")
     instructions: Optional[str] = Field(None, description="Optional cooking instructions")
@@ -1374,6 +1375,7 @@ class RecipeUpdate(BaseModel):
     description: Optional[str] = Field(None, max_length=2000)
     source_url: Optional[str] = Field(None, max_length=500)
     servings: Optional[int] = Field(None, ge=1, le=999)
+    is_favorite: Optional[bool] = None
     tags: Optional[list[str]] = None
     ingredients: Optional[list[IngredientItem]] = None
     instructions: Optional[str] = None
@@ -1393,6 +1395,8 @@ class RecipeResponse(BaseModel):
     description: Optional[str]
     source_url: Optional[str]
     servings: Optional[int]
+    is_favorite: bool
+    last_used_at: Optional[datetime]
     tags: list[str]
     ingredients: list[IngredientItem]
     instructions: Optional[str]

--- a/backend/tests/test_recipe_qol.py
+++ b/backend/tests/test_recipe_qol.py
@@ -1,0 +1,78 @@
+"""Quality-of-life coverage for recipe favorites, recents, and scaling metadata."""
+
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).parent))
+from app.database import Base, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+from test_recipes import (  # noqa: E402
+    TestSession,
+    _auth,
+    _create_recipe,
+    _seed_member,
+    _seed_shopping_list,
+    client,
+    engine,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_favorite_recipes_are_returned_first_and_can_be_toggled():
+    token, family_id = _seed_member("*", "qol-favorite")
+    weeknight = _create_recipe(token, family_id, title="Weeknight pasta")
+    favorite = _create_recipe(token, family_id, title="Apple pancakes")
+
+    patch = client.patch(
+        f"/recipes/{favorite['id']}",
+        json={"is_favorite": True},
+        headers=_auth(token),
+    )
+
+    assert patch.status_code == 200, patch.json()
+    assert patch.json()["is_favorite"] is True
+
+    listed = client.get(f"/recipes?family_id={family_id}", headers=_auth(token))
+    assert listed.status_code == 200
+    data = listed.json()
+    assert [recipe["title"] for recipe in data[:2]] == ["Apple pancakes", "Weeknight pasta"]
+    assert data[0]["is_favorite"] is True
+    assert data[1]["is_favorite"] is False
+
+
+def test_add_to_shopping_marks_recipe_recently_used():
+    token, family_id = _seed_member("*", "qol-recent")
+    recipe = _create_recipe(token, family_id, title="Pancakes")
+    list_id = _seed_shopping_list(family_id)
+
+    before = datetime.utcnow()
+    resp = client.post(
+        f"/recipes/{recipe['id']}/add-to-shopping",
+        json={"shopping_list_id": list_id, "ingredient_names": ["Flour"]},
+        headers=_auth(token),
+    )
+
+    assert resp.status_code == 200, resp.json()
+    fetched = client.get(f"/recipes/{recipe['id']}", headers=_auth(token))
+    assert fetched.status_code == 200
+    used_at = datetime.fromisoformat(fetched.json()["last_used_at"].replace("Z", "+00:00"))
+    assert used_at >= before

--- a/frontend/__tests__/components/RecipesView.test.js
+++ b/frontend/__tests__/components/RecipesView.test.js
@@ -46,6 +46,8 @@ const recipe = {
   description: 'Weekend breakfast',
   source_url: 'https://example.com/pancakes',
   servings: 4,
+  is_favorite: false,
+  last_used_at: null,
   tags: ['breakfast'],
   ingredients: [
     { name: 'Flour', amount: 200, unit: 'g' },
@@ -84,6 +86,45 @@ describe('RecipesView', () => {
     expect(screen.getByText('breakfast')).toBeInTheDocument();
   });
 
+  test('renders favorite and recently used metadata and toggles favorites', async () => {
+    mockAppState = baseState();
+    apiListRecipes.mockResolvedValueOnce({
+      ok: true,
+      data: [{ ...recipe, is_favorite: true, last_used_at: '2099-01-02T03:04:05' }],
+    });
+
+    render(<RecipesView />);
+
+    await waitFor(() => expect(screen.getByText('Favorite')).toBeInTheDocument());
+    expect(screen.getByText('Used recently')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Pancakes from favorites' }));
+
+    await waitFor(() => expect(apiUpdateRecipe).toHaveBeenCalledWith(5, { is_favorite: false }));
+  });
+
+  test('shows conservative serving scaling in the recipe dialog', async () => {
+    mockAppState = baseState();
+    apiListRecipes.mockResolvedValueOnce({
+      ok: true,
+      data: [{
+        ...recipe,
+        ingredients: [...recipe.ingredients, { name: 'Salt', amount: null, unit: null }],
+      }],
+    });
+
+    render(<RecipesView />);
+    await waitFor(() => expect(screen.getByText('Pancakes')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Edit recipe "Pancakes"' }));
+
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Edit recipe' })).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('Scale to servings'), { target: { value: '8' } });
+
+    expect(screen.getByText('Scaled ingredients')).toBeInTheDocument();
+    expect(screen.getAllByText('Flour').length).toBeGreaterThan(0);
+    expect(screen.getByText('400 g')).toBeInTheDocument();
+    expect(screen.getAllByText('Salt').length).toBeGreaterThan(0);
+    expect(screen.getByText('Cannot scale')).toBeInTheDocument();
+  });
 
   test('does not render unsafe recipe source URLs as links', async () => {
     mockAppState = baseState();

--- a/frontend/__tests__/lib/recipes.test.js
+++ b/frontend/__tests__/lib/recipes.test.js
@@ -1,0 +1,28 @@
+import { formatIngredientAmount, scaleRecipeIngredients } from '../../lib/recipes';
+
+describe('recipe scaling helpers', () => {
+  test('scales numeric ingredient amounts from base servings to target servings', () => {
+    const scaled = scaleRecipeIngredients(
+      [
+        { name: 'Flour', amount: 250, unit: 'g' },
+        { name: 'Milk', amount: 300, unit: 'ml' },
+        { name: 'Salt', amount: null, unit: null },
+      ],
+      4,
+      8,
+    );
+
+    expect(scaled).toEqual([
+      { name: 'Flour', amount: 500, unit: 'g', scalable: true },
+      { name: 'Milk', amount: 600, unit: 'ml', scalable: true },
+      { name: 'Salt', amount: null, unit: null, scalable: false },
+    ]);
+    expect(formatIngredientAmount(scaled[0])).toBe('500 g');
+  });
+
+  test('keeps unsupported scaling explicit when base or target servings are missing', () => {
+    const scaled = scaleRecipeIngredients([{ name: 'Flour', amount: 250, unit: 'g' }], null, 8);
+
+    expect(scaled).toEqual([{ name: 'Flour', amount: 250, unit: 'g', scalable: false }]);
+  });
+});

--- a/frontend/components/RecipesView.js
+++ b/frontend/components/RecipesView.js
@@ -6,6 +6,7 @@ import {
   Plus,
   Search,
   ShoppingCart,
+  Star,
   Tags,
   Trash2,
   Users,
@@ -15,7 +16,7 @@ import { useApp } from '../contexts/AppContext';
 import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap';
 import { useRecipes } from '../hooks/useRecipes';
 import { t } from '../lib/i18n';
-import { createEmptyRecipeIngredient, formatIngredientAmount } from '../lib/recipes';
+import { createEmptyRecipeIngredient, formatIngredientAmount, scaleRecipeIngredients } from '../lib/recipes';
 import ConfirmDialog from './ConfirmDialog';
 
 
@@ -34,7 +35,7 @@ function ingredientCountLabel(messages, count) {
   return t(messages, 'module.recipes.ingredients_summary').replace('{count}', String(count));
 }
 
-function RecipeCard({ recipe, messages, onEdit }) {
+function RecipeCard({ recipe, messages, onEdit, onToggleFavorite }) {
   const ingredients = recipe.ingredients || [];
   const previewIngredients = ingredients.slice(0, 4);
   const sourceUrl = safeHttpUrl(recipe.source_url);
@@ -46,18 +47,39 @@ function RecipeCard({ recipe, messages, onEdit }) {
           <BookOpen size={17} className="recipe-card-icon" aria-hidden="true" />
           <h3 className="recipe-card-title">{recipe.title}</h3>
         </div>
-        <button
-          type="button"
-          className="recipe-card-action"
-          onClick={() => onEdit(recipe)}
-          aria-label={t(messages, 'module.recipes.edit_aria').replace('{title}', recipe.title)}
-        >
-          <Edit2 size={14} aria-hidden="true" />
-        </button>
+        <div className="recipe-card-actions">
+          <button
+            type="button"
+            className={`recipe-card-action ${recipe.is_favorite ? 'recipe-card-action-active' : ''}`}
+            onClick={() => onToggleFavorite(recipe)}
+            aria-label={(recipe.is_favorite
+              ? t(messages, 'module.recipes.favorite_remove_aria')
+              : t(messages, 'module.recipes.favorite_add_aria')).replace('{title}', recipe.title)}
+          >
+            <Star size={14} aria-hidden="true" fill={recipe.is_favorite ? 'currentColor' : 'none'} />
+          </button>
+          <button
+            type="button"
+            className="recipe-card-action"
+            onClick={() => onEdit(recipe)}
+            aria-label={t(messages, 'module.recipes.edit_aria').replace('{title}', recipe.title)}
+          >
+            <Edit2 size={14} aria-hidden="true" />
+          </button>
+        </div>
       </div>
 
-      {(recipe.servings || ingredients.length > 0) && (
+      {(recipe.servings || ingredients.length > 0 || recipe.is_favorite || recipe.last_used_at) && (
         <div className="recipe-card-meta">
+          {recipe.is_favorite && (
+            <span className="recipe-card-meta-item recipe-card-favorite">
+              <Star size={13} aria-hidden="true" fill="currentColor" />
+              {t(messages, 'module.recipes.favorite')}
+            </span>
+          )}
+          {recipe.last_used_at && (
+            <span className="recipe-card-meta-item">{t(messages, 'module.recipes.used_recently')}</span>
+          )}
           {recipe.servings && (
             <span className="recipe-card-meta-item">
               <Users size={13} aria-hidden="true" />
@@ -129,6 +151,7 @@ function RecipeDialog({
   const [pushing, setPushing] = useState(false);
   const [selectedListId, setSelectedListId] = useState('');
   const [selectedIngredientNames, setSelectedIngredientNames] = useState([]);
+  const [scaleServings, setScaleServings] = useState('');
   const datalistId = useId();
   const titleId = 'recipe-dialog-title';
 
@@ -148,6 +171,10 @@ function RecipeDialog({
     );
   }, [open, form.ingredients]);
 
+  useEffect(() => {
+    if (open) setScaleServings('');
+  }, [open, form.servings]);
+
   useDialogFocusTrap({ open, containerRef: dialogRef, initialFocusRef: firstFieldRef, onClose });
 
   if (!open) return null;
@@ -155,6 +182,9 @@ function RecipeDialog({
   const namedIngredients = (form.ingredients || [])
     .map((ingredient) => (ingredient.name || '').trim())
     .filter(Boolean);
+  const scaledIngredients = scaleServings
+    ? scaleRecipeIngredients(form.ingredients || [], form.servings, scaleServings)
+    : [];
 
   function updateIngredient(index, patch) {
     setForm((prev) => {
@@ -328,6 +358,40 @@ function RecipeDialog({
                 </li>
               ))}
             </ul>
+            {form.ingredients.length > 0 && form.servings && (
+              <div className="recipe-scale">
+                <label className="recipe-scale-label">
+                  {t(messages, 'module.recipes.scale_to_servings')}
+                  <input
+                    className="form-input recipe-scale-input"
+                    type="number"
+                    min="1"
+                    max="999"
+                    step="1"
+                    inputMode="numeric"
+                    aria-label={t(messages, 'module.recipes.scale_to_servings')}
+                    value={scaleServings}
+                    onChange={(e) => setScaleServings(e.target.value)}
+                  />
+                </label>
+                {scaledIngredients.length > 0 && (
+                  <div className="recipe-scale-preview">
+                    <span className="recipe-section-title">{t(messages, 'module.recipes.scaled_ingredients')}</span>
+                    <ul>
+                      {scaledIngredients.map((ingredient) => {
+                        const amount = formatIngredientAmount(ingredient);
+                        return (
+                          <li key={ingredient.name}>
+                            <span>{ingredient.name}</span>
+                            <span>{ingredient.scalable ? amount : t(messages, 'module.recipes.cannot_scale')}</span>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           <textarea
@@ -495,6 +559,10 @@ export default function RecipesView() {
     return recipes.pushToShopping(editingId, shoppingListId, ingredientNames);
   }
 
+  async function handleToggleFavorite(recipe) {
+    return recipes.updateRecipeFields(recipe.id, { is_favorite: !recipe.is_favorite });
+  }
+
   return (
     <div>
       {confirmAction && (
@@ -574,6 +642,7 @@ export default function RecipesView() {
               recipe={recipe}
               messages={messages}
               onEdit={openEdit}
+              onToggleFavorite={handleToggleFavorite}
             />
           ))}
         </section>

--- a/frontend/e2e/tests/recipes.spec.js
+++ b/frontend/e2e/tests/recipes.spec.js
@@ -53,7 +53,13 @@ test.describe('Recipes', () => {
     await expect(page.getByRole('heading', { name: 'Playwright Pancakes' })).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('2 ingredients')).toBeVisible();
 
+    await page.getByRole('button', { name: 'Add Playwright Pancakes to favorites' }).click();
+    await expect(page.getByText('Favorite')).toBeVisible({ timeout: 10000 });
+
     await page.getByRole('button', { name: 'Edit recipe "Playwright Pancakes"' }).click();
+    await page.getByLabel('Scale to servings').fill('8');
+    await expect(page.locator('.recipe-scale-preview').getByText('400 g')).toBeVisible();
+    await expect(page.locator('.recipe-scale-preview').getByText('600 ml')).toBeVisible();
     await expect(page.getByRole('dialog', { name: 'Edit recipe' })).toBeVisible();
     await page.locator('.recipe-push-btn').click();
     await expect(page.getByLabel('Notifications').getByText('2 ingredients pushed to the shopping list')).toBeVisible({ timeout: 10000 });

--- a/frontend/hooks/useRecipes.js
+++ b/frontend/hooks/useRecipes.js
@@ -73,6 +73,16 @@ export function useRecipes() {
     return { ok: true, data };
   }
 
+  async function updateRecipeFields(recipeId, fields) {
+    const { ok, data } = await api.apiUpdateRecipe(recipeId, fields);
+    if (!ok) {
+      toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
+      return { ok: false };
+    }
+    await load();
+    return { ok: true, data };
+  }
+
   async function deleteRecipe(recipeId) {
     const { ok, data } = await api.apiDeleteRecipe(recipeId);
     if (!ok) {
@@ -109,6 +119,7 @@ export function useRecipes() {
     reload: load,
     createRecipe,
     updateRecipe,
+    updateRecipeFields,
     deleteRecipe,
     pushToShopping,
     emptyForm: createEmptyRecipeForm,

--- a/frontend/i18n/modules/recipes/de.json
+++ b/frontend/i18n/modules/recipes/de.json
@@ -47,6 +47,13 @@
   "module.recipes.delete_confirm": "\"{title}\" wirklich löschen?",
   "module.recipes.edit_aria": "Rezept \"{title}\" bearbeiten",
   "module.recipes.push_to_shopping": "In Einkaufsliste",
+  "module.recipes.favorite": "Favorit",
+  "module.recipes.used_recently": "Kürzlich genutzt",
+  "module.recipes.favorite_add_aria": "{title} als Favorit markieren",
+  "module.recipes.favorite_remove_aria": "{title} aus Favoriten entfernen",
+  "module.recipes.scale_to_servings": "Auf Portionen skalieren",
+  "module.recipes.scaled_ingredients": "Skalierte Zutaten",
+  "module.recipes.cannot_scale": "Nicht skalierbar",
   "module.recipes.pushed_one": "1 Zutat auf die Einkaufsliste geschoben",
   "module.recipes.pushed_many": "{count} Zutaten auf die Einkaufsliste geschoben",
   "module.recipes.demo_blocked": "Im Demo-Modus nicht verfügbar"

--- a/frontend/i18n/modules/recipes/en.json
+++ b/frontend/i18n/modules/recipes/en.json
@@ -47,6 +47,13 @@
   "module.recipes.delete_confirm": "Really delete \"{title}\"?",
   "module.recipes.edit_aria": "Edit recipe \"{title}\"",
   "module.recipes.push_to_shopping": "To shopping list",
+  "module.recipes.favorite": "Favorite",
+  "module.recipes.used_recently": "Used recently",
+  "module.recipes.favorite_add_aria": "Add {title} to favorites",
+  "module.recipes.favorite_remove_aria": "Remove {title} from favorites",
+  "module.recipes.scale_to_servings": "Scale to servings",
+  "module.recipes.scaled_ingredients": "Scaled ingredients",
+  "module.recipes.cannot_scale": "Cannot scale",
   "module.recipes.pushed_one": "1 ingredient pushed to the shopping list",
   "module.recipes.pushed_many": "{count} ingredients pushed to the shopping list",
   "module.recipes.demo_blocked": "Not available in demo mode"

--- a/frontend/lib/recipes.js
+++ b/frontend/lib/recipes.js
@@ -81,3 +81,26 @@ export function formatIngredientAmount(ingredient) {
   if (ingredient?.unit) parts.push(ingredient.unit);
   return parts.join(' ');
 }
+
+function roundScaledAmount(value) {
+  return Number(Number(value).toFixed(2));
+}
+
+export function scaleRecipeIngredients(ingredients, baseServings, targetServings) {
+  const base = Number(baseServings);
+  const target = Number(targetServings);
+  const canScaleRecipe = Number.isFinite(base) && base > 0 && Number.isFinite(target) && target > 0;
+  const factor = canScaleRecipe ? target / base : 1;
+
+  return (ingredients || []).map((ingredient) => {
+    const rawAmount = ingredient?.amount;
+    const amount = rawAmount === '' || rawAmount == null ? null : Number(rawAmount);
+    const canScaleAmount = canScaleRecipe && Number.isFinite(amount);
+    return {
+      ...ingredient,
+      amount: canScaleAmount ? roundScaledAmount(amount * factor) : ingredient?.amount ?? null,
+      unit: ingredient?.unit ?? null,
+      scalable: canScaleAmount,
+    };
+  });
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2209,6 +2209,9 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .recipe-card-title { font-size: 1rem; font-weight: 600; margin: 0; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .recipe-card-action { background: transparent; border: 1px solid transparent; color: var(--text-muted); border-radius: var(--radius-sm); padding: 6px; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; min-height: auto; transition: all 0.15s; }
 .recipe-card-action:hover { color: var(--text-primary); background: rgba(120, 130, 180, 0.1); border-color: var(--glass-border); }
+.recipe-card-actions { display: flex; align-items: center; gap: 4px; }
+.recipe-card-action-active { color: var(--warning); background: rgba(245, 158, 11, 0.12); }
+.recipe-card-favorite { color: var(--warning); }
 .recipe-card-action:focus-visible { outline: 2px solid var(--amethyst); outline-offset: 2px; }
 .recipe-card-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 12px; color: var(--text-secondary); font-size: 0.82rem; }
 .recipe-card-meta-item { display: inline-flex; align-items: center; gap: 5px; }
@@ -2269,6 +2272,11 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .recipe-push-row { display: flex; gap: 6px; align-items: center; }
 .recipe-push-list { flex: 1; min-width: 0; }
 .recipe-push-btn { white-space: nowrap; }
+.recipe-scale { display: flex; flex-direction: column; gap: 8px; padding: var(--space-sm); border: 1px dashed var(--glass-border); border-radius: var(--radius-sm); background: rgba(245, 158, 11, 0.05); }
+.recipe-scale-label { display: flex; align-items: center; gap: 8px; color: var(--text-secondary); font-size: 0.85rem; }
+.recipe-scale-input { max-width: 120px; }
+.recipe-scale-preview ul { list-style: none; padding: 0; margin: 8px 0 0; display: grid; gap: 4px; }
+.recipe-scale-preview li { display: flex; justify-content: space-between; gap: 12px; color: var(--text-secondary); font-size: 0.82rem; }
 
 @media (max-width: 780px) {
   .recipe-header-actions { width: 100%; }


### PR DESCRIPTION
## Summary
- Add recipe favorites and a recently used marker after pushing ingredients to shopping
- Add serving scaling in the recipe editor so ingredient amounts can be adjusted before saving
- Cover the new behavior with backend, frontend, and browser tests

## Test plan
- [x] `DATABASE_URL=sqlite:///./test-recipes.db JWT_SECRET=test-secret PYTHONPATH=$PWD pytest -q tests/test_recipes.py tests/test_recipe_qol.py tests/test_meal_plans.py`
- [x] `npm test -- --runTestsByPath __tests__/lib/recipes.test.js __tests__/components/RecipesView.test.js --runInBand --silent=false`
- [x] `BACKEND_URL=http://127.0.0.1:8000 npm run build`
- [x] `npx playwright test e2e/tests/recipes.spec.js --project='Desktop Chrome' --reporter=list`
- [x] `npx playwright test e2e/tests/recipes.spec.js --project='Mobile Chrome' --reporter=list`

Closes #234
