### PR TITLE
Fix dashboard desktop layout spacing

### DIFF
--- a/frontend/__tests__/components/DashboardDesktopLayout.test.js
+++ b/frontend/__tests__/components/DashboardDesktopLayout.test.js
@@ -1,0 +1,110 @@
+import fs from 'fs';
+import path from 'path';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DashboardView from '../../components/DashboardView';
+
+let mockAppState = {};
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+jest.mock('../../lib/i18n', () => ({
+  t: (messages, key) => messages?.[key] || key,
+}));
+
+jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
+  return <div className="bento-card bento-rewards" data-testid="rewards-widget" />;
+});
+
+const messages = {
+  'module.dashboard.greeting_morning': 'Good morning',
+  'module.dashboard.greeting_afternoon': 'Good afternoon',
+  'module.dashboard.greeting_evening': 'Good evening',
+  'module.dashboard.summary_events': 'Today you have {count} events',
+  'module.dashboard.summary_no_events': 'No events today',
+  'module.dashboard.summary_tasks': ' and {count} open tasks.',
+  'module.dashboard.open_tasks': 'Open tasks',
+  'module.dashboard.all': 'All',
+  'module.dashboard.empty_events': 'No upcoming events',
+  'module.dashboard.empty_events_action': 'Open calendar',
+  'module.dashboard.empty_tasks': 'All done!',
+  'module.dashboard.empty_tasks_action': 'Create task',
+  'module.tasks.no_tasks': 'No tasks yet',
+  'module.dashboard.empty_birthdays': 'No birthdays',
+  'module.dashboard.days': 'days',
+  'module.dashboard.quick_event': 'Event',
+  'module.dashboard.quick_task': 'Task',
+  'module.dashboard.quick_contact': 'Contact',
+  'module.dashboard.context_chips_label': 'Dashboard summary',
+  'module.dashboard.quick_actions_label': 'Quick actions',
+  'module.dashboard.members': 'Members',
+  'module.dashboard.today': 'Today',
+  'module.dashboard.open_tasks_short': 'Open tasks',
+  next_events: 'Next events',
+  upcoming_birthdays_4w: 'Birthdays',
+};
+
+function baseApp(overrides = {}) {
+  return {
+    summary: { next_events: [], upcoming_birthdays: [] },
+    me: { display_name: 'Dennis' },
+    members: [
+      { user_id: 1, display_name: 'Dennis' },
+      { user_id: 2, display_name: 'Family member' },
+    ],
+    tasks: [{ id: 1, title: 'Take bins out', status: 'done' }],
+    events: [{ id: 1, title: 'Training', starts_at: '2030-01-01T10:00:00Z' }],
+    shoppingLists: [{ id: 1, items: [{ id: 1, name: 'Milk' }] }],
+    setActiveView: jest.fn(),
+    messages,
+    lang: 'en',
+    timeFormat: '24h',
+    isChild: false,
+    isAdmin: true,
+    ...overrides,
+  };
+}
+
+describe('DashboardView desktop bento layout', () => {
+  beforeEach(() => {
+    mockAppState = baseApp();
+  });
+
+  it('places next events and open tasks as the first two desktop modules', () => {
+    const { container } = render(<DashboardView />);
+
+    const modules = Array.from(container.querySelectorAll('.bento-grid > .bento-card'));
+    expect(modules[0]).toHaveClass('bento-events');
+    expect(modules[0]).toHaveAccessibleName('Next events');
+    expect(modules[1]).toHaveClass('bento-tasks');
+    expect(modules[1]).toHaveAccessibleName('Open tasks');
+    expect(modules[2]).toHaveClass('bento-birthdays');
+    expect(modules[2]).toHaveAccessibleName('Birthdays');
+    expect(modules[3]).toHaveClass('bento-rewards');
+  });
+
+  it('keeps the loading skeleton in the same card order', () => {
+    const appShellPath = path.join(__dirname, '../../components/AppShell.js');
+    const appShell = fs.readFileSync(appShellPath, 'utf8');
+    const skeletonBlock = appShell.match(/function DashboardSkeleton\(\) \{[\s\S]*?\n\}/)?.[0];
+
+    expect(skeletonBlock).toBeDefined();
+    expect(skeletonBlock.indexOf('bento-events')).toBeLessThan(skeletonBlock.indexOf('bento-tasks'));
+    expect(skeletonBlock.indexOf('bento-tasks')).toBeLessThan(skeletonBlock.indexOf('bento-birthdays'));
+    expect(skeletonBlock.indexOf('bento-birthdays')).toBeLessThan(skeletonBlock.indexOf('bento-rewards'));
+  });
+
+  it('uses equal two-column spans until the mobile breakpoint', () => {
+    const cssPath = path.join(__dirname, '../../styles/globals.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+
+    expect(css).toMatch(/\.bento-events\s*\{\s*grid-column:\s*span 6;\s*\}/);
+    expect(css).toMatch(/\.bento-tasks\s*\{\s*grid-column:\s*span 6;\s*\}/);
+    expect(css).toMatch(/\.bento-birthdays\s*\{\s*grid-column:\s*span 6;\s*\}/);
+    expect(css).toMatch(/\.bento-rewards\s*\{\s*grid-column:\s*span 6;\s*\}/);
+    expect(css).toMatch(/@media \(max-width: 1100px\) \{\s*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-rewards \{ grid-column: span 6; \}/);
+    expect(css).toMatch(/@media \(max-width: 768px\)[\s\S]*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-rewards \{ grid-column: span 1; \}/);
+  });
+});

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -50,6 +50,7 @@ function DashboardSkeleton() {
         <div className="bento-events skeleton skeleton-card" style={{ minHeight: 180 }} />
         <div className="bento-tasks skeleton skeleton-card" style={{ minHeight: 180 }} />
         <div className="bento-birthdays skeleton skeleton-card" style={{ minHeight: 180 }} />
+        <div className="bento-rewards skeleton skeleton-card" style={{ minHeight: 180 }} />
       </div>
     </div>
   );

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -729,10 +729,10 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-grid { display: grid; grid-template-columns: repeat(12, 1fr); column-gap: var(--space-md); row-gap: var(--space-lg); }
 .bento-card { padding: var(--space-lg); background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); transition: all 0.2s; }
 .bento-card:hover { border-color: rgba(120, 130, 180, 0.2); }
-.bento-events { grid-column: span 12; }
-.bento-tasks { grid-column: span 7; }
-.bento-birthdays { grid-column: span 5; }
-.bento-rewards { grid-column: span 12; }
+.bento-events { grid-column: span 6; }
+.bento-tasks { grid-column: span 6; }
+.bento-birthdays { grid-column: span 6; }
+.bento-rewards { grid-column: span 6; }
 .bento-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-md); }
 .bento-card-title { font-size: 0.78rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 8px; }
 .bento-more { background: none; border: none; color: var(--text-muted); cursor: pointer; font-family: inherit; font-size: 0.78rem; padding: 4px 10px; border-radius: var(--radius-pill); transition: all 0.2s; }
@@ -1629,10 +1629,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    RESPONSIVE
    ═══════════════════════════════════════════ */
 @media (max-width: 1100px) {
-  .bento-events { grid-column: span 12; }
-  .bento-tasks { grid-column: span 6; }
-  .bento-birthdays { grid-column: span 6; }
-  .bento-rewards { grid-column: span 12; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards { grid-column: span 6; }
   .calendar-layout { grid-template-columns: 1fr; }
 }
 


### PR DESCRIPTION
## Summary
- makes the dashboard bento cards use equal two-column spans on desktop
- keeps the 2-column rhythm through the tablet breakpoint and stacks on mobile
- aligns the dashboard loading skeleton with the rendered card order
- adds regression coverage for card order and responsive span rules

## Test plan
- `npm test -- --runTestsByPath __tests__/components/DashboardDesktopLayout.test.js --runInBand`
- `npm run build`
- `npx playwright test e2e/tests/dashboard.spec.js --reporter=list`
