### PR TITLE
Add household activity feed

### DIFF
--- a/backend/alembic/versions/0040_add_household_activity.py
+++ b/backend/alembic/versions/0040_add_household_activity.py
@@ -1,0 +1,49 @@
+"""Add household activity feed.
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-04-29
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0040"
+down_revision: Union[str, None] = "0039"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "household_activity",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("family_id", sa.Integer(), nullable=False),
+        sa.Column("actor_user_id", sa.Integer(), nullable=True),
+        sa.Column("actor_display_name", sa.String(length=80), nullable=True),
+        sa.Column("action", sa.String(length=40), nullable=False),
+        sa.Column("object_type", sa.String(length=60), nullable=False),
+        sa.Column("object_id", sa.Integer(), nullable=True),
+        sa.Column("summary", sa.String(length=240), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_household_activity_id"), "household_activity", ["id"], unique=False)
+    op.create_index(op.f("ix_household_activity_family_id"), "household_activity", ["family_id"], unique=False)
+    op.create_index(op.f("ix_household_activity_actor_user_id"), "household_activity", ["actor_user_id"], unique=False)
+    op.create_index("ix_household_activity_family_created", "household_activity", ["family_id", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_household_activity_family_created", table_name="household_activity")
+    op.drop_index(op.f("ix_household_activity_actor_user_id"), table_name="household_activity")
+    op.drop_index(op.f("ix_household_activity_family_id"), table_name="household_activity")
+    op.drop_index(op.f("ix_household_activity_id"), table_name="household_activity")
+    op.drop_table("household_activity")

--- a/backend/app/core/activity.py
+++ b/backend/app/core/activity.py
@@ -1,0 +1,64 @@
+"""Public-safe household activity helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models import HouseholdActivity
+
+MAX_LABEL_LENGTH = 80
+MAX_SUMMARY_LENGTH = 240
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def safe_activity_label(value: Optional[str], fallback: str = "item") -> str:
+    """Return a short single-line label safe for feed summaries."""
+    cleaned = _WHITESPACE_RE.sub(" ", (value or "").strip())
+    if not cleaned:
+        cleaned = fallback
+    if len(cleaned) > MAX_LABEL_LENGTH:
+        cleaned = f"{cleaned[: MAX_LABEL_LENGTH - 1].rstrip()}…"
+    return cleaned
+
+
+def build_activity_summary(actor_name: Optional[str], verb: str, object_label: str, *, object_kind: str | None = None) -> str:
+    actor = safe_activity_label(actor_name, "Someone")
+    label = safe_activity_label(object_label)
+    if object_kind and object_kind.startswith("to "):
+        summary = f'{actor} {verb} "{label}" {object_kind}'
+    else:
+        noun = f" {object_kind}" if object_kind else ""
+        summary = f'{actor} {verb}{noun} "{label}"'
+    if len(summary) > MAX_SUMMARY_LENGTH:
+        summary = f"{summary[: MAX_SUMMARY_LENGTH - 1].rstrip()}…"
+    return summary
+
+
+def record_activity(
+    db: Session,
+    *,
+    family_id: int,
+    actor_user_id: Optional[int],
+    actor_display_name: Optional[str],
+    action: str,
+    object_type: str,
+    object_label: str,
+    object_id: Optional[int] = None,
+    verb: str,
+    object_kind: str | None = None,
+) -> HouseholdActivity:
+    """Add a sanitized household activity row to the current transaction."""
+    activity = HouseholdActivity(
+        family_id=family_id,
+        actor_user_id=actor_user_id,
+        actor_display_name=safe_activity_label(actor_display_name, "Someone") if actor_display_name else None,
+        action=action,
+        object_type=object_type,
+        object_id=object_id,
+        summary=build_activity_summary(actor_display_name, verb, object_label, object_kind=object_kind),
+    )
+    db.add(activity)
+    return activity

--- a/backend/app/core/scopes.py
+++ b/backend/app/core/scopes.py
@@ -13,6 +13,7 @@ SCOPE_DESCRIPTIONS: dict[str, str] = {
     "birthdays:write": "Create birthdays",
     "families:read": "View family members, invitations, and audit log",
     "families:write": "Manage members, invitations, roles, and passwords",
+    "activity:read": "View public-safe household activity feed",
     "shopping:read": "View shopping lists and items",
     "shopping:write": "Create, update, and delete shopping lists and items",
     "profile:read": "View own profile and list personal access tokens",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.models import AuditLog, CalendarEvent, Family, Membership, ShoppingList
 from app.modules.birthdays_router import router as birthdays_router
 from app.modules.calendar_router import router as calendar_router
 from app.modules.dashboard_router import router as dashboard_router
+from app.modules.activity_router import router as activity_router
 from app.modules.families_router import router as families_router
 from app.modules.contacts_router import router as contacts_router
 from app.modules.tasks_router import router as tasks_router
@@ -169,6 +170,7 @@ TAG_METADATA = [
     {"name": "contacts", "description": "Contact management with CSV import/export. Auto-syncs birthday entries."},
     {"name": "birthdays", "description": "Family birthday tracking."},
     {"name": "dashboard", "description": "Aggregated dashboard with upcoming events (14 days) and birthdays (28 days)."},
+    {"name": "activity", "description": "Recent public-safe household activity for the current family."},
     {"name": "notifications", "description": "User notifications with SSE streaming, read/unread management, and notification preferences."},
     {"name": "tokens", "description": "Personal Access Token (PAT) management for API automation."},
     {"name": "backup", "description": "Database backup management — schedule, trigger, download, and delete. Admin only."},
@@ -588,6 +590,7 @@ app.include_router(families_router)
 app.include_router(calendar_router)
 app.include_router(birthdays_router)
 app.include_router(dashboard_router)
+app.include_router(activity_router)
 app.include_router(contacts_router)
 app.include_router(tasks_router)
 app.include_router(shopping_router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -44,6 +44,7 @@ class Family(Base):
     invitations = relationship("FamilyInvitation", back_populates="family", cascade="all, delete-orphan")
     reward_currency = relationship("RewardCurrency", back_populates="family", uselist=False, cascade="all, delete-orphan")
     display_devices = relationship("DisplayDevice", back_populates="family", cascade="all, delete-orphan")
+    household_activities = relationship("HouseholdActivity", back_populates="family", cascade="all, delete-orphan")
 
 
 class Membership(Base):
@@ -491,6 +492,26 @@ class AuditLog(Base):
     target_user_id = Column(Integer, nullable=True)
     details = Column(JSON, nullable=True)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+
+class HouseholdActivity(Base):
+    __tablename__ = "household_activity"
+    __table_args__ = (
+        Index("ix_household_activity_family_created", "family_id", "created_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    actor_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    actor_display_name = Column(String(80), nullable=True)
+    action = Column(String(40), nullable=False)
+    object_type = Column(String(60), nullable=False)
+    object_id = Column(Integer, nullable=True)
+    summary = Column(String(240), nullable=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    family = relationship("Family", back_populates="household_activities")
+    actor = relationship("User")
 
 
 class FamilyInvitation(Base):

--- a/backend/app/modules/activity_router.py
+++ b/backend/app/modules/activity_router.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.deps import current_user, ensure_family_membership
+from app.core.scopes import require_scope
+from app.database import get_db
+from app.models import HouseholdActivity, User
+from app.schemas import AUTH_RESPONSES, HouseholdActivityEntry, PaginatedHouseholdActivity
+
+router = APIRouter(prefix="/activity", tags=["activity"], responses={**AUTH_RESPONSES})
+
+
+@router.get(
+    "",
+    response_model=PaginatedHouseholdActivity,
+    summary="List household activity",
+    description="Return recent public-safe activity for a family. Scope: `activity:read`.",
+    response_description="Paginated household activity feed",
+)
+def list_activity(
+    family_id: int,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(20, ge=1, le=100),
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("activity:read"),
+):
+    ensure_family_membership(db, user.id, family_id)
+    base = db.query(HouseholdActivity).filter(HouseholdActivity.family_id == family_id)
+    total = base.count()
+    rows = (
+        base
+        .order_by(HouseholdActivity.created_at.desc(), HouseholdActivity.id.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    items = [
+        HouseholdActivityEntry(
+            id=activity.id,
+            actor_display_name=activity.actor_display_name,
+            action=activity.action,
+            object_type=activity.object_type,
+            summary=activity.summary,
+            created_at=activity.created_at,
+        )
+        for activity in rows
+    ]
+    return PaginatedHouseholdActivity(items=items, total=total, offset=offset, limit=limit)

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.deps import current_user, ensure_adult, ensure_family_membership
+from app.core.activity import record_activity
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import ShoppingItem, ShoppingList, ShoppingTemplate, ShoppingTemplateItem, User
@@ -277,6 +278,19 @@ def create_list(
         created_by_user_id=user.id,
     )
     db.add(sl)
+    db.flush()
+    record_activity(
+        db,
+        family_id=sl.family_id,
+        actor_user_id=user.id,
+        actor_display_name=user.display_name,
+        action="created",
+        object_type="shopping_list",
+        object_id=sl.id,
+        object_label=sl.name,
+        verb="created",
+        object_kind="shopping list",
+    )
     db.commit()
     db.refresh(sl)
     resp = _list_response(sl)
@@ -365,6 +379,19 @@ def add_item(
         added_by_user_id=user.id,
     )
     db.add(item)
+    db.flush()
+    record_activity(
+        db,
+        family_id=sl.family_id,
+        actor_user_id=user.id,
+        actor_display_name=user.display_name,
+        action="added",
+        object_type="shopping_item",
+        object_id=item.id,
+        object_label=item.name,
+        verb="added",
+        object_kind="to shopping",
+    )
     db.commit()
     db.refresh(item)
     broadcast_item_added(list_id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
@@ -403,8 +430,21 @@ def update_item(
     if payload.category is not None:
         item.category = payload.category
     if payload.checked is not None:
+        was_checked = item.checked
         item.checked = payload.checked
         item.checked_at = utcnow() if payload.checked else None
+        if payload.checked and not was_checked:
+            record_activity(
+                db,
+                family_id=sl.family_id,
+                actor_user_id=user.id,
+                actor_display_name=user.display_name,
+                action="checked",
+                object_type="shopping_item",
+                object_id=item.id,
+                object_label=item.name,
+                verb="checked off",
+            )
 
     db.commit()
     db.refresh(item)

--- a/backend/app/modules/tasks_router.py
+++ b/backend/app/modules/tasks_router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.core.deps import current_user, ensure_adult, ensure_family_membership, to_utc_naive
+from app.core.activity import record_activity
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import Membership, RewardCurrency, Task, TokenTransaction, User
@@ -103,6 +104,19 @@ def create_task(
         token_require_confirmation=payload.token_require_confirmation,
     )
     db.add(task)
+    db.flush()
+    record_activity(
+        db,
+        family_id=task.family_id,
+        actor_user_id=user.id,
+        actor_display_name=user.display_name,
+        action="created",
+        object_type="task",
+        object_id=task.id,
+        object_label=task.title,
+        verb="created",
+        object_kind="task",
+    )
     db.commit()
     db.refresh(task)
     return task
@@ -168,6 +182,7 @@ def update_task(
         task.token_require_confirmation = payload.token_require_confirmation
 
     next_task = None
+    was_done = task.status == "done"
     if payload.status is not None:
         task.status = payload.status
         if payload.status == "done":
@@ -200,6 +215,19 @@ def update_task(
                     token_require_confirmation=task.token_require_confirmation,
                 )
                 db.add(next_task)
+        if payload.status == "done" and not was_done:
+            record_activity(
+                db,
+                family_id=task.family_id,
+                actor_user_id=user.id,
+                actor_display_name=user.display_name,
+                action="completed",
+                object_type="task",
+                object_id=task.id,
+                object_label=task.title,
+                verb="completed",
+                object_kind="task",
+            )
 
     db.commit()
     db.refresh(task)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -801,6 +801,24 @@ class DashboardSummary(BaseModel):
     upcoming_birthdays: list[UpcomingBirthday] = Field(..., description="Upcoming birthdays within 28 days")
 
 
+class HouseholdActivityEntry(BaseModel):
+    """Public-safe household activity feed item."""
+    id: int = Field(..., description="Activity ID")
+    actor_display_name: Optional[str] = Field(None, description="Actor display name, null if unavailable")
+    action: str = Field(..., description="Stable action code")
+    object_type: str = Field(..., description="Stable object type code")
+    summary: str = Field(..., description="Short sanitized human-readable summary")
+    created_at: datetime = Field(..., description="Activity timestamp")
+
+
+class PaginatedHouseholdActivity(BaseModel):
+    """Paginated household activity feed."""
+    items: list[HouseholdActivityEntry] = Field(..., description="Activity entries")
+    total: int = Field(..., description="Total matching entries")
+    offset: int = Field(..., description="Pagination offset")
+    limit: int = Field(..., description="Pagination limit")
+
+
 # ---------------------------------------------------------------------------
 # Personal Access Tokens (PAT)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_household_activity.py
+++ b/backend/tests/test_household_activity.py
@@ -1,0 +1,227 @@
+"""Household activity feed integration tests."""
+
+import hashlib
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import Family, HouseholdActivity, Membership, PersonalAccessToken, User
+from app.security import PAT_PREFIX, hash_password
+
+
+engine = create_engine(
+    "sqlite:///./test-household-activity.db",
+    connect_args={"check_same_thread": False},
+)
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_member(
+    scopes: str,
+    suffix: str,
+    *,
+    display_name: str = "Activity User",
+    is_adult: bool = True,
+    family_id: int | None = None,
+) -> tuple[str, int, int]:
+    db = TestSession()
+    user = User(
+        email=f"activity-{suffix}@example.com",
+        password_hash=hash_password("Password123"),
+        display_name=display_name,
+    )
+    db.add(user)
+    db.flush()
+
+    if family_id is None:
+        family = Family(name=f"Activity Family {suffix}")
+        db.add(family)
+        db.flush()
+        family_id = family.id
+
+    db.add(Membership(user_id=user.id, family_id=family_id, role="admin" if is_adult else "member", is_adult=is_adult))
+    plain = f"{PAT_PREFIX}activity-{suffix}-{scopes.replace(',', '-').replace(':', '_').replace('*', 'star')}"
+    lookup = hashlib.sha256(plain.encode()).hexdigest()
+    db.add(PersonalAccessToken(
+        user_id=user.id,
+        name="activity-pat",
+        token_hash=lookup,
+        token_lookup=lookup,
+        scopes=scopes,
+    ))
+    db.commit()
+    user_id = user.id
+    db.close()
+    return plain, family_id, user_id
+
+
+def test_task_create_and_complete_are_recorded_public_safely():
+    token, family_id, user_id = _seed_member("*", "tasks", display_name="Dennis")
+
+    created = client.post(
+        "/tasks",
+        json={
+            "family_id": family_id,
+            "title": "  Pay school lunch  ",
+            "description": "private bank detail should not leak",
+            "priority": "normal",
+        },
+        headers=_auth(token),
+    )
+    assert created.status_code == 200, created.json()
+    task_id = created.json()["id"]
+
+    completed = client.patch(
+        f"/tasks/{task_id}",
+        json={"status": "done"},
+        headers=_auth(token),
+    )
+    assert completed.status_code == 200, completed.json()
+
+    feed = client.get(f"/activity?family_id={family_id}&limit=10", headers=_auth(token))
+    assert feed.status_code == 200, feed.json()
+    data = feed.json()
+    assert data["total"] == 2
+    assert [item["action"] for item in data["items"]] == ["completed", "created"]
+    assert [item["object_type"] for item in data["items"]] == ["task", "task"]
+    assert data["items"][0]["actor_display_name"] == "Dennis"
+    assert "family_id" not in data["items"][0]
+    assert "actor_user_id" not in data["items"][0]
+    assert "object_id" not in data["items"][0]
+
+    db = TestSession()
+    db.query(HouseholdActivity).filter(HouseholdActivity.family_id == family_id).update({"actor_user_id": None})
+    db.commit()
+    db.close()
+
+    feed_after_actor_delete = client.get(f"/activity?family_id={family_id}&limit=10", headers=_auth(token))
+    assert feed_after_actor_delete.status_code == 200
+    assert feed_after_actor_delete.json()["items"][0]["actor_display_name"] == "Dennis"
+
+    assert data["items"][0]["summary"] == "Dennis completed task \"Pay school lunch\""
+    assert data["items"][1]["summary"] == "Dennis created task \"Pay school lunch\""
+    assert "created_at" in data["items"][0]
+    serialized = str(data)
+    assert "private bank detail" not in serialized
+    assert "token" not in serialized.lower()
+    assert "password" not in serialized.lower()
+    assert "details" not in data["items"][0]
+
+
+def test_shopping_activity_and_family_boundaries():
+    token, family_id, _ = _seed_member("*", "shopping", display_name="Anna")
+    intruder_token, _, _ = _seed_member("*", "intruder", display_name="Other")
+
+    shopping_list = client.post(
+        "/shopping/lists",
+        json={"family_id": family_id, "name": "Weekly groceries"},
+        headers=_auth(token),
+    )
+    assert shopping_list.status_code == 200, shopping_list.json()
+    list_id = shopping_list.json()["id"]
+
+    item = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "Milk", "spec": "private note", "category": "Dairy"},
+        headers=_auth(token),
+    )
+    assert item.status_code == 200, item.json()
+    item_id = item.json()["id"]
+
+    checked = client.patch(
+        f"/shopping/items/{item_id}",
+        json={"checked": True},
+        headers=_auth(token),
+    )
+    assert checked.status_code == 200, checked.json()
+
+    denied = client.get(f"/activity?family_id={family_id}", headers=_auth(intruder_token))
+    assert denied.status_code == 403
+
+    feed = client.get(f"/activity?family_id={family_id}&limit=10", headers=_auth(token))
+    assert feed.status_code == 200, feed.json()
+    summaries = [entry["summary"] for entry in feed.json()["items"]]
+    assert summaries == [
+        'Anna checked off "Milk"',
+        'Anna added "Milk" to shopping',
+        'Anna created shopping list "Weekly groceries"',
+    ]
+    assert "private note" not in str(feed.json())
+
+
+def test_activity_feed_orders_and_paginates():
+    token, family_id, user_id = _seed_member("*", "pages")
+    db = TestSession()
+    now = datetime.utcnow()
+    db.add_all([
+        HouseholdActivity(
+            family_id=family_id,
+            actor_user_id=user_id,
+            action="created",
+            object_type="task",
+            object_id=idx,
+            summary=f"Activity User created task \"Item {idx}\"",
+            created_at=now + timedelta(minutes=idx),
+        )
+        for idx in range(3)
+    ])
+    db.commit()
+    db.close()
+
+    feed = client.get(f"/activity?family_id={family_id}&limit=2&offset=1", headers=_auth(token))
+    assert feed.status_code == 200, feed.json()
+    data = feed.json()
+    assert data["total"] == 3
+    assert data["offset"] == 1
+    assert data["limit"] == 2
+    assert [item["summary"] for item in data["items"]] == [
+        "Activity User created task \"Item 1\"",
+        "Activity User created task \"Item 0\"",
+    ]
+
+
+def test_activity_read_scope_is_required_for_pats():
+    token, family_id, _ = _seed_member("tasks:read", "bad-scope")
+    resp = client.get(f"/activity?family_id={family_id}", headers=_auth(token))
+    assert resp.status_code == 403
+
+    good_token, good_family_id, _ = _seed_member("activity:read", "good-scope")
+    allowed = client.get(f"/activity?family_id={good_family_id}", headers=_auth(good_token))
+    assert allowed.status_code == 200, allowed.json()

--- a/frontend/__tests__/components/DashboardDailyLoop.test.js
+++ b/frontend/__tests__/components/DashboardDailyLoop.test.js
@@ -71,6 +71,9 @@ const messages = {
   'module.dashboard.daily_loop_open_shopping': 'Open shopping',
   'module.dashboard.daily_loop_open_routines': 'Open routines',
   'module.dashboard.daily_loop_empty': 'Plan a meal, add groceries or set a recurring task to start the daily loop.',
+  'module.dashboard.activity_title': 'Recent activity',
+  'module.dashboard.activity_empty': 'No household activity yet.',
+  'module.dashboard.activity_unknown_actor': 'Someone',
   next_events: 'Next events',
   upcoming_birthdays_4w: 'Birthdays',
 };
@@ -91,6 +94,7 @@ function baseApp(overrides = {}) {
     tasks: [],
     events: [{ id: 1, title: 'School', starts_at: `${isoDate()}T08:00:00` }],
     shoppingLists: [],
+    activity: [],
     familyId: 42,
     setActiveView: jest.fn(),
     messages,
@@ -164,5 +168,21 @@ describe('DashboardView daily loop', () => {
 
     const card = screen.getByRole('region', { name: 'Today in motion' });
     expect(await within(card).findByText('Plan a meal, add groceries or set a recurring task to start the daily loop.')).toBeVisible();
+  });
+
+  it('shows household activity on the dashboard', async () => {
+    mockAppState = baseApp({
+      activity: [{
+        id: 1,
+        actor_display_name: 'Dennis',
+        summary: 'Dennis completed task "Pay school lunch"',
+        created_at: '2026-04-29T10:00:00Z',
+      }],
+    });
+
+    render(<DashboardView />);
+
+    const card = screen.getByRole('region', { name: 'Recent activity' });
+    expect(within(card).getByText('Dennis completed task "Pay school lunch"')).toBeVisible();
   });
 });

--- a/frontend/__tests__/components/HouseholdActivityFeed.test.js
+++ b/frontend/__tests__/components/HouseholdActivityFeed.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HouseholdActivityFeed from '../../components/HouseholdActivityFeed';
+
+const messages = {
+  'module.dashboard.activity_title': 'Recent activity',
+  'module.dashboard.activity_empty': 'No household activity yet.',
+  'module.dashboard.activity_unknown_actor': 'Someone',
+};
+
+describe('HouseholdActivityFeed', () => {
+  it('renders public activity entries without internal fields', () => {
+    render(
+      <HouseholdActivityFeed
+        messages={messages}
+        lang="en"
+        activity={[
+          {
+            id: 7,
+            actor_display_name: 'Dennis',
+            summary: 'Dennis completed task "Pay school lunch"',
+            created_at: '2026-04-29T10:00:00Z',
+            object_id: 123,
+            details: 'private detail should not render',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('region', { name: 'Recent activity' })).toBeInTheDocument();
+    expect(screen.getByText('Dennis')).toBeInTheDocument();
+    expect(screen.getByText('Dennis completed task "Pay school lunch"')).toBeInTheDocument();
+    expect(screen.queryByText('private detail should not render')).not.toBeInTheDocument();
+    expect(screen.queryByText('123')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty state', () => {
+    render(<HouseholdActivityFeed messages={messages} activity={[]} />);
+    expect(screen.getByText('No household activity yet.')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/contexts/AppContext.test.js
+++ b/frontend/__tests__/contexts/AppContext.test.js
@@ -44,6 +44,7 @@ describe('AppProvider bootstrap', () => {
     api.apiGetContacts.mockResolvedValue({ ok: true, data: [] });
     api.apiGetBirthdays.mockResolvedValue({ ok: true, data: [] });
     api.apiGetShoppingLists.mockResolvedValue({ ok: true, data: [] });
+    api.apiGetActivity.mockResolvedValue({ ok: true, data: { items: [] } });
     api.apiGetNavOrder.mockResolvedValue({ ok: true, data: { nav_order: ['dashboard'] } });
     api.apiGetTimeFormat.mockResolvedValue({ ok: true, data: { time_format: '24h' } });
     api.apiGetUnreadCount.mockResolvedValue({ ok: true, data: { count: 0 } });
@@ -64,5 +65,6 @@ describe('AppProvider bootstrap', () => {
     await waitFor(() => expect(screen.getByTestId('family-id')).toHaveTextContent('7'));
     await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('ready'));
     expect(api.apiGetTasks).toHaveBeenCalledWith('7');
+    expect(api.apiGetActivity).toHaveBeenCalledWith('7', 10, 0);
   });
 });

--- a/frontend/__tests__/lib/api.test.js
+++ b/frontend/__tests__/lib/api.test.js
@@ -4,6 +4,7 @@ import {
   apiGetDashboard, apiGetEvents, apiCreateEvent, apiAddBirthday,
   apiGetContacts, apiImportContactsCsv,
   apiExportCalendarIcs, apiImportCalendarIcs, apiExportContactsCsv,
+  apiGetActivity,
   apiGetTasks, apiCreateTask, apiUpdateTask, apiDeleteTask,
   apiListRecipes, apiCreateRecipe, apiUpdateRecipe, apiDeleteRecipe, apiAddRecipeIngredientsToShopping,
 } from '../../lib/api';
@@ -86,6 +87,11 @@ describe('Dashboard API', () => {
   it('apiGetDashboard includes family_id', async () => {
     await apiGetDashboard('7');
     expect(lastCall()[0]).toBe('/api/dashboard/summary?family_id=7');
+  });
+
+  it('apiGetActivity includes family_id and pagination', async () => {
+    await apiGetActivity('7', 5, 10);
+    expect(lastCall()[0]).toBe('/api/activity?family_id=7&limit=5&offset=10');
   });
 });
 

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -8,6 +8,7 @@ import { apiListMealPlans } from '../lib/api';
 import AssignedBadges from './AssignedBadges';
 import MemberAvatar from './MemberAvatar';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
+import HouseholdActivityFeed from './HouseholdActivityFeed';
 
 function todayIsoDate() {
   const now = new Date();
@@ -150,7 +151,7 @@ function ActivationPanel({ steps, messages }) {
 }
 
 export default function DashboardView() {
-  const { summary, me, members, tasks, events, shoppingLists, familyId, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode } = useApp();
+  const { summary, me, members, tasks, events, shoppingLists, activity, familyId, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode } = useApp();
   const todayIso = useMemo(() => todayIsoDate(), []);
   const [mealsTodayCount, setMealsTodayCount] = useState(0);
 
@@ -440,6 +441,8 @@ export default function DashboardView() {
             })}
           </div>
         </div>
+
+        <HouseholdActivityFeed activity={activity} messages={messages} lang={lang} />
 
         {/* Rewards Widget */}
         <RewardsDashboardWidget />

--- a/frontend/components/HouseholdActivityFeed.js
+++ b/frontend/components/HouseholdActivityFeed.js
@@ -1,0 +1,51 @@
+import { Activity } from 'lucide-react';
+import { t } from '../lib/i18n';
+import { parseDate } from '../lib/helpers';
+
+function formatActivityTime(value, lang = 'en') {
+  const parsed = parseDate(value);
+  if (!parsed || Number.isNaN(parsed.getTime())) return '';
+  const locale = lang === 'de' ? 'de-DE' : 'en-US';
+  return parsed.toLocaleString(locale, {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function HouseholdActivityFeed({ activity = [], messages = {}, lang = 'en' }) {
+  const entries = Array.isArray(activity) ? activity.slice(0, 5) : [];
+  const title = t(messages, 'module.dashboard.activity_title');
+  const unknownActor = t(messages, 'module.dashboard.activity_unknown_actor');
+
+  return (
+    <div className="bento-card bento-activity" role="region" aria-label={title}>
+      <div className="bento-card-header">
+        <h2 className="bento-card-title"><Activity size={16} aria-hidden="true" /> {title}</h2>
+      </div>
+      {entries.length === 0 ? (
+        <div className="bento-empty">{t(messages, 'module.dashboard.activity_empty')}</div>
+      ) : (
+        <div className="activity-feed-list">
+          {entries.map((entry) => {
+            const actor = entry.actor_display_name || unknownActor;
+            const when = formatActivityTime(entry.created_at, lang);
+            return (
+              <div key={entry.id} className="activity-feed-item">
+                <span className="activity-feed-dot" aria-hidden="true" />
+                <div className="activity-feed-copy">
+                  <div className="activity-feed-summary">{entry.summary}</div>
+                  <div className="activity-feed-meta">
+                    <span>{actor}</span>
+                    {when && <span>{when}</span>}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/contexts/AppContext.js
+++ b/frontend/contexts/AppContext.js
@@ -22,7 +22,7 @@ function AppOrchestrator({ children }) {
 
   const { loggedIn, demoMode, setMe, setLoggedIn, setDemoMode, setProfileImage, setNeedsSetup } = auth;
   const { familyId, setFamilyId, families, setFamilies, setMyFamilyRole, setMyFamilyIsAdult, loadMembers, setMembers } = family;
-  const { loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadNotifications, resetData, lastEventIdRef, setNotifications, setUnreadCount, setEvents, setTasks, setShoppingLists, setContacts, setBirthdays, setSummary } = data;
+  const { loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadNotifications, resetData, lastEventIdRef, setNotifications, setUnreadCount, setEvents, setTasks, setShoppingLists, setActivity, setContacts, setBirthdays, setSummary } = data;
   const { setLoading, setTheme, setLang, setActiveView: setActiveViewUI, restoreView, setIsMobile, setNavOrder, setTimeFormat, lang } = ui;
 
   // Wrap data loaders to inject familyId default and skip in demo mode
@@ -61,6 +61,11 @@ function AppOrchestrator({ children }) {
     return loadShoppingLists(fid);
   }, [familyId, demoMode, loadShoppingLists]);
 
+  const loadActivityWrapped = useCallback(async (fid = familyId) => {
+    if (demoMode) return;
+    return loadActivity(fid);
+  }, [familyId, demoMode, loadActivity]);
+
   const loadNotificationsWrapped = useCallback(async () => {
     if (demoMode) return;
     return loadNotifications();
@@ -84,9 +89,9 @@ function AppOrchestrator({ children }) {
       setMyFamilyRole(selected.role);
       setMyFamilyIsAdult(selected.is_adult);
     }
-    await Promise.all([loadDashboard(fid), loadEvents(fid), loadMembers(fid), loadContacts(fid), loadBirthdays(fid), loadTasks(fid), loadShoppingLists(fid)]);
+    await Promise.all([loadDashboard(fid), loadEvents(fid), loadMembers(fid), loadContacts(fid), loadBirthdays(fid), loadTasks(fid), loadShoppingLists(fid), loadActivity(fid)]);
     setLoading(false);
-  }, [families, loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, setLoading, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult]);
+  }, [families, loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, setLoading, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult]);
 
   const loadFamilyDataInBackground = useCallback((fid) => {
     void Promise.allSettled([
@@ -97,12 +102,13 @@ function AppOrchestrator({ children }) {
       loadBirthdays(fid),
       loadTasks(fid),
       loadShoppingLists(fid),
+      loadActivity(fid),
       loadNavOrderWrapped(),
       api.apiGetTimeFormat().then(({ ok, data: tfData }) => {
         if (ok && tfData?.time_format) setTimeFormat(tfData.time_format);
       }),
     ]);
-  }, [loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadNavOrderWrapped, setTimeFormat]);
+  }, [loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadNavOrderWrapped, setTimeFormat]);
 
   const enterDemo = useCallback(() => {
     const demo = buildDemoData(lang);
@@ -116,12 +122,13 @@ function AppOrchestrator({ children }) {
     setEvents(demo.events);
     setTasks(demo.tasks);
     setShoppingLists(demo.shoppingLists);
+    setActivity(demo.activity || []);
     setContacts(demo.contacts);
     setBirthdays(demo.birthdays);
     setSummary(demo.summary);
     setLoggedIn(true);
     setLoading(false);
-  }, [lang, setDemoMode, setMe, setFamilies, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult, setMembers, setEvents, setTasks, setShoppingLists, setContacts, setBirthdays, setSummary, setLoggedIn, setLoading]);
+  }, [lang, setDemoMode, setMe, setFamilies, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult, setMembers, setEvents, setTasks, setShoppingLists, setActivity, setContacts, setBirthdays, setSummary, setLoggedIn, setLoading]);
 
   const logout = useCallback(async () => {
     await auth.logout();
@@ -326,6 +333,7 @@ function AppOrchestrator({ children }) {
     loadBirthdays: loadBirthdaysWrapped,
     loadTasks: loadTasksWrapped,
     loadShoppingLists: loadShoppingListsWrapped,
+    loadActivity: loadActivityWrapped,
     loadNotifications: loadNotificationsWrapped,
     loadNavOrder: loadNavOrderWrapped,
     // Cross-domain

--- a/frontend/contexts/DataContext.js
+++ b/frontend/contexts/DataContext.js
@@ -11,6 +11,7 @@ export function DataProvider({ children }) {
   const [birthdays, setBirthdays] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [shoppingLists, setShoppingLists] = useState([]);
+  const [activity, setActivity] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const lastEventIdRef = useRef(0);
@@ -45,6 +46,11 @@ export function DataProvider({ children }) {
     if (ok) setShoppingLists(data);
   }, []);
 
+  const loadActivity = useCallback(async (fid) => {
+    const { ok, data } = await api.apiGetActivity(fid, 10, 0);
+    if (ok) setActivity(Array.isArray(data?.items) ? data.items : []);
+  }, []);
+
   const loadNotifications = useCallback(async () => {
     const { ok, data } = await api.apiGetNotifications(50, 0);
     if (ok) {
@@ -63,6 +69,7 @@ export function DataProvider({ children }) {
     setBirthdays([]);
     setTasks([]);
     setShoppingLists([]);
+    setActivity([]);
     setNotifications([]);
     setUnreadCount(0);
   }, []);
@@ -74,10 +81,11 @@ export function DataProvider({ children }) {
     birthdays, setBirthdays,
     tasks, setTasks,
     shoppingLists, setShoppingLists,
+    activity, setActivity,
     notifications, setNotifications,
     unreadCount, setUnreadCount,
     lastEventIdRef,
-    loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadNotifications,
+    loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadNotifications,
     resetData,
   };
 

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require('../helpers/fixtures');
+const { getFamilyId, seedTask } = require('../helpers/api-setup');
 const { navigateTo } = require('../helpers/navigation');
 
 test.describe('Dashboard', () => {
@@ -31,5 +32,21 @@ test.describe('Dashboard', () => {
     // Invite → Admin
     await page.getByTestId('quick-action-invite').click();
     await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('shows household activity from recent task changes', async ({ authedPage: page, apiCtx, testUser }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedTask(apiCtx, familyId, {
+      title: 'E2E Activity Task',
+      description: 'private detail should stay out of the dashboard feed',
+    });
+
+    await page.reload();
+    await page.locator('#main-content').waitFor({ timeout: 15000 });
+
+    const activityCard = page.getByRole('region', { name: 'Recent activity' });
+    await expect(activityCard).toBeVisible({ timeout: 10000 });
+    await expect(activityCard).toContainText(`${testUser.displayName} created task "E2E Activity Task"`, { timeout: 10000 });
+    await expect(activityCard).not.toContainText('private detail');
   });
 });

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -58,5 +58,8 @@
   "module.dashboard.daily_loop_open_meals": "Essen planen",
   "module.dashboard.daily_loop_open_shopping": "Einkauf öffnen",
   "module.dashboard.daily_loop_open_routines": "Routinen öffnen",
-  "module.dashboard.daily_loop_empty": "Plane ein Essen, ergänze den Einkauf oder lege eine wiederkehrende Aufgabe an, damit der Tag gut startet."
+  "module.dashboard.daily_loop_empty": "Plane ein Essen, ergänze den Einkauf oder lege eine wiederkehrende Aufgabe an, damit der Tag gut startet.",
+  "module.dashboard.activity_title": "Letzte Aktivitäten",
+  "module.dashboard.activity_empty": "Noch keine Haushaltsaktivitäten.",
+  "module.dashboard.activity_unknown_actor": "Jemand"
 }

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -58,5 +58,8 @@
   "module.dashboard.daily_loop_open_meals": "Plan meals",
   "module.dashboard.daily_loop_open_shopping": "Open shopping",
   "module.dashboard.daily_loop_open_routines": "Open routines",
-  "module.dashboard.daily_loop_empty": "Plan a meal, add groceries, or set a recurring task to get today started."
+  "module.dashboard.daily_loop_empty": "Plan a meal, add groceries, or set a recurring task to get today started.",
+  "module.dashboard.activity_title": "Recent activity",
+  "module.dashboard.activity_empty": "No household activity yet.",
+  "module.dashboard.activity_unknown_actor": "Someone"
 }

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -117,6 +117,10 @@ export function apiGetDashboard(familyId) {
   return request(`/dashboard/summary?family_id=${familyId}`);
 }
 
+export function apiGetActivity(familyId, limit = 10, offset = 0) {
+  return request(`/activity?family_id=${familyId}&limit=${limit}&offset=${offset}`);
+}
+
 // Calendar
 export async function apiGetEvents(familyId, rangeStart, rangeEnd) {
   let url = `/calendar/events?family_id=${familyId}`;

--- a/frontend/lib/demo-data.js
+++ b/frontend/lib/demo-data.js
@@ -290,5 +290,24 @@ export function buildDemoData(lang = 'en') {
     ],
   };
 
-  return { me, families, members, events, tasks, contacts, birthdays, shoppingLists, summary };
+  const activity = [
+    {
+      id: nextId(),
+      actor_display_name: 'Anna',
+      action: 'checked',
+      object_type: 'shopping_item',
+      summary: lang === 'de' ? 'Anna hat "Hafermilch" abgehakt' : 'Anna checked off "Oat milk"',
+      created_at: dateAt(0, 8, 20),
+    },
+    {
+      id: nextId(),
+      actor_display_name: 'Dennis',
+      action: 'completed',
+      object_type: 'task',
+      summary: lang === 'de' ? 'Dennis hat Aufgabe "Blumen gießen" erledigt' : 'Dennis completed task "Water plants"',
+      created_at: dateAt(-1, 18, 15),
+    },
+  ];
+
+  return { me, families, members, events, tasks, contacts, birthdays, shoppingLists, activity, summary };
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -733,6 +733,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-events { grid-column: span 6; }
 .bento-tasks { grid-column: span 6; }
 .bento-birthdays { grid-column: span 6; }
+.bento-activity { grid-column: span 6; }
 .bento-rewards { grid-column: span 6; }
 .bento-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-md); }
 .bento-card-title { font-size: 0.78rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 8px; }
@@ -749,6 +750,13 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .daily-loop-action { justify-self: end; min-height: 44px; border: none; border-radius: var(--radius-pill); padding: 7px 11px; background: var(--void-surface); color: var(--amethyst); font-family: inherit; font-size: 0.78rem; font-weight: 600; cursor: pointer; box-shadow: var(--shadow-sm); }
 .daily-loop-action:hover { background: rgba(139, 92, 246, 0.1); }
 .daily-loop-empty { margin-top: var(--space-sm); padding: 10px 12px; border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); color: var(--text-muted); font-size: 0.85rem; }
+.activity-feed-list { display: flex; flex-direction: column; gap: var(--space-sm); }
+.activity-feed-item { display: grid; grid-template-columns: auto 1fr; gap: var(--space-sm); align-items: flex-start; padding: 10px 0; border-bottom: 1px solid rgba(120, 130, 180, 0.08); }
+.activity-feed-item:last-child { border-bottom: 0; }
+.activity-feed-dot { width: 10px; height: 10px; margin-top: 6px; border-radius: var(--radius-pill); background: linear-gradient(135deg, var(--amethyst), var(--sapphire)); box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.08); }
+.activity-feed-copy { min-width: 0; }
+.activity-feed-summary { color: var(--text-primary); font-size: 0.9rem; line-height: 1.35; overflow-wrap: anywhere; }
+.activity-feed-meta { display: flex; flex-wrap: wrap; gap: 6px 10px; margin-top: 4px; color: var(--text-muted); font-size: 0.75rem; }
 .bento-empty { color: var(--text-muted); font-size: 0.85rem; padding: var(--space-md) 0; display: flex; align-items: center; gap: var(--space-sm); }
 .bento-empty-action { background: none; border: none; color: var(--amethyst); cursor: pointer; font-family: inherit; font-size: 0.85rem; font-weight: 500; padding: 8px 12px; min-height: 44px; display: inline-flex; align-items: center; border-radius: var(--radius-sm); transition: opacity 0.2s; }
 .bento-empty-action:hover { opacity: 0.7; }
@@ -1661,7 +1669,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    ═══════════════════════════════════════════ */
 @media (max-width: 1100px) {
   .bento-daily-loop { grid-column: span 12; }
-  .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards { grid-column: span 6; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards { grid-column: span 6; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .calendar-layout { grid-template-columns: 1fr; }
 }
@@ -1673,7 +1681,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .mobile-header { display: flex; }
   .bottom-nav { display: block; }
   .bento-grid { grid-template-columns: 1fr; row-gap: var(--space-md); }
-  .bento-events, .bento-tasks, .bento-birthdays, .bento-rewards, .bento-daily-loop { grid-column: span 1; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards, .bento-daily-loop { grid-column: span 1; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .daily-loop-item { grid-template-columns: auto 1fr; }
   .daily-loop-action { grid-column: 1 / -1; justify-self: stretch; text-align: center; }


### PR DESCRIPTION
## Summary
- Add a household activity feed backed by task and shopping events
- Add the activity API with family membership checks and `activity:read` scoped access
- Show recent household activity on the dashboard with localized empty states and demo data

## Test Plan
- Backend: `tests/test_household_activity.py tests/test_pat_scope_enforcement.py tests/test_shopping_templates.py`
- Frontend: `HouseholdActivityFeed.test.js`, `DashboardDailyLoop.test.js`, `AppContext.test.js`, `api.test.js`
- Build: `npm run build`
- E2E: `npx playwright test e2e/tests/dashboard.spec.js` across Desktop Chrome and Mobile Chrome

Closes #243
