### PR TITLE
Introduce a clearer dashboard daily hub

### DIFF
--- a/frontend/__tests__/components/DashboardHero.test.js
+++ b/frontend/__tests__/components/DashboardHero.test.js
@@ -1,0 +1,220 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DashboardView from '../../components/DashboardView';
+
+let mockAppState = {};
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+jest.mock('../../lib/i18n', () => ({
+  t: (messages, key) => messages?.[key] || key,
+}));
+
+jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
+  return <div data-testid="rewards-widget" />;
+});
+
+const messages = {
+  'module.dashboard.greeting_morning': 'Good morning',
+  'module.dashboard.greeting_afternoon': 'Good afternoon',
+  'module.dashboard.greeting_evening': 'Good evening',
+  'module.dashboard.summary_events': 'Today you have {count} events',
+  'module.dashboard.summary_no_events': 'No events today',
+  'module.dashboard.summary_tasks': ' and {count} open tasks.',
+  'module.dashboard.family': 'Family',
+  'module.dashboard.members': 'Members',
+  'module.dashboard.events_count': 'Events',
+  'module.dashboard.tasks_done': 'Done',
+  'module.dashboard.open_tasks': 'Open tasks',
+  'module.dashboard.all': 'All',
+  'module.dashboard.empty_events': 'No upcoming events',
+  'module.dashboard.empty_events_action': 'Open calendar',
+  'module.dashboard.empty_tasks': 'All done!',
+  'module.dashboard.empty_tasks_action': 'Create task',
+  'module.tasks.no_tasks': 'No tasks yet',
+  'module.dashboard.empty_birthdays': 'No birthdays',
+  'module.dashboard.days': 'days',
+  'module.dashboard.quick_event': 'Event',
+  'module.dashboard.quick_task': 'Task',
+  'module.dashboard.quick_shopping': 'Shopping',
+  'module.dashboard.quick_invite': 'Invite',
+  'module.dashboard.quick_actions_label': 'Quick actions',
+  'module.dashboard.quick_my_tasks': 'My tasks',
+  'module.dashboard.quick_rewards': 'Rewards',
+  'module.dashboard.context_chips_label': 'Family at a glance',
+  'module.dashboard.chip_members': 'Members',
+  'module.dashboard.chip_today_events': 'Today',
+  'module.dashboard.chip_open_tasks': 'Open tasks',
+  'module.dashboard.activation_title': 'Get your household started',
+  'module.dashboard.activation_subtitle': 'A few quick steps so the whole family can use Tribu together.',
+  'module.dashboard.activation_step_invite_title': 'Invite your family',
+  'module.dashboard.activation_step_invite_desc': 'Send an invitation link.',
+  'module.dashboard.activation_step_invite_cta': 'Open invitations',
+  'module.dashboard.activation_step_invite_done': 'Family members joined',
+  'module.dashboard.activation_step_event_title': 'Add your first event',
+  'module.dashboard.activation_step_event_desc': 'Put a shared appointment on the calendar.',
+  'module.dashboard.activation_step_event_cta': 'Open calendar',
+  'module.dashboard.activation_step_event_done': 'Calendar in use',
+  'module.dashboard.activation_step_task_title': 'Add your first task',
+  'module.dashboard.activation_step_task_desc': 'Capture something that needs doing.',
+  'module.dashboard.activation_step_task_cta': 'Open tasks',
+  'module.dashboard.activation_step_task_done': 'Tasks in use',
+  'module.dashboard.activation_step_shopping_title': 'Start a shopping list',
+  'module.dashboard.activation_step_shopping_desc': 'Create a shared list.',
+  'module.dashboard.activation_step_shopping_cta': 'Open shopping',
+  'module.dashboard.activation_step_shopping_done': 'Shopping list ready',
+  'module.dashboard.activation_step_done_aria': 'Step completed',
+  'module.dashboard.activation_step_pending_aria': 'Step pending',
+  next_events: 'Next events',
+  upcoming_birthdays_4w: 'Birthdays',
+};
+
+function baseApp(overrides = {}) {
+  return {
+    summary: { next_events: [], upcoming_birthdays: [] },
+    me: { display_name: 'Dennis' },
+    members: [
+      { user_id: 1, display_name: 'Dennis' },
+      { user_id: 2, display_name: 'Mira' },
+      { user_id: 3, display_name: 'Leo' },
+    ],
+    tasks: [],
+    events: [],
+    shoppingLists: [],
+    setActiveView: jest.fn(),
+    messages,
+    lang: 'en',
+    timeFormat: '24h',
+    isChild: false,
+    isAdmin: true,
+    ...overrides,
+  };
+}
+
+function todayAt(hour = 10, minute = 0) {
+  const d = new Date();
+  d.setHours(hour, minute, 0, 0);
+  // Use local naive ISO without "Z" so parseDate keeps it local.
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(hour)}:${pad(minute)}:00`;
+}
+
+describe('DashboardView hero', () => {
+  beforeEach(() => {
+    mockAppState = baseApp();
+  });
+
+  it('keeps the greeting with the user display name', () => {
+    render(<DashboardView />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('Dennis');
+  });
+
+  it('renders a labeled quick action pill row for adult users', () => {
+    render(<DashboardView />);
+    const region = screen.getByRole('group', { name: 'Quick actions' });
+    expect(within(region).getByRole('button', { name: 'Event' })).toBeVisible();
+    expect(within(region).getByRole('button', { name: 'Task' })).toBeVisible();
+    expect(within(region).getByRole('button', { name: 'Shopping' })).toBeVisible();
+    expect(within(region).getByRole('button', { name: 'Invite' })).toBeVisible();
+  });
+
+  it('navigates from the labeled quick action pills to the correct views', () => {
+    const setActiveView = jest.fn();
+    mockAppState = baseApp({ setActiveView });
+    render(<DashboardView />);
+    const region = screen.getByRole('group', { name: 'Quick actions' });
+    fireEvent.click(within(region).getByRole('button', { name: 'Event' }));
+    fireEvent.click(within(region).getByRole('button', { name: 'Task' }));
+    fireEvent.click(within(region).getByRole('button', { name: 'Shopping' }));
+    fireEvent.click(within(region).getByRole('button', { name: 'Invite' }));
+    expect(setActiveView).toHaveBeenCalledWith('calendar');
+    expect(setActiveView).toHaveBeenCalledWith('tasks');
+    expect(setActiveView).toHaveBeenCalledWith('shopping');
+    expect(setActiveView).toHaveBeenCalledWith('admin');
+  });
+
+  it('does not render the icon-only header quick action buttons anymore', () => {
+    const { container } = render(<DashboardView />);
+    expect(container.querySelectorAll('.dashboard-header-actions .btn-icon')).toHaveLength(0);
+  });
+
+  it('renders child-safe quick action pills and hides admin members chip for child members', () => {
+    mockAppState = baseApp({ isChild: true, isAdmin: false });
+    render(<DashboardView />);
+    const region = screen.getByRole('group', { name: 'Quick actions' });
+    expect(within(region).getByRole('button', { name: 'My tasks' })).toBeVisible();
+    expect(within(region).getByRole('button', { name: 'Rewards' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Event' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
+
+    const chipGroup = screen.getByRole('group', { name: 'Family at a glance' });
+    expect(within(chipGroup).queryByTestId('hero-chip-members')).not.toBeInTheDocument();
+    expect(within(chipGroup).getByTestId('hero-chip-events')).toBeVisible();
+    expect(within(chipGroup).getByTestId('hero-chip-tasks')).toBeVisible();
+  });
+
+
+
+  it('does not expose invite actions or the members chip to non-admin adults', () => {
+    mockAppState = baseApp({ isAdmin: false });
+    render(<DashboardView />);
+    const region = screen.getByRole('group', { name: 'Quick actions' });
+    expect(within(region).getByRole('button', { name: 'Event' })).toBeVisible();
+    expect(within(region).getByRole('button', { name: 'Task' })).toBeVisible();
+    expect(within(region).getByRole('button', { name: 'Shopping' })).toBeVisible();
+    expect(within(region).queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-chip-members')).not.toBeInTheDocument();
+  });
+
+  it('renders hero context chips for admin members, today events and open tasks using existing data', () => {
+    mockAppState = baseApp({
+      members: [
+        { user_id: 1, display_name: 'Dennis' },
+        { user_id: 2, display_name: 'Mira' },
+        { user_id: 3, display_name: 'Leo' },
+      ],
+      tasks: [
+        { id: 1, title: 'Pack bags', status: 'open' },
+        { id: 2, title: 'Buy milk', status: 'open' },
+        { id: 3, title: 'Clean kitchen', status: 'done' },
+      ],
+      events: [{ id: 1, title: 'School run', starts_at: todayAt(8, 0) }],
+      summary: {
+        next_events: [
+          { id: 1, title: 'School run', starts_at: todayAt(8, 0) },
+          { id: 2, title: 'Soccer practice', starts_at: todayAt(17, 30) },
+        ],
+        upcoming_birthdays: [],
+      },
+    });
+    render(<DashboardView />);
+
+    const chipGroup = screen.getByRole('group', { name: 'Family at a glance' });
+    const membersChip = within(chipGroup).getByTestId('hero-chip-members');
+    expect(membersChip).toHaveTextContent('3');
+    expect(membersChip).toHaveTextContent('Members');
+
+    const eventsChip = within(chipGroup).getByTestId('hero-chip-events');
+    expect(eventsChip).toHaveTextContent('2');
+    expect(eventsChip).toHaveTextContent('Today');
+
+    const tasksChip = within(chipGroup).getByTestId('hero-chip-tasks');
+    expect(tasksChip).toHaveTextContent('2');
+    expect(tasksChip).toHaveTextContent('Open tasks');
+  });
+
+  it('removes the standalone Family Stats bento card from the grid', () => {
+    render(<DashboardView />);
+    expect(screen.queryByRole('region', { name: 'Family' })).not.toBeInTheDocument();
+  });
+
+  it('still renders Events, Tasks and Birthdays modules', () => {
+    render(<DashboardView />);
+    expect(screen.getByRole('region', { name: 'Next events' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Open tasks' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Birthdays' })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -48,7 +48,6 @@ function DashboardSkeleton() {
       </div>
       <div className="bento-grid">
         <div className="bento-events skeleton skeleton-card" style={{ minHeight: 180 }} />
-        <div className="bento-stats skeleton skeleton-card" style={{ minHeight: 180 }} />
         <div className="bento-tasks skeleton skeleton-card" style={{ minHeight: 180 }} />
         <div className="bento-birthdays skeleton skeleton-card" style={{ minHeight: 180 }} />
       </div>

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,4 +1,4 @@
-import { CalendarClock, ListChecks, Cake, BarChart3, Users, Calendar, CheckCircle, Plus, CheckSquare, UserPlus, Circle, ShoppingCart } from 'lucide-react';
+import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
@@ -58,10 +58,35 @@ export default function DashboardView() {
   const { summary, me, members, tasks, events, shoppingLists, setActiveView, messages, lang, timeFormat, isChild, isAdmin } = useApp();
 
   const openTasks = tasks.filter((t) => t.status === 'open');
-  const doneTasks = tasks.filter((t) => t.status === 'done');
-  const donePercent = tasks.length > 0 ? Math.round((doneTasks.length / tasks.length) * 100) : 0;
   const locale = lang === 'de' ? 'de-DE' : 'en-US';
   const todayStr = new Date().toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+
+  const todayEventCount = (summary.next_events || []).filter((ev) => {
+    const d = parseDate(ev.starts_at);
+    if (!d) return false;
+    const now = new Date();
+    return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
+  }).length;
+
+  const adultQuickActions = [
+    { key: 'event', label: t(messages, 'module.dashboard.quick_event'), icon: Calendar, onClick: () => setActiveView('calendar') },
+    { key: 'task', label: t(messages, 'module.dashboard.quick_task'), icon: CheckSquare, onClick: () => setActiveView('tasks') },
+    { key: 'shopping', label: t(messages, 'module.dashboard.quick_shopping'), icon: ShoppingCart, onClick: () => setActiveView('shopping') },
+    ...(isAdmin ? [{ key: 'invite', label: t(messages, 'module.dashboard.quick_invite'), icon: UserPlus, onClick: () => setActiveView('admin') }] : []),
+  ];
+
+  const quickActions = isChild
+    ? [
+        { key: 'my-tasks', label: t(messages, 'module.dashboard.quick_my_tasks'), icon: CheckSquare, onClick: () => setActiveView('tasks') },
+        { key: 'rewards', label: t(messages, 'module.dashboard.quick_rewards'), icon: CheckCircle, onClick: () => setActiveView('rewards') },
+      ]
+    : adultQuickActions;
+
+  const heroChips = [
+    ...(isAdmin ? [{ key: 'members', testId: 'hero-chip-members', value: members.length, label: t(messages, 'module.dashboard.chip_members'), icon: Users, onClick: () => setActiveView('admin') }] : []),
+    { key: 'events', testId: 'hero-chip-events', value: todayEventCount, label: t(messages, 'module.dashboard.chip_today_events'), icon: CalendarClock, onClick: () => setActiveView('calendar') },
+    { key: 'tasks', testId: 'hero-chip-tasks', value: openTasks.length, label: t(messages, 'module.dashboard.chip_open_tasks'), icon: ListChecks, onClick: () => setActiveView('tasks') },
+  ];
 
   const safeShoppingLists = Array.isArray(shoppingLists) ? shoppingLists : [];
   const hasShoppingContent = safeShoppingLists.some((list) => {
@@ -124,14 +149,8 @@ export default function DashboardView() {
   const showActivationPanel = !isChild && adoptionIncomplete;
 
   const summaryText = (() => {
-    const now = new Date();
-    const todayEvents = (summary.next_events || []).filter(ev => {
-      const d = parseDate(ev.starts_at);
-      return d && d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
-    });
-    const evCount = todayEvents.length;
-    let s = evCount > 0
-      ? t(messages, 'module.dashboard.summary_events').replace('{count}', evCount)
+    let s = todayEventCount > 0
+      ? t(messages, 'module.dashboard.summary_events').replace('{count}', todayEventCount)
       : t(messages, 'module.dashboard.summary_no_events');
     if (openTasks.length > 0) {
       s += t(messages, 'module.dashboard.summary_tasks').replace('{count}', openTasks.length);
@@ -149,15 +168,53 @@ export default function DashboardView() {
           <div className="view-subtitle">{summaryText}</div>
         </div>
         <div className="dashboard-header-actions">
-          {!isChild && (
-            <>
-              <button className="btn-ghost btn-icon" onClick={() => setActiveView('calendar')} aria-label={t(messages, 'module.dashboard.quick_event')}><Plus size={16} aria-hidden="true" /></button>
-              <button className="btn-ghost btn-icon" onClick={() => setActiveView('tasks')} aria-label={t(messages, 'module.dashboard.quick_task')}><CheckSquare size={16} aria-hidden="true" /></button>
-              <button className="btn-ghost btn-icon" onClick={() => setActiveView('contacts')} aria-label={t(messages, 'module.dashboard.quick_contact')}><UserPlus size={16} aria-hidden="true" /></button>
-            </>
-          )}
           <div className="view-date">{todayStr}</div>
         </div>
+      </div>
+
+      <div
+        className="hero-context-chips"
+        role="group"
+        aria-label={t(messages, 'module.dashboard.context_chips_label')}
+      >
+        {heroChips.map((chip) => {
+          const Icon = chip.icon;
+          return (
+            <button
+              key={chip.key}
+              type="button"
+              className="hero-chip"
+              data-testid={chip.testId}
+              onClick={chip.onClick}
+            >
+              <span className="hero-chip-icon" aria-hidden="true"><Icon size={14} /></span>
+              <span className="hero-chip-value">{chip.value}</span>
+              <span className="hero-chip-label">{chip.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className="dashboard-quick-actions"
+        role="group"
+        aria-label={t(messages, 'module.dashboard.quick_actions_label')}
+      >
+        {quickActions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <button
+              key={action.key}
+              type="button"
+              className="quick-action-pill"
+              data-testid={`quick-action-${action.key}`}
+              onClick={action.onClick}
+            >
+              <Icon size={16} aria-hidden="true" />
+              <span>{action.label}</span>
+            </button>
+          );
+        })}
       </div>
 
       {showActivationPanel && <ActivationPanel steps={activationSteps} messages={messages} />}
@@ -196,27 +253,6 @@ export default function DashboardView() {
               </div>
               );
             })}
-          </div>
-        </div>
-
-        {/* Stats Card */}
-        <div className="bento-card bento-stats" role="region" aria-label={t(messages, 'module.dashboard.family')}>
-          <div className="bento-card-header">
-            <h2 className="bento-card-title"><BarChart3 size={16} aria-hidden="true" /> {t(messages, 'module.dashboard.family')}</h2>
-          </div>
-          <div className="stat-grid">
-            <div className="stat-item stat-item-link" onClick={() => setActiveView('admin')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && setActiveView('admin')}>
-              <div className="stat-icon" style={{ background: 'rgba(124,58,237,0.12)' }}><Users size={18} style={{ color: 'var(--amethyst)' }} aria-hidden="true" /></div>
-              <div><div className="stat-value">{members.length}</div><div className="stat-label">{t(messages, 'module.dashboard.members')}</div></div>
-            </div>
-            <div className="stat-item stat-item-link" onClick={() => setActiveView('calendar')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && setActiveView('calendar')}>
-              <div className="stat-icon" style={{ background: 'rgba(59,130,246,0.12)' }}><Calendar size={18} style={{ color: 'var(--sapphire)' }} aria-hidden="true" /></div>
-              <div><div className="stat-value">{events.length}</div><div className="stat-label">{t(messages, 'module.dashboard.events_count')}</div></div>
-            </div>
-            <div className="stat-item stat-item-link" onClick={() => setActiveView('tasks')} role="link" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && setActiveView('tasks')}>
-              <div className="stat-icon" style={{ background: 'rgba(16,185,129,0.12)' }}><CheckCircle size={18} style={{ color: 'var(--success)' }} aria-hidden="true" /></div>
-              <div><div className="stat-value">{donePercent}%</div><div className="stat-label">{t(messages, 'module.dashboard.tasks_done')}</div></div>
-            </div>
           </div>
         </div>
 

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -8,27 +8,28 @@ test.describe('Dashboard', () => {
     await expect(greeting).toContainText(testUser.displayName);
   });
 
-  test('quick-action buttons navigate to correct views', async ({ authedPage: page }) => {
-    await page.locator('.dashboard-header-actions').waitFor({ timeout: 10000 });
+  test('quick-action pills navigate to correct views', async ({ authedPage: page }) => {
+    const quickActions = page.getByRole('group', { name: 'Quick actions' });
+    await quickActions.waitFor({ timeout: 10000 });
 
-    // Event → Calendar (icon button with aria-label)
-    await page.locator('.dashboard-header-actions .btn-icon').first().click();
+    // Event → Calendar
+    await page.getByTestId('quick-action-event').click();
     await expect(page.locator('.calendar-grid-wrapper')).toBeVisible({ timeout: 10000 });
 
     // Back to Dashboard
     await navigateTo(page, 'Home');
-    await page.locator('.dashboard-header-actions').waitFor({ timeout: 10000 });
+    await page.getByRole('group', { name: 'Quick actions' }).waitFor({ timeout: 10000 });
 
-    // Task → Tasks (second icon button)
-    await page.locator('.dashboard-header-actions .btn-icon').nth(1).click();
+    // Task → Tasks
+    await page.getByTestId('quick-action-task').click();
     await expect(page.locator('.tasks-filter-tabs')).toBeVisible({ timeout: 10000 });
 
     // Back to Dashboard
     await navigateTo(page, 'Home');
-    await page.locator('.dashboard-header-actions').waitFor({ timeout: 10000 });
+    await page.getByRole('group', { name: 'Quick actions' }).waitFor({ timeout: 10000 });
 
-    // Contact → Contacts (third icon button)
-    await page.locator('.dashboard-header-actions .btn-icon').nth(2).click();
-    await expect(page.locator('.contacts-grid')).toBeVisible({ timeout: 10000 });
+    // Invite → Admin
+    await page.getByTestId('quick-action-invite').click();
+    await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible({ timeout: 10000 });
   });
 });

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -8,7 +8,14 @@
   "module.dashboard.summary_tasks": " und {count} offene Aufgaben.",
   "module.dashboard.quick_event": "Termin",
   "module.dashboard.quick_task": "Aufgabe",
+  "module.dashboard.quick_shopping": "Einkauf",
+  "module.dashboard.quick_invite": "Einladen",
   "module.dashboard.quick_contact": "Kontakt",
+  "module.dashboard.quick_actions_label": "Schnellaktionen",
+  "module.dashboard.context_chips_label": "Familie auf einen Blick",
+  "module.dashboard.chip_members": "Mitglieder",
+  "module.dashboard.chip_today_events": "Heute",
+  "module.dashboard.chip_open_tasks": "Offene Aufgaben",
   "module.dashboard.family": "Familie",
   "module.dashboard.members": "Mitglieder",
   "module.dashboard.events_count": "Termine",
@@ -40,5 +47,7 @@
   "module.dashboard.activation_step_shopping_cta": "Einkauf öffnen",
   "module.dashboard.activation_step_shopping_done": "Einkaufsliste bereit",
   "module.dashboard.activation_step_done_aria": "Schritt erledigt",
-  "module.dashboard.activation_step_pending_aria": "Schritt offen"
+  "module.dashboard.activation_step_pending_aria": "Schritt offen",
+  "module.dashboard.quick_my_tasks": "Meine Aufgaben",
+  "module.dashboard.quick_rewards": "Rewards"
 }

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -8,7 +8,14 @@
   "module.dashboard.summary_tasks": " and {count} open tasks.",
   "module.dashboard.quick_event": "Event",
   "module.dashboard.quick_task": "Task",
+  "module.dashboard.quick_shopping": "Shopping",
+  "module.dashboard.quick_invite": "Invite",
   "module.dashboard.quick_contact": "Contact",
+  "module.dashboard.quick_actions_label": "Quick actions",
+  "module.dashboard.context_chips_label": "Family at a glance",
+  "module.dashboard.chip_members": "Members",
+  "module.dashboard.chip_today_events": "Today",
+  "module.dashboard.chip_open_tasks": "Open tasks",
   "module.dashboard.family": "Family",
   "module.dashboard.members": "Members",
   "module.dashboard.events_count": "Events",
@@ -40,5 +47,7 @@
   "module.dashboard.activation_step_shopping_cta": "Open shopping",
   "module.dashboard.activation_step_shopping_done": "Shopping list ready",
   "module.dashboard.activation_step_done_aria": "Step completed",
-  "module.dashboard.activation_step_pending_aria": "Step pending"
+  "module.dashboard.activation_step_pending_aria": "Step pending",
+  "module.dashboard.quick_my_tasks": "My tasks",
+  "module.dashboard.quick_rewards": "Rewards"
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -705,7 +705,21 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .view-subtitle { color: var(--text-secondary); font-size: 0.88rem; margin-top: 2px; }
 .view-date { font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; color: var(--text-secondary); background: rgba(255,255,255,0.03); padding: 8px 14px; border-radius: var(--radius-sm); border: 1px solid var(--glass-border); }
 .dashboard-header-actions { display: flex; align-items: center; gap: var(--space-sm); }
-.btn-icon { width: 44px; height: 44px; padding: 0; display: inline-flex; align-items: center; justify-content: center; }
+.dashboard-quick-actions { display: flex; flex-wrap: wrap; gap: var(--space-sm); margin-bottom: var(--space-md); }
+.quick-action-pill { display: inline-flex; align-items: center; gap: 8px; padding: 10px 16px; min-height: 44px; border-radius: var(--radius-pill); border: 1px solid var(--glass-border); background: rgba(255,255,255,0.03); color: var(--text-primary); font-family: inherit; font-size: 0.85rem; font-weight: 500; cursor: pointer; transition: background 0.2s, border-color 0.2s, transform 0.1s; }
+.quick-action-pill:hover { background: rgba(255,255,255,0.06); border-color: rgba(120, 130, 180, 0.35); }
+.quick-action-pill:active { transform: scale(0.98); }
+.quick-action-pill svg { color: var(--amethyst); }
+.hero-context-chips { display: flex; flex-wrap: wrap; gap: var(--space-sm); margin-bottom: var(--space-md); }
+.hero-chip { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; min-height: 32px; border-radius: var(--radius-pill); border: 1px solid var(--glass-border); background: rgba(255,255,255,0.02); color: var(--text-primary); font-family: inherit; font-size: 0.82rem; cursor: pointer; transition: background 0.2s, border-color 0.2s; }
+.hero-chip:hover { background: rgba(255,255,255,0.05); border-color: rgba(120, 130, 180, 0.3); }
+.hero-chip-icon { display: inline-flex; align-items: center; color: var(--text-muted); }
+.hero-chip-value { font-family: 'JetBrains Mono', monospace; font-weight: 600; font-size: 0.95rem; color: var(--text-primary); }
+.hero-chip-label { color: var(--text-muted); }
+
+@media (max-width: 768px) {
+  .hero-chip { min-height: 44px; }
+}
 .view-enter { animation: viewEnter 0.4s var(--ease-out-expo) both; }
 @keyframes viewEnter { from { opacity: 0; } to { opacity: 1; } }
 
@@ -715,8 +729,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-grid { display: grid; grid-template-columns: repeat(12, 1fr); column-gap: var(--space-md); row-gap: var(--space-lg); }
 .bento-card { padding: var(--space-lg); background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); transition: all 0.2s; }
 .bento-card:hover { border-color: rgba(120, 130, 180, 0.2); }
-.bento-events { grid-column: span 8; }
-.bento-stats { grid-column: span 4; }
+.bento-events { grid-column: span 12; }
 .bento-tasks { grid-column: span 7; }
 .bento-birthdays { grid-column: span 5; }
 .bento-rewards { grid-column: span 12; }
@@ -792,15 +805,6 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 
 /* Admin: audit log */
 .adm-load-more { margin-top: var(--space-sm); }
-
-/* ─── Stats ─── */
-.stat-grid { display: grid; gap: var(--space-sm); }
-.stat-item { display: flex; align-items: center; gap: 12px; padding: 12px; border-radius: var(--radius-sm); background: rgba(255,255,255,0.02); border: 1px solid transparent; transition: all 0.2s; }
-.stat-item:hover { background: rgba(255,255,255,0.04); border-color: var(--glass-border); }
-.stat-item-link { cursor: pointer; }
-.stat-icon { width: 36px; height: 36px; border-radius: 10px; display: flex; align-items: center; justify-content: center; }
-.stat-value { font-family: 'JetBrains Mono', monospace; font-size: 1.2rem; font-weight: 600; }
-.stat-label { font-size: 0.75rem; color: var(--text-muted); }
 
 /* ─── Events ─── */
 .event-list { display: grid; gap: var(--space-sm); }
@@ -1626,7 +1630,6 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    ═══════════════════════════════════════════ */
 @media (max-width: 1100px) {
   .bento-events { grid-column: span 12; }
-  .bento-stats { grid-column: span 12; }
   .bento-tasks { grid-column: span 6; }
   .bento-birthdays { grid-column: span 6; }
   .bento-rewards { grid-column: span 12; }
@@ -1640,9 +1643,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .mobile-header { display: flex; }
   .bottom-nav { display: block; }
   .bento-grid { grid-template-columns: 1fr; row-gap: var(--space-md); }
-  .bento-stats, .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards { grid-column: span 1; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards { grid-column: span 1; }
   .dashboard-header-actions { flex-wrap: wrap; }
-  .stat-grid { grid-template-columns: repeat(2, 1fr); }
   .view-header { flex-direction: column; align-items: flex-start; }
   .tasks-toolbar { flex-direction: column; align-items: flex-start; }
   .tasks-count { margin-left: 0; }


### PR DESCRIPTION
## Summary
- Reworks the dashboard header into a clearer daily hub with context chips for members, today, and open tasks
- Replaces icon-only quick actions with labeled, touch-friendly actions for desktop, tablet, and mobile
- Keeps child and non-admin users away from invite/admin affordances
- Removes the old family stats card and matching loading skeleton so the grid aligns cleanly

## Test plan
- `npm test -- --runTestsByPath __tests__/components/DashboardHero.test.js __tests__/components/RewardsDashboardWidget.test.js __tests__/components/DashboardActivationPanel.test.js --runInBand --silent=false`
- `BACKEND_URL=http://127.0.0.1:8000 npm run build`
- `npx playwright test e2e/tests/dashboard.spec.js --project='Desktop Chrome' --reporter=list`
- `npx playwright test e2e/tests/dashboard.spec.js --project='Mobile Chrome' --reporter=list`
