### PR TITLE
Add dashboard daily planning loop

### DIFF
--- a/frontend/__tests__/components/DashboardDailyLoop.test.js
+++ b/frontend/__tests__/components/DashboardDailyLoop.test.js
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DashboardView from '../../components/DashboardView';
+import { apiListMealPlans } from '../../lib/api';
+
+let mockAppState = {};
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+jest.mock('../../lib/api', () => ({
+  apiListMealPlans: jest.fn(),
+}));
+
+jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
+  return <div data-testid="rewards-widget" />;
+});
+
+const messages = {
+  'module.dashboard.greeting_morning': 'Good morning',
+  'module.dashboard.greeting_afternoon': 'Good afternoon',
+  'module.dashboard.greeting_evening': 'Good evening',
+  'module.dashboard.summary_events': 'Today you have {count} events',
+  'module.dashboard.summary_no_events': 'No events today',
+  'module.dashboard.summary_tasks': ' and {count} open tasks.',
+  'module.dashboard.quick_event': 'Event',
+  'module.dashboard.quick_task': 'Task',
+  'module.dashboard.quick_shopping': 'Shopping',
+  'module.dashboard.quick_invite': 'Invite',
+  'module.dashboard.quick_actions_label': 'Quick actions',
+  'module.dashboard.context_chips_label': 'Family at a glance',
+  'module.dashboard.chip_members': 'Members',
+  'module.dashboard.chip_today_events': 'Today',
+  'module.dashboard.chip_open_tasks': 'Open tasks',
+  'module.dashboard.open_tasks': 'Open tasks',
+  'module.dashboard.all': 'All',
+  'module.dashboard.empty_events': 'No upcoming events',
+  'module.dashboard.empty_events_action': 'Open calendar',
+  'module.dashboard.empty_tasks': 'All done!',
+  'module.dashboard.empty_tasks_action': 'Create task',
+  'module.tasks.no_tasks': 'No tasks yet',
+  'module.dashboard.empty_birthdays': 'No birthdays',
+  'module.dashboard.days': 'days',
+  'module.dashboard.activation_title': 'Get your household started',
+  'module.dashboard.activation_subtitle': 'A few quick steps so the whole family can use Tribu together.',
+  'module.dashboard.activation_step_invite_title': 'Invite your family',
+  'module.dashboard.activation_step_invite_desc': 'Send an invitation link.',
+  'module.dashboard.activation_step_invite_cta': 'Open invitations',
+  'module.dashboard.activation_step_invite_done': 'Family members joined',
+  'module.dashboard.activation_step_event_title': 'Add your first event',
+  'module.dashboard.activation_step_event_desc': 'Put a shared appointment on the calendar.',
+  'module.dashboard.activation_step_event_cta': 'Open calendar',
+  'module.dashboard.activation_step_event_done': 'Calendar in use',
+  'module.dashboard.activation_step_task_title': 'Add your first task',
+  'module.dashboard.activation_step_task_desc': 'Capture something that needs doing.',
+  'module.dashboard.activation_step_task_cta': 'Open tasks',
+  'module.dashboard.activation_step_task_done': 'Tasks in use',
+  'module.dashboard.activation_step_shopping_title': 'Start a shopping list',
+  'module.dashboard.activation_step_shopping_desc': 'Create a shared list.',
+  'module.dashboard.activation_step_shopping_cta': 'Open shopping',
+  'module.dashboard.activation_step_shopping_done': 'Shopping list ready',
+  'module.dashboard.activation_step_done_aria': 'Step completed',
+  'module.dashboard.activation_step_pending_aria': 'Step pending',
+  'module.dashboard.daily_loop_title': 'Today in motion',
+  'module.dashboard.daily_loop_subtitle': 'Meals, groceries and routines in one daily check-in.',
+  'module.dashboard.daily_loop_meals': 'Meals planned',
+  'module.dashboard.daily_loop_shopping': 'Shopping open',
+  'module.dashboard.daily_loop_routines': 'Routines due',
+  'module.dashboard.daily_loop_open_meals': 'Plan meals',
+  'module.dashboard.daily_loop_open_shopping': 'Open shopping',
+  'module.dashboard.daily_loop_open_routines': 'Open routines',
+  'module.dashboard.daily_loop_empty': 'Plan a meal, add groceries or set a recurring task to start the daily loop.',
+  next_events: 'Next events',
+  upcoming_birthdays_4w: 'Birthdays',
+};
+
+function isoDate(offsetDays = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
+function baseApp(overrides = {}) {
+  return {
+    summary: { next_events: [], upcoming_birthdays: [] },
+    me: { display_name: 'Dennis' },
+    members: [{ user_id: 1, display_name: 'Dennis' }],
+    tasks: [],
+    events: [{ id: 1, title: 'School', starts_at: `${isoDate()}T08:00:00` }],
+    shoppingLists: [],
+    familyId: 42,
+    setActiveView: jest.fn(),
+    messages,
+    lang: 'en',
+    timeFormat: '24h',
+    isChild: false,
+    isAdmin: false,
+    demoMode: false,
+    ...overrides,
+  };
+}
+
+describe('DashboardView daily loop', () => {
+  beforeEach(() => {
+    apiListMealPlans.mockResolvedValue({ ok: true, data: [] });
+    mockAppState = baseApp();
+  });
+
+  it('fetches today meal plans and summarizes meals, open shopping and due routines', async () => {
+    apiListMealPlans.mockResolvedValue({
+      ok: true,
+      data: [
+        { id: 1, plan_date: isoDate(), slot: 'evening' },
+        { id: 2, plan_date: isoDate(), slot: 'noon' },
+      ],
+    });
+    mockAppState = baseApp({
+      shoppingLists: [
+        { id: 1, item_count: 5, checked_count: 2 },
+        { id: 2, items: [{ checked: false }, { checked: true }, { checked: false }] },
+      ],
+      tasks: [
+        { id: 1, title: 'Take out bins', status: 'open', recurrence: 'weekly', due_date: isoDate(-1) },
+        { id: 2, title: 'Water plants', status: 'open', recurrence: 'weekly', due_date: isoDate() },
+        { id: 3, title: 'Future routine', status: 'open', recurrence: 'weekly', due_date: isoDate(2) },
+        { id: 4, title: 'Undated routine', status: 'open', recurrence: 'weekly' },
+        { id: 5, title: 'Done routine', status: 'done', recurrence: 'daily', due_date: isoDate() },
+      ],
+    });
+
+    render(<DashboardView />);
+
+    await waitFor(() => {
+      expect(apiListMealPlans).toHaveBeenCalledWith(42, isoDate(), isoDate());
+    });
+
+    const card = screen.getByRole('region', { name: 'Today in motion' });
+    await waitFor(() => expect(within(card).getByTestId('daily-loop-meals')).toHaveTextContent('2'));
+    expect(within(card).getByTestId('daily-loop-shopping')).toHaveTextContent('5');
+    expect(within(card).getByTestId('daily-loop-routines')).toHaveTextContent('2');
+  });
+
+  it('navigates from daily loop actions to meals, shopping and routines', async () => {
+    const setActiveView = jest.fn();
+    mockAppState = baseApp({ setActiveView });
+
+    render(<DashboardView />);
+
+    const card = screen.getByRole('region', { name: 'Today in motion' });
+    fireEvent.click(within(card).getByRole('button', { name: 'Plan meals' }));
+    fireEvent.click(within(card).getByRole('button', { name: 'Open shopping' }));
+    fireEvent.click(within(card).getByRole('button', { name: 'Open routines' }));
+
+    expect(setActiveView).toHaveBeenCalledWith('meal_plans');
+    expect(setActiveView).toHaveBeenCalledWith('shopping');
+    expect(setActiveView).toHaveBeenCalledWith('tasks');
+  });
+
+  it('shows an empty prompt when no daily loop inputs exist', async () => {
+    render(<DashboardView />);
+
+    const card = screen.getByRole('region', { name: 'Today in motion' });
+    expect(await within(card).findByText('Plan a meal, add groceries or set a recurring task to start the daily loop.')).toBeVisible();
+  });
+});

--- a/frontend/__tests__/components/DashboardDesktopLayout.test.js
+++ b/frontend/__tests__/components/DashboardDesktopLayout.test.js
@@ -14,6 +14,10 @@ jest.mock('../../lib/i18n', () => ({
   t: (messages, key) => messages?.[key] || key,
 }));
 
+jest.mock('../../lib/api', () => ({
+  apiListMealPlans: jest.fn().mockResolvedValue({ ok: true, data: [] }),
+}));
+
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
   return <div className="bento-card bento-rewards" data-testid="rewards-widget" />;
 });
@@ -42,6 +46,15 @@ const messages = {
   'module.dashboard.members': 'Members',
   'module.dashboard.today': 'Today',
   'module.dashboard.open_tasks_short': 'Open tasks',
+  'module.dashboard.daily_loop_title': 'Today in motion',
+  'module.dashboard.daily_loop_subtitle': 'Meals, groceries and routines in one daily check-in.',
+  'module.dashboard.daily_loop_meals': 'Meals planned',
+  'module.dashboard.daily_loop_shopping': 'Shopping open',
+  'module.dashboard.daily_loop_routines': 'Routines due',
+  'module.dashboard.daily_loop_open_meals': 'Plan meals',
+  'module.dashboard.daily_loop_open_shopping': 'Open shopping',
+  'module.dashboard.daily_loop_open_routines': 'Open routines',
+  'module.dashboard.daily_loop_empty': 'Plan a meal, add groceries or set a recurring task to start the daily loop.',
   next_events: 'Next events',
   upcoming_birthdays_4w: 'Birthdays',
 };
@@ -57,6 +70,7 @@ function baseApp(overrides = {}) {
     tasks: [{ id: 1, title: 'Take bins out', status: 'done' }],
     events: [{ id: 1, title: 'Training', starts_at: '2030-01-01T10:00:00Z' }],
     shoppingLists: [{ id: 1, items: [{ id: 1, name: 'Milk' }] }],
+    familyId: 42,
     setActiveView: jest.fn(),
     messages,
     lang: 'en',
@@ -72,17 +86,19 @@ describe('DashboardView desktop bento layout', () => {
     mockAppState = baseApp();
   });
 
-  it('places next events and open tasks as the first two desktop modules', () => {
+  it('places the daily loop before the existing desktop modules', () => {
     const { container } = render(<DashboardView />);
 
     const modules = Array.from(container.querySelectorAll('.bento-grid > .bento-card'));
-    expect(modules[0]).toHaveClass('bento-events');
-    expect(modules[0]).toHaveAccessibleName('Next events');
-    expect(modules[1]).toHaveClass('bento-tasks');
-    expect(modules[1]).toHaveAccessibleName('Open tasks');
-    expect(modules[2]).toHaveClass('bento-birthdays');
-    expect(modules[2]).toHaveAccessibleName('Birthdays');
-    expect(modules[3]).toHaveClass('bento-rewards');
+    expect(modules[0]).toHaveClass('bento-daily-loop');
+    expect(modules[0]).toHaveAccessibleName('Today in motion');
+    expect(modules[1]).toHaveClass('bento-events');
+    expect(modules[1]).toHaveAccessibleName('Next events');
+    expect(modules[2]).toHaveClass('bento-tasks');
+    expect(modules[2]).toHaveAccessibleName('Open tasks');
+    expect(modules[3]).toHaveClass('bento-birthdays');
+    expect(modules[3]).toHaveAccessibleName('Birthdays');
+    expect(modules[4]).toHaveClass('bento-rewards');
   });
 
   it('keeps the loading skeleton in the same card order', () => {
@@ -91,6 +107,7 @@ describe('DashboardView desktop bento layout', () => {
     const skeletonBlock = appShell.match(/function DashboardSkeleton\(\) \{[\s\S]*?\n\}/)?.[0];
 
     expect(skeletonBlock).toBeDefined();
+    expect(skeletonBlock.indexOf('bento-daily-loop')).toBeLessThan(skeletonBlock.indexOf('bento-events'));
     expect(skeletonBlock.indexOf('bento-events')).toBeLessThan(skeletonBlock.indexOf('bento-tasks'));
     expect(skeletonBlock.indexOf('bento-tasks')).toBeLessThan(skeletonBlock.indexOf('bento-birthdays'));
     expect(skeletonBlock.indexOf('bento-birthdays')).toBeLessThan(skeletonBlock.indexOf('bento-rewards'));
@@ -101,10 +118,11 @@ describe('DashboardView desktop bento layout', () => {
     const css = fs.readFileSync(cssPath, 'utf8');
 
     expect(css).toMatch(/\.bento-events\s*\{\s*grid-column:\s*span 6;\s*\}/);
+    expect(css).toMatch(/\.bento-daily-loop\s*\{\s*grid-column:\s*span 12;\s*\}/);
     expect(css).toMatch(/\.bento-tasks\s*\{\s*grid-column:\s*span 6;\s*\}/);
     expect(css).toMatch(/\.bento-birthdays\s*\{\s*grid-column:\s*span 6;\s*\}/);
     expect(css).toMatch(/\.bento-rewards\s*\{\s*grid-column:\s*span 6;\s*\}/);
-    expect(css).toMatch(/@media \(max-width: 1100px\) \{\s*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-rewards \{ grid-column: span 6; \}/);
-    expect(css).toMatch(/@media \(max-width: 768px\)[\s\S]*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-rewards \{ grid-column: span 1; \}/);
+    expect(css).toMatch(/@media \(max-width: 1100px\) \{[\s\S]*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-rewards \{ grid-column: span 6; \}/);
+    expect(css).toMatch(/@media \(max-width: 768px\)[\s\S]*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-rewards, \.bento-daily-loop \{ grid-column: span 1; \}/);
   });
 });

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -47,6 +47,7 @@ function DashboardSkeleton() {
         </div>
       </div>
       <div className="bento-grid">
+        <div className="bento-daily-loop skeleton skeleton-card" style={{ minHeight: 170 }} />
         <div className="bento-events skeleton skeleton-card" style={{ minHeight: 180 }} />
         <div className="bento-tasks skeleton skeleton-card" style={{ minHeight: 180 }} />
         <div className="bento-birthdays skeleton skeleton-card" style={{ minHeight: 180 }} />

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,11 +1,106 @@
-import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { getMemberColor } from '../lib/member-colors';
+import { apiListMealPlans } from '../lib/api';
 import AssignedBadges from './AssignedBadges';
 import MemberAvatar from './MemberAvatar';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
+
+function todayIsoDate() {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+function normalizeDateOnly(value) {
+  if (!value) return null;
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value)) return value.slice(0, 10);
+  const parsed = parseDate(value);
+  if (!parsed) return null;
+  const month = String(parsed.getMonth() + 1).padStart(2, '0');
+  const day = String(parsed.getDate()).padStart(2, '0');
+  return `${parsed.getFullYear()}-${month}-${day}`;
+}
+
+function countOpenShoppingItems(lists) {
+  return (Array.isArray(lists) ? lists : []).reduce((sum, list) => {
+    if (!list) return sum;
+    if (typeof list.item_count === 'number' || typeof list.checked_count === 'number') {
+      return sum + Math.max(0, Number(list.item_count || 0) - Number(list.checked_count || 0));
+    }
+    const items = Array.isArray(list.items) ? list.items : [];
+    return sum + items.filter((item) => !item?.checked && !item?.is_checked).length;
+  }, 0);
+}
+
+function countDueRoutines(tasks, today = todayIsoDate()) {
+  return (Array.isArray(tasks) ? tasks : []).filter((task) => {
+    if (!task || task.status !== 'open' || !task.recurrence) return false;
+    const dueDate = normalizeDateOnly(task.due_date);
+    return Boolean(dueDate) && dueDate <= today;
+  }).length;
+}
+
+function DailyLoopCard({ mealsTodayCount, shoppingOpenCount, routineDueCount, messages, setActiveView }) {
+  const hasDailyInputs = mealsTodayCount > 0 || shoppingOpenCount > 0 || routineDueCount > 0;
+  const items = [
+    {
+      key: 'meals',
+      icon: Utensils,
+      value: mealsTodayCount,
+      label: t(messages, 'module.dashboard.daily_loop_meals'),
+      actionLabel: t(messages, 'module.dashboard.daily_loop_open_meals'),
+      onClick: () => setActiveView('meal_plans'),
+    },
+    {
+      key: 'shopping',
+      icon: ShoppingCart,
+      value: shoppingOpenCount,
+      label: t(messages, 'module.dashboard.daily_loop_shopping'),
+      actionLabel: t(messages, 'module.dashboard.daily_loop_open_shopping'),
+      onClick: () => setActiveView('shopping'),
+    },
+    {
+      key: 'routines',
+      icon: ListChecks,
+      value: routineDueCount,
+      label: t(messages, 'module.dashboard.daily_loop_routines'),
+      actionLabel: t(messages, 'module.dashboard.daily_loop_open_routines'),
+      onClick: () => setActiveView('tasks'),
+    },
+  ];
+
+  return (
+    <div className="bento-card bento-daily-loop" role="region" aria-label={t(messages, 'module.dashboard.daily_loop_title')}>
+      <div className="bento-card-header daily-loop-header">
+        <div>
+          <h2 className="bento-card-title"><Sparkles size={16} aria-hidden="true" /> {t(messages, 'module.dashboard.daily_loop_title')}</h2>
+          <p className="daily-loop-subtitle">{t(messages, 'module.dashboard.daily_loop_subtitle')}</p>
+        </div>
+      </div>
+      <div className="daily-loop-list">
+        {items.map((item) => {
+          const Icon = item.icon;
+          return (
+            <div key={item.key} className="daily-loop-item">
+              <span className="daily-loop-icon" aria-hidden="true"><Icon size={16} /></span>
+              <div className="daily-loop-copy">
+                <span className="daily-loop-value" data-testid={`daily-loop-${item.key}`}>{item.value}</span>
+                <span className="daily-loop-label">{item.label}</span>
+              </div>
+              <button type="button" className="daily-loop-action" onClick={item.onClick}>{item.actionLabel}</button>
+            </div>
+          );
+        })}
+      </div>
+      {!hasDailyInputs && <div className="daily-loop-empty">{t(messages, 'module.dashboard.daily_loop_empty')}</div>}
+    </div>
+  );
+}
 
 function getGreeting(messages) {
   const h = new Date().getHours();
@@ -55,11 +150,33 @@ function ActivationPanel({ steps, messages }) {
 }
 
 export default function DashboardView() {
-  const { summary, me, members, tasks, events, shoppingLists, setActiveView, messages, lang, timeFormat, isChild, isAdmin } = useApp();
+  const { summary, me, members, tasks, events, shoppingLists, familyId, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode } = useApp();
+  const todayIso = useMemo(() => todayIsoDate(), []);
+  const [mealsTodayCount, setMealsTodayCount] = useState(0);
 
-  const openTasks = tasks.filter((t) => t.status === 'open');
+  const openTasks = tasks.filter((task) => task.status === 'open');
+  const shoppingOpenCount = useMemo(() => countOpenShoppingItems(shoppingLists), [shoppingLists]);
+  const routineDueCount = useMemo(() => countDueRoutines(tasks, todayIso), [tasks, todayIso]);
   const locale = lang === 'de' ? 'de-DE' : 'en-US';
   const todayStr = new Date().toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!familyId || demoMode) {
+      setMealsTodayCount(0);
+      return () => { cancelled = true; };
+    }
+
+    apiListMealPlans(familyId, todayIso, todayIso).then((res) => {
+      if (cancelled) return;
+      const items = Array.isArray(res?.data?.items) ? res.data.items : Array.isArray(res?.data) ? res.data : [];
+      setMealsTodayCount(items.length);
+    }).catch(() => {
+      if (!cancelled) setMealsTodayCount(0);
+    });
+
+    return () => { cancelled = true; };
+  }, [familyId, demoMode, todayIso]);
 
   const todayEventCount = (summary.next_events || []).filter((ev) => {
     const d = parseDate(ev.starts_at);
@@ -220,6 +337,14 @@ export default function DashboardView() {
       {showActivationPanel && <ActivationPanel steps={activationSteps} messages={messages} />}
 
       <div className="bento-grid">
+        <DailyLoopCard
+          mealsTodayCount={mealsTodayCount}
+          shoppingOpenCount={shoppingOpenCount}
+          routineDueCount={routineDueCount}
+          messages={messages}
+          setActiveView={setActiveView}
+        />
+
         {/* Events Card */}
         <div className="bento-card bento-events" role="region" aria-label={t(messages, 'next_events')}>
           <div className="bento-card-header">

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -49,5 +49,14 @@
   "module.dashboard.activation_step_done_aria": "Schritt erledigt",
   "module.dashboard.activation_step_pending_aria": "Schritt offen",
   "module.dashboard.quick_my_tasks": "Meine Aufgaben",
-  "module.dashboard.quick_rewards": "Rewards"
+  "module.dashboard.quick_rewards": "Rewards",
+  "module.dashboard.daily_loop_title": "Heute im Griff",
+  "module.dashboard.daily_loop_subtitle": "Essen, Einkauf und Routinen in einem täglichen Check-in.",
+  "module.dashboard.daily_loop_meals": "Geplante Mahlzeiten",
+  "module.dashboard.daily_loop_shopping": "Offener Einkauf",
+  "module.dashboard.daily_loop_routines": "Fällige Routinen",
+  "module.dashboard.daily_loop_open_meals": "Essen planen",
+  "module.dashboard.daily_loop_open_shopping": "Einkauf öffnen",
+  "module.dashboard.daily_loop_open_routines": "Routinen öffnen",
+  "module.dashboard.daily_loop_empty": "Plane ein Essen, ergänze den Einkauf oder lege eine wiederkehrende Aufgabe an, damit der Tag gut startet."
 }

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -49,5 +49,14 @@
   "module.dashboard.activation_step_done_aria": "Step completed",
   "module.dashboard.activation_step_pending_aria": "Step pending",
   "module.dashboard.quick_my_tasks": "My tasks",
-  "module.dashboard.quick_rewards": "Rewards"
+  "module.dashboard.quick_rewards": "Rewards",
+  "module.dashboard.daily_loop_title": "Today in motion",
+  "module.dashboard.daily_loop_subtitle": "Meals, groceries and routines in one daily check-in.",
+  "module.dashboard.daily_loop_meals": "Meals planned",
+  "module.dashboard.daily_loop_shopping": "Shopping open",
+  "module.dashboard.daily_loop_routines": "Routines due",
+  "module.dashboard.daily_loop_open_meals": "Plan meals",
+  "module.dashboard.daily_loop_open_shopping": "Open shopping",
+  "module.dashboard.daily_loop_open_routines": "Open routines",
+  "module.dashboard.daily_loop_empty": "Plan a meal, add groceries, or set a recurring task to get today started."
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -729,6 +729,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-grid { display: grid; grid-template-columns: repeat(12, 1fr); column-gap: var(--space-md); row-gap: var(--space-lg); }
 .bento-card { padding: var(--space-lg); background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); transition: all 0.2s; }
 .bento-card:hover { border-color: rgba(120, 130, 180, 0.2); }
+.bento-daily-loop { grid-column: span 12; }
 .bento-events { grid-column: span 6; }
 .bento-tasks { grid-column: span 6; }
 .bento-birthdays { grid-column: span 6; }
@@ -737,6 +738,17 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-card-title { font-size: 0.78rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 8px; }
 .bento-more { background: none; border: none; color: var(--text-muted); cursor: pointer; font-family: inherit; font-size: 0.78rem; padding: 4px 10px; border-radius: var(--radius-pill); transition: all 0.2s; }
 .bento-more:hover { background: rgba(255,255,255,0.05); color: var(--text-primary); }
+.daily-loop-header { align-items: flex-start; margin-bottom: var(--space-sm); }
+.daily-loop-subtitle { margin: 6px 0 0; color: var(--text-muted); font-size: 0.9rem; }
+.daily-loop-list { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-sm); }
+.daily-loop-item { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: var(--space-sm); padding: var(--space-md); border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); border: 1px solid rgba(120, 130, 180, 0.08); }
+.daily-loop-icon { display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px; border-radius: var(--radius-pill); background: rgba(139, 92, 246, 0.12); color: var(--amethyst); }
+.daily-loop-copy { display: flex; flex-direction: column; min-width: 0; }
+.daily-loop-value { font-family: 'JetBrains Mono', monospace; font-size: 1.35rem; font-weight: 700; color: var(--text-primary); line-height: 1; }
+.daily-loop-label { margin-top: 4px; color: var(--text-muted); font-size: 0.82rem; }
+.daily-loop-action { justify-self: end; min-height: 44px; border: none; border-radius: var(--radius-pill); padding: 7px 11px; background: var(--void-surface); color: var(--amethyst); font-family: inherit; font-size: 0.78rem; font-weight: 600; cursor: pointer; box-shadow: var(--shadow-sm); }
+.daily-loop-action:hover { background: rgba(139, 92, 246, 0.1); }
+.daily-loop-empty { margin-top: var(--space-sm); padding: 10px 12px; border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); color: var(--text-muted); font-size: 0.85rem; }
 .bento-empty { color: var(--text-muted); font-size: 0.85rem; padding: var(--space-md) 0; display: flex; align-items: center; gap: var(--space-sm); }
 .bento-empty-action { background: none; border: none; color: var(--amethyst); cursor: pointer; font-family: inherit; font-size: 0.85rem; font-weight: 500; padding: 8px 12px; min-height: 44px; display: inline-flex; align-items: center; border-radius: var(--radius-sm); transition: opacity 0.2s; }
 .bento-empty-action:hover { opacity: 0.7; }
@@ -1629,7 +1641,9 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    RESPONSIVE
    ═══════════════════════════════════════════ */
 @media (max-width: 1100px) {
+  .bento-daily-loop { grid-column: span 12; }
   .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards { grid-column: span 6; }
+  .daily-loop-list { grid-template-columns: 1fr; }
   .calendar-layout { grid-template-columns: 1fr; }
 }
 
@@ -1640,7 +1654,10 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .mobile-header { display: flex; }
   .bottom-nav { display: block; }
   .bento-grid { grid-template-columns: 1fr; row-gap: var(--space-md); }
-  .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards { grid-column: span 1; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards, .bento-daily-loop { grid-column: span 1; }
+  .daily-loop-list { grid-template-columns: 1fr; }
+  .daily-loop-item { grid-template-columns: auto 1fr; }
+  .daily-loop-action { grid-column: 1 / -1; justify-self: stretch; text-align: center; }
   .dashboard-header-actions { flex-wrap: wrap; }
   .view-header { flex-direction: column; align-items: flex-start; }
   .tasks-toolbar { flex-direction: column; align-items: flex-start; }


### PR DESCRIPTION
## Summary
- Adds a dashboard daily planning card that connects today’s meal plans, open shopping items, and due recurring routines.
- Adds direct actions into meal planning, shopping, and tasks.
- Updates dashboard skeleton, responsive styling, and dashboard translations.

## Test plan
- `npm test -- --runTestsByPath __tests__/components/DashboardDailyLoop.test.js __tests__/components/DashboardDesktopLayout.test.js __tests__/components/DashboardHero.test.js __tests__/components/DashboardActivationPanel.test.js __tests__/components/MealPlansView.test.js __tests__/components/ShoppingView.test.js __tests__/components/TasksView.test.js __tests__/lib/i18n.test.js --runInBand`
- `npm run build`
- `npx playwright test e2e/tests/dashboard.spec.js e2e/tests/meal-plans.spec.js e2e/tests/shopping.spec.js e2e/tests/tasks.spec.js --reporter=list`

Closes #173
