### PR TITLE
Add universal quick capture inbox

### DIFF
--- a/backend/alembic/versions/0041_add_quick_capture_items.py
+++ b/backend/alembic/versions/0041_add_quick_capture_items.py
@@ -1,0 +1,47 @@
+"""Add quick capture inbox.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-04-29
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0041"
+down_revision: Union[str, None] = "0040"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "quick_capture_items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("family_id", sa.Integer(), nullable=False),
+        sa.Column("text", sa.String(length=240), nullable=False),
+        sa.Column("status", sa.String(length=20), server_default="open", nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("converted_to", sa.String(length=40), nullable=True),
+        sa.Column("converted_object_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_quick_capture_items_id"), "quick_capture_items", ["id"], unique=False)
+    op.create_index(op.f("ix_quick_capture_items_family_id"), "quick_capture_items", ["family_id"], unique=False)
+    op.create_index("ix_quick_capture_family_status_created", "quick_capture_items", ["family_id", "status", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_quick_capture_family_status_created", table_name="quick_capture_items")
+    op.drop_index(op.f("ix_quick_capture_items_family_id"), table_name="quick_capture_items")
+    op.drop_index(op.f("ix_quick_capture_items_id"), table_name="quick_capture_items")
+    op.drop_table("quick_capture_items")

--- a/backend/app/core/scopes.py
+++ b/backend/app/core/scopes.py
@@ -14,6 +14,8 @@ SCOPE_DESCRIPTIONS: dict[str, str] = {
     "families:read": "View family members, invitations, and audit log",
     "families:write": "Manage members, invitations, roles, and passwords",
     "activity:read": "View public-safe household activity feed",
+    "quick_capture:read": "View quick capture inbox items",
+    "quick_capture:write": "Create and triage quick captures",
     "shopping:read": "View shopping lists and items",
     "shopping:write": "Create, update, and delete shopping lists and items",
     "profile:read": "View own profile and list personal access tokens",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from app.modules.birthdays_router import router as birthdays_router
 from app.modules.calendar_router import router as calendar_router
 from app.modules.dashboard_router import router as dashboard_router
 from app.modules.activity_router import router as activity_router
+from app.modules.quick_capture_router import router as quick_capture_router
 from app.modules.families_router import router as families_router
 from app.modules.contacts_router import router as contacts_router
 from app.modules.tasks_router import router as tasks_router
@@ -591,6 +592,7 @@ app.include_router(calendar_router)
 app.include_router(birthdays_router)
 app.include_router(dashboard_router)
 app.include_router(activity_router)
+app.include_router(quick_capture_router)
 app.include_router(contacts_router)
 app.include_router(tasks_router)
 app.include_router(shopping_router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -45,6 +45,7 @@ class Family(Base):
     reward_currency = relationship("RewardCurrency", back_populates="family", uselist=False, cascade="all, delete-orphan")
     display_devices = relationship("DisplayDevice", back_populates="family", cascade="all, delete-orphan")
     household_activities = relationship("HouseholdActivity", back_populates="family", cascade="all, delete-orphan")
+    quick_capture_items = relationship("QuickCaptureItem", back_populates="family", cascade="all, delete-orphan")
 
 
 class Membership(Base):
@@ -512,6 +513,26 @@ class HouseholdActivity(Base):
 
     family = relationship("Family", back_populates="household_activities")
     actor = relationship("User")
+
+
+class QuickCaptureItem(Base):
+    __tablename__ = "quick_capture_items"
+    __table_args__ = (
+        Index("ix_quick_capture_family_status_created", "family_id", "status", "created_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    text = Column(String(240), nullable=False)
+    status = Column(String(20), nullable=False, default="open", server_default="open")
+    created_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    converted_to = Column(String(40), nullable=True)
+    converted_object_id = Column(Integer, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+
+    family = relationship("Family", back_populates="quick_capture_items")
+    created_by = relationship("User")
 
 
 class FamilyInvitation(Base):

--- a/backend/app/modules/quick_capture_router.py
+++ b/backend/app/modules/quick_capture_router.py
@@ -1,0 +1,251 @@
+"""Universal quick capture API."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.activity import record_activity
+from app.core.deps import current_user, ensure_adult
+from app.core.errors import error_detail
+from app.core.scopes import require_scope
+from app.database import get_db
+from app.models import QuickCaptureItem, ShoppingItem, ShoppingList, Task, User
+from app.schemas import (
+    NOT_FOUND_RESPONSE,
+    PaginatedQuickCaptureInbox,
+    QuickCaptureConvertRequest,
+    QuickCaptureConvertResponse,
+    QuickCaptureCreate,
+    QuickCaptureDestination,
+    QuickCaptureResponse,
+    ShoppingItemResponse,
+    TaskResponse,
+)
+
+router = APIRouter(prefix="/quick-capture", tags=["quick-capture"])
+
+QUICK_CAPTURE_NOT_FOUND = "QUICK_CAPTURE_NOT_FOUND"
+QUICK_CAPTURE_ALREADY_TRIAGED = "QUICK_CAPTURE_ALREADY_TRIAGED"
+QUICK_CAPTURE_SHOPPING_LIST_NAME = "Quick capture"
+
+
+def _capture_text(raw: str) -> str:
+    text = " ".join(raw.split())
+    if not text:
+        raise HTTPException(status_code=400, detail=error_detail("INVALID_QUICK_CAPTURE_TEXT"))
+    return text[:240]
+
+
+def _task_response(task: Task) -> TaskResponse:
+    return TaskResponse.model_validate(task)
+
+
+def _shopping_item_response(item: ShoppingItem) -> ShoppingItemResponse:
+    return ShoppingItemResponse.model_validate(item)
+
+
+def _get_or_create_quick_list(db: Session, family_id: int, user_id: int) -> ShoppingList:
+    shopping_list = (
+        db.query(ShoppingList)
+        .filter(ShoppingList.family_id == family_id, ShoppingList.name == QUICK_CAPTURE_SHOPPING_LIST_NAME)
+        .order_by(ShoppingList.created_at.asc())
+        .first()
+    )
+    if shopping_list:
+        return shopping_list
+    shopping_list = ShoppingList(
+        family_id=family_id,
+        name=QUICK_CAPTURE_SHOPPING_LIST_NAME,
+        created_by_user_id=user_id,
+    )
+    db.add(shopping_list)
+    db.flush()
+    return shopping_list
+
+
+def _create_task(db: Session, *, family_id: int, user: User, text: str) -> Task:
+    task = Task(
+        family_id=family_id,
+        title=text,
+        priority="normal",
+        created_by_user_id=user.id,
+    )
+    db.add(task)
+    db.flush()
+    record_activity(
+        db,
+        family_id=family_id,
+        actor_user_id=user.id,
+        actor_display_name=user.display_name,
+        action="created",
+        object_type="task",
+        object_id=task.id,
+        object_label=task.title,
+        verb="created",
+        object_kind="task",
+    )
+    return task
+
+
+def _create_shopping_item(db: Session, *, family_id: int, user: User, text: str) -> ShoppingItem:
+    shopping_list = _get_or_create_quick_list(db, family_id, user.id)
+    item = ShoppingItem(
+        list_id=shopping_list.id,
+        name=text,
+        added_by_user_id=user.id,
+    )
+    db.add(item)
+    db.flush()
+    record_activity(
+        db,
+        family_id=family_id,
+        actor_user_id=user.id,
+        actor_display_name=user.display_name,
+        action="added",
+        object_type="shopping_item",
+        object_id=item.id,
+        object_label=item.name,
+        verb="added",
+        object_kind="to shopping",
+    )
+    return item
+
+
+def _created_payload(destination: QuickCaptureDestination, created_item: Task | ShoppingItem) -> QuickCaptureResponse:
+    if destination == QuickCaptureDestination.task:
+        return QuickCaptureResponse(destination=destination, created_item=_task_response(created_item))
+    return QuickCaptureResponse(destination=destination, created_item=_shopping_item_response(created_item))
+
+
+@router.post(
+    "",
+    response_model=QuickCaptureResponse,
+    summary="Capture a quick note",
+    description="Capture text into the inbox or route it directly to a task or shopping item. Adult only. Scope: `quick_capture:write`.",
+)
+def create_quick_capture(
+    payload: QuickCaptureCreate,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("quick_capture:write"),
+):
+    ensure_adult(db, user.id, payload.family_id)
+    text = _capture_text(payload.text)
+
+    if payload.destination == QuickCaptureDestination.task:
+        task = _create_task(db, family_id=payload.family_id, user=user, text=text)
+        db.commit()
+        db.refresh(task)
+        return _created_payload(payload.destination, task)
+
+    if payload.destination == QuickCaptureDestination.shopping:
+        item = _create_shopping_item(db, family_id=payload.family_id, user=user, text=text)
+        db.commit()
+        db.refresh(item)
+        return _created_payload(payload.destination, item)
+
+    item = QuickCaptureItem(
+        family_id=payload.family_id,
+        text=text,
+        created_by_user_id=user.id,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return QuickCaptureResponse(destination=QuickCaptureDestination.inbox, inbox_item=item)
+
+
+@router.get(
+    "/inbox",
+    response_model=PaginatedQuickCaptureInbox,
+    summary="List quick capture inbox items",
+    description="Return open quick capture inbox items for a family. Scope: `quick_capture:read`.",
+)
+def list_quick_capture_inbox(
+    family_id: int,
+    limit: int = Query(10, ge=1, le=50),
+    offset: int = Query(0, ge=0),
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("quick_capture:read"),
+):
+    ensure_adult(db, user.id, family_id)
+    query = db.query(QuickCaptureItem).filter(
+        QuickCaptureItem.family_id == family_id,
+        QuickCaptureItem.status == "open",
+    )
+    total = query.count()
+    items = query.order_by(QuickCaptureItem.created_at.desc(), QuickCaptureItem.id.desc()).offset(offset).limit(limit).all()
+    return PaginatedQuickCaptureInbox(items=items, total=total, offset=offset, limit=limit)
+
+
+def _get_inbox_item(db: Session, item_id: int) -> QuickCaptureItem:
+    item = db.query(QuickCaptureItem).filter(QuickCaptureItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=404, detail=error_detail(QUICK_CAPTURE_NOT_FOUND))
+    return item
+
+
+def _ensure_open(item: QuickCaptureItem) -> None:
+    if item.status != "open":
+        raise HTTPException(status_code=409, detail=error_detail(QUICK_CAPTURE_ALREADY_TRIAGED))
+
+
+@router.post(
+    "/inbox/{item_id}/convert",
+    response_model=QuickCaptureConvertResponse,
+    summary="Convert an inbox item",
+    description="Convert a quick capture inbox item to a task or shopping item. Adult only. Scope: `quick_capture:write`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def convert_quick_capture_item(
+    item_id: int,
+    payload: QuickCaptureConvertRequest,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("quick_capture:write"),
+):
+    item = _get_inbox_item(db, item_id)
+    ensure_adult(db, user.id, item.family_id)
+    _ensure_open(item)
+    if payload.destination == QuickCaptureDestination.inbox:
+        raise HTTPException(status_code=400, detail=error_detail("INVALID_QUICK_CAPTURE_DESTINATION"))
+
+    if payload.destination == QuickCaptureDestination.task:
+        created = _create_task(db, family_id=item.family_id, user=user, text=item.text)
+    else:
+        created = _create_shopping_item(db, family_id=item.family_id, user=user, text=item.text)
+
+    item.status = "converted"
+    item.converted_to = payload.destination.value
+    item.converted_object_id = created.id
+    db.commit()
+    db.refresh(item)
+    db.refresh(created)
+    return QuickCaptureConvertResponse(
+        status=item.status,
+        converted_to=payload.destination,
+        inbox_item=item,
+        converted_item=_task_response(created) if payload.destination == QuickCaptureDestination.task else _shopping_item_response(created),
+    )
+
+
+@router.post(
+    "/inbox/{item_id}/dismiss",
+    response_model=QuickCaptureConvertResponse,
+    summary="Dismiss an inbox item",
+    description="Dismiss an open quick capture inbox item. Adult only. Scope: `quick_capture:write`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def dismiss_quick_capture_item(
+    item_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("quick_capture:write"),
+):
+    item = _get_inbox_item(db, item_id)
+    ensure_adult(db, user.id, item.family_id)
+    _ensure_open(item)
+    item.status = "dismissed"
+    db.commit()
+    db.refresh(item)
+    return QuickCaptureConvertResponse(status=item.status, converted_to=None, inbox_item=item, converted_item=None)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -820,6 +820,64 @@ class PaginatedHouseholdActivity(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Quick capture
+# ---------------------------------------------------------------------------
+
+class QuickCaptureDestination(str, Enum):
+    """Supported destinations for a captured note."""
+    inbox = "inbox"
+    task = "task"
+    shopping = "shopping"
+
+
+class QuickCaptureCreate(BaseModel):
+    """Create a quick capture item or route it directly."""
+    family_id: int = Field(..., description="Family ID")
+    text: str = Field(min_length=1, max_length=240, description="Captured text")
+    destination: QuickCaptureDestination = Field(QuickCaptureDestination.inbox, description="Where to send the capture")
+
+
+class QuickCaptureInboxItem(BaseModel):
+    """Inbox item awaiting triage."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Inbox item ID")
+    text: str = Field(..., description="Captured text")
+    status: str = Field(..., description="Status: open, converted, or dismissed")
+    converted_to: Optional[str] = Field(None, description="Destination after conversion")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+
+class QuickCaptureResponse(BaseModel):
+    """Result of a quick capture action."""
+    destination: QuickCaptureDestination = Field(..., description="Resolved destination")
+    inbox_item: Optional[QuickCaptureInboxItem] = Field(None, description="Created inbox item")
+    created_item: Optional[Union[TaskResponse, ShoppingItemResponse]] = Field(None, description="Created task or shopping item")
+
+
+class PaginatedQuickCaptureInbox(BaseModel):
+    """Paginated quick capture inbox."""
+    items: list[QuickCaptureInboxItem] = Field(..., description="Inbox items")
+    total: int = Field(..., description="Total matching entries")
+    offset: int = Field(..., description="Pagination offset")
+    limit: int = Field(..., description="Pagination limit")
+
+
+class QuickCaptureConvertRequest(BaseModel):
+    """Convert an inbox item to a destination."""
+    destination: QuickCaptureDestination = Field(..., description="Conversion destination")
+
+
+class QuickCaptureConvertResponse(BaseModel):
+    """Converted or dismissed inbox item response."""
+    status: str = Field(..., description="New inbox item status")
+    converted_to: Optional[QuickCaptureDestination] = Field(None, description="Destination after conversion")
+    inbox_item: QuickCaptureInboxItem = Field(..., description="Updated inbox item")
+    converted_item: Optional[Union[TaskResponse, ShoppingItemResponse]] = Field(None, description="Created task or shopping item")
+
+
+# ---------------------------------------------------------------------------
 # Personal Access Tokens (PAT)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_quick_capture.py
+++ b/backend/tests/test_quick_capture.py
@@ -1,0 +1,203 @@
+"""Universal quick capture and inbox tests."""
+
+import hashlib
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import Family, Membership, PersonalAccessToken, ShoppingItem, Task, User
+from app.security import PAT_PREFIX, hash_password
+
+
+engine = create_engine(
+    "sqlite:///./test-quick-capture.db",
+    connect_args={"check_same_thread": False},
+)
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_member(scopes: str, suffix: str, *, is_adult: bool = True, family_id: int | None = None) -> tuple[str, int, int]:
+    db = TestSession()
+    user = User(
+        email=f"capture-{suffix}@example.com",
+        password_hash=hash_password("Password123"),
+        display_name="Capture User",
+    )
+    db.add(user)
+    db.flush()
+    if family_id is None:
+        family = Family(name=f"Capture Family {suffix}")
+        db.add(family)
+        db.flush()
+        family_id = family.id
+    db.add(Membership(user_id=user.id, family_id=family_id, role="admin" if is_adult else "member", is_adult=is_adult))
+    plain = f"{PAT_PREFIX}capture-{suffix}-{scopes.replace(',', '-').replace(':', '_').replace('*', 'star')}"
+    lookup = hashlib.sha256(plain.encode()).hexdigest()
+    db.add(PersonalAccessToken(
+        user_id=user.id,
+        name="quick-capture-pat",
+        token_hash=lookup,
+        token_lookup=lookup,
+        scopes=scopes,
+    ))
+    db.commit()
+    user_id = user.id
+    db.close()
+    return plain, family_id, user_id
+
+
+def test_quick_capture_routes_to_task_shopping_and_inbox_public_safely():
+    token, family_id, _ = _seed_member("*", "routes")
+
+    task_resp = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "  Pack sports bag  ", "destination": "task"},
+        headers=_auth(token),
+    )
+    assert task_resp.status_code == 200, task_resp.json()
+    assert task_resp.json()["destination"] == "task"
+    assert task_resp.json()["created_item"]["title"] == "Pack sports bag"
+
+    shopping_resp = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "Milk", "destination": "shopping"},
+        headers=_auth(token),
+    )
+    assert shopping_resp.status_code == 200, shopping_resp.json()
+    assert shopping_resp.json()["destination"] == "shopping"
+    assert shopping_resp.json()["created_item"]["name"] == "Milk"
+
+    inbox_resp = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "Call pediatrician tomorrow private token", "destination": "inbox"},
+        headers=_auth(token),
+    )
+    assert inbox_resp.status_code == 200, inbox_resp.json()
+    item = inbox_resp.json()["inbox_item"]
+    assert item["text"] == "Call pediatrician tomorrow private token"
+    assert item["status"] == "open"
+    assert "family_id" not in item
+    assert "created_by_user_id" not in item
+    assert "converted_object_id" not in item
+
+    db = TestSession()
+    assert db.query(Task).filter(Task.family_id == family_id, Task.title == "Pack sports bag").count() == 1
+    assert db.query(ShoppingItem).filter(ShoppingItem.name == "Milk").count() == 1
+    db.close()
+
+    inbox = client.get(f"/quick-capture/inbox?family_id={family_id}", headers=_auth(token))
+    assert inbox.status_code == 200, inbox.json()
+    assert inbox.json()["total"] == 1
+    assert inbox.json()["items"][0]["text"] == "Call pediatrician tomorrow private token"
+    assert "password" not in str(inbox.json()).lower()
+
+    long_text = "Call school about the class trip, bring the signed form, ask about lunch, and confirm pickup details before Friday afternoon"
+    long_resp = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": long_text, "destination": "inbox"},
+        headers=_auth(token),
+    )
+    assert long_resp.status_code == 200, long_resp.json()
+    assert long_resp.json()["inbox_item"]["text"] == long_text
+
+
+def test_quick_capture_inbox_convert_and_dismiss_enforces_family_scope():
+    token, family_id, _ = _seed_member("*", "owner")
+    intruder_token, _, _ = _seed_member("*", "intruder")
+
+    inbox_resp = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "Book dentist appointment", "destination": "inbox"},
+        headers=_auth(token),
+    )
+    item_id = inbox_resp.json()["inbox_item"]["id"]
+
+    denied = client.post(
+        f"/quick-capture/inbox/{item_id}/convert",
+        json={"destination": "task"},
+        headers=_auth(intruder_token),
+    )
+    assert denied.status_code == 403
+
+    converted = client.post(
+        f"/quick-capture/inbox/{item_id}/convert",
+        json={"destination": "task"},
+        headers=_auth(token),
+    )
+    assert converted.status_code == 200, converted.json()
+    assert converted.json()["status"] == "converted"
+    assert converted.json()["converted_to"] == "task"
+    assert converted.json()["converted_item"]["title"] == "Book dentist appointment"
+
+    inbox = client.get(f"/quick-capture/inbox?family_id={family_id}", headers=_auth(token))
+    assert inbox.json()["total"] == 0
+
+    second = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "Bring cake Friday", "destination": "inbox"},
+        headers=_auth(token),
+    ).json()["inbox_item"]
+    dismissed = client.post(f"/quick-capture/inbox/{second['id']}/dismiss", headers=_auth(token))
+    assert dismissed.status_code == 200, dismissed.json()
+    assert dismissed.json()["status"] == "dismissed"
+
+
+def test_quick_capture_scope_and_adult_rules():
+    child_token, family_id, _ = _seed_member("*", "child", is_adult=False)
+    bad_scope_token, bad_family_id, _ = _seed_member("tasks:read", "bad-scope")
+
+    child_resp = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "Clean room", "destination": "task"},
+        headers=_auth(child_token),
+    )
+    assert child_resp.status_code == 403
+
+    bad_scope = client.get(f"/quick-capture/inbox?family_id={bad_family_id}", headers=_auth(bad_scope_token))
+    assert bad_scope.status_code == 403
+
+    child_read = client.get(f"/quick-capture/inbox?family_id={family_id}", headers=_auth(child_token))
+    assert child_read.status_code == 403
+
+    invalid = client.post(
+        "/quick-capture",
+        json={"family_id": bad_family_id, "text": "x", "destination": "voice"},
+        headers=_auth(bad_scope_token),
+    )
+    assert invalid.status_code == 403

--- a/frontend/__tests__/components/QuickCaptureCard.test.js
+++ b/frontend/__tests__/components/QuickCaptureCard.test.js
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuickCaptureCard from '../../components/QuickCaptureCard';
+import { apiCreateQuickCapture, apiConvertQuickCapture, apiDismissQuickCapture } from '../../lib/api';
+
+jest.mock('../../lib/api', () => ({
+  apiCreateQuickCapture: jest.fn(),
+  apiConvertQuickCapture: jest.fn(),
+  apiDismissQuickCapture: jest.fn(),
+}));
+
+const messages = {
+  'module.dashboard.quick_capture_title': 'Quick capture',
+  'module.dashboard.quick_capture_placeholder': 'Capture anything for later',
+  'module.dashboard.quick_capture_save_inbox': 'Save to inbox',
+  'module.dashboard.quick_capture_add_task': 'Add task',
+  'module.dashboard.quick_capture_add_shopping': 'Add shopping',
+  'module.dashboard.quick_capture_inbox_title': 'Inbox',
+  'module.dashboard.quick_capture_inbox_empty': 'Nothing waiting for triage.',
+  'module.dashboard.quick_capture_to_task': 'Task',
+  'module.dashboard.quick_capture_to_shopping': 'Shopping',
+  'module.dashboard.quick_capture_dismiss': 'Dismiss',
+};
+
+function renderCard(overrides = {}) {
+  const loadQuickCaptureInbox = jest.fn();
+  const loadTasks = jest.fn();
+  const loadShoppingLists = jest.fn();
+  const loadActivity = jest.fn();
+  render(
+    <QuickCaptureCard
+      familyId="7"
+      inbox={overrides.inbox || []}
+      messages={messages}
+      loadQuickCaptureInbox={loadQuickCaptureInbox}
+      loadTasks={loadTasks}
+      loadShoppingLists={loadShoppingLists}
+      loadActivity={loadActivity}
+    />
+  );
+  return { loadQuickCaptureInbox, loadTasks, loadShoppingLists, loadActivity };
+}
+
+describe('QuickCaptureCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('captures text to the inbox and refreshes the inbox', async () => {
+    apiCreateQuickCapture.mockResolvedValue({ ok: true, data: { destination: 'inbox' } });
+    const { loadQuickCaptureInbox } = renderCard();
+
+    fireEvent.change(screen.getByPlaceholderText('Capture anything for later'), { target: { value: 'Bring sports shoes' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save to inbox' }));
+
+    await waitFor(() => expect(apiCreateQuickCapture).toHaveBeenCalledWith({
+      family_id: '7',
+      text: 'Bring sports shoes',
+      destination: 'inbox',
+    }));
+    expect(loadQuickCaptureInbox).toHaveBeenCalledWith('7');
+    expect(screen.getByPlaceholderText('Capture anything for later')).toHaveValue('');
+  });
+
+  it('routes quick text directly to tasks and shopping', async () => {
+    apiCreateQuickCapture.mockResolvedValue({ ok: true, data: {} });
+    const { loadTasks, loadShoppingLists, loadActivity } = renderCard();
+
+    fireEvent.change(screen.getByPlaceholderText('Capture anything for later'), { target: { value: 'Pay school lunch' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add task' }));
+    await waitFor(() => expect(apiCreateQuickCapture).toHaveBeenCalledWith({ family_id: '7', text: 'Pay school lunch', destination: 'task' }));
+    expect(loadTasks).toHaveBeenCalledWith('7');
+    expect(loadActivity).toHaveBeenCalledWith('7');
+
+    fireEvent.change(screen.getByPlaceholderText('Capture anything for later'), { target: { value: 'Milk' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add shopping' }));
+    await waitFor(() => expect(apiCreateQuickCapture).toHaveBeenLastCalledWith({ family_id: '7', text: 'Milk', destination: 'shopping' }));
+    expect(loadShoppingLists).toHaveBeenCalledWith('7');
+  });
+
+  it('triages inbox items', async () => {
+    apiConvertQuickCapture.mockResolvedValue({ ok: true, data: {} });
+    apiDismissQuickCapture.mockResolvedValue({ ok: true, data: {} });
+    const { loadQuickCaptureInbox, loadTasks } = renderCard({ inbox: [{ id: 3, text: 'Book dentist' }] });
+
+    expect(screen.getByText('Book dentist')).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Task' }));
+    await waitFor(() => expect(apiConvertQuickCapture).toHaveBeenCalledWith(3, { destination: 'task' }));
+    expect(loadTasks).toHaveBeenCalledWith('7');
+    expect(loadQuickCaptureInbox).toHaveBeenCalledWith('7');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    await waitFor(() => expect(apiDismissQuickCapture).toHaveBeenCalledWith(3));
+  });
+});

--- a/frontend/__tests__/contexts/AppContext.test.js
+++ b/frontend/__tests__/contexts/AppContext.test.js
@@ -45,6 +45,7 @@ describe('AppProvider bootstrap', () => {
     api.apiGetBirthdays.mockResolvedValue({ ok: true, data: [] });
     api.apiGetShoppingLists.mockResolvedValue({ ok: true, data: [] });
     api.apiGetActivity.mockResolvedValue({ ok: true, data: { items: [] } });
+    api.apiGetQuickCaptureInbox.mockResolvedValue({ ok: true, data: { items: [] } });
     api.apiGetNavOrder.mockResolvedValue({ ok: true, data: { nav_order: ['dashboard'] } });
     api.apiGetTimeFormat.mockResolvedValue({ ok: true, data: { time_format: '24h' } });
     api.apiGetUnreadCount.mockResolvedValue({ ok: true, data: { count: 0 } });
@@ -66,5 +67,6 @@ describe('AppProvider bootstrap', () => {
     await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('ready'));
     expect(api.apiGetTasks).toHaveBeenCalledWith('7');
     expect(api.apiGetActivity).toHaveBeenCalledWith('7', 10, 0);
+    expect(api.apiGetQuickCaptureInbox).toHaveBeenCalledWith('7', 10, 0);
   });
 });

--- a/frontend/__tests__/lib/api.test.js
+++ b/frontend/__tests__/lib/api.test.js
@@ -5,6 +5,7 @@ import {
   apiGetContacts, apiImportContactsCsv,
   apiExportCalendarIcs, apiImportCalendarIcs, apiExportContactsCsv,
   apiGetActivity,
+  apiCreateQuickCapture, apiGetQuickCaptureInbox, apiConvertQuickCapture, apiDismissQuickCapture,
   apiGetTasks, apiCreateTask, apiUpdateTask, apiDeleteTask,
   apiListRecipes, apiCreateRecipe, apiUpdateRecipe, apiDeleteRecipe, apiAddRecipeIngredientsToShopping,
 } from '../../lib/api';
@@ -92,6 +93,23 @@ describe('Dashboard API', () => {
   it('apiGetActivity includes family_id and pagination', async () => {
     await apiGetActivity('7', 5, 10);
     expect(lastCall()[0]).toBe('/api/activity?family_id=7&limit=5&offset=10');
+  });
+
+  it('quick capture API supports create, list, convert, and dismiss', async () => {
+    await apiCreateQuickCapture({ family_id: 7, text: 'Buy milk' });
+    expect(lastCall()[0]).toBe('/api/quick-capture');
+    expect(lastCall()[1].method).toBe('POST');
+
+    await apiGetQuickCaptureInbox('7', 6, 2);
+    expect(lastCall()[0]).toBe('/api/quick-capture/inbox?family_id=7&limit=6&offset=2');
+
+    await apiConvertQuickCapture(11, { target_type: 'task' });
+    expect(lastCall()[0]).toBe('/api/quick-capture/inbox/11/convert');
+    expect(lastCall()[1].method).toBe('POST');
+
+    await apiDismissQuickCapture(11);
+    expect(lastCall()[0]).toBe('/api/quick-capture/inbox/11/dismiss');
+    expect(lastCall()[1].method).toBe('POST');
   });
 });
 

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -9,6 +9,7 @@ import AssignedBadges from './AssignedBadges';
 import MemberAvatar from './MemberAvatar';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
 import HouseholdActivityFeed from './HouseholdActivityFeed';
+import QuickCaptureCard from './QuickCaptureCard';
 
 function todayIsoDate() {
   const now = new Date();
@@ -151,7 +152,7 @@ function ActivationPanel({ steps, messages }) {
 }
 
 export default function DashboardView() {
-  const { summary, me, members, tasks, events, shoppingLists, activity, familyId, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode } = useApp();
+  const { summary, me, members, tasks, events, shoppingLists, activity, quickCaptureInbox, familyId, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode, loadQuickCaptureInbox, loadTasks, loadShoppingLists, loadActivity } = useApp();
   const todayIso = useMemo(() => todayIsoDate(), []);
   const [mealsTodayCount, setMealsTodayCount] = useState(0);
 
@@ -338,6 +339,18 @@ export default function DashboardView() {
       {showActivationPanel && <ActivationPanel steps={activationSteps} messages={messages} />}
 
       <div className="bento-grid">
+        {!isChild && (
+          <QuickCaptureCard
+            familyId={familyId}
+            inbox={quickCaptureInbox}
+            messages={messages}
+            loadQuickCaptureInbox={loadQuickCaptureInbox}
+            loadTasks={loadTasks}
+            loadShoppingLists={loadShoppingLists}
+            loadActivity={loadActivity}
+          />
+        )}
+
         <DailyLoopCard
           mealsTodayCount={mealsTodayCount}
           shoppingOpenCount={shoppingOpenCount}

--- a/frontend/components/QuickCaptureCard.js
+++ b/frontend/components/QuickCaptureCard.js
@@ -1,0 +1,125 @@
+import { Inbox, ListChecks, Send, ShoppingCart, X } from 'lucide-react';
+import { useState } from 'react';
+import { apiCreateQuickCapture, apiConvertQuickCapture, apiDismissQuickCapture } from '../lib/api';
+import { t } from '../lib/i18n';
+
+export default function QuickCaptureCard({
+  familyId,
+  inbox = [],
+  messages,
+  loadQuickCaptureInbox,
+  loadTasks,
+  loadShoppingLists,
+  loadActivity,
+}) {
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [triagingId, setTriagingId] = useState(null);
+
+  const canSubmit = text.trim().length > 0 && !busy && familyId;
+
+  async function refresh(destination) {
+    await Promise.allSettled([
+      loadQuickCaptureInbox?.(familyId),
+      destination === 'task' ? loadTasks?.(familyId) : Promise.resolve(),
+      destination === 'shopping' ? loadShoppingLists?.(familyId) : Promise.resolve(),
+      destination !== 'inbox' ? loadActivity?.(familyId) : Promise.resolve(),
+    ]);
+  }
+
+  async function capture(destination) {
+    if (!canSubmit) return;
+    const captured = text.trim();
+    setBusy(true);
+    try {
+      const result = await apiCreateQuickCapture({ family_id: familyId, text: captured, destination });
+      if (result.ok) {
+        setText('');
+        await refresh(destination);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function convertItem(itemId, destination) {
+    setTriagingId(itemId);
+    try {
+      const result = await apiConvertQuickCapture(itemId, { destination });
+      if (result.ok) await refresh(destination);
+    } finally {
+      setTriagingId(null);
+    }
+  }
+
+  async function dismissItem(itemId) {
+    setTriagingId(itemId);
+    try {
+      const result = await apiDismissQuickCapture(itemId);
+      if (result.ok) await refresh('inbox');
+    } finally {
+      setTriagingId(null);
+    }
+  }
+
+  const inboxItems = Array.isArray(inbox) ? inbox : [];
+  const openItems = inboxItems.slice(0, 3);
+
+  return (
+    <section className="bento-card bento-quick-capture" role="region" aria-label={t(messages, 'module.dashboard.quick_capture_title')}>
+      <div className="bento-card-header quick-capture-header">
+        <div>
+          <h2 className="bento-card-title"><Send size={16} aria-hidden="true" /> {t(messages, 'module.dashboard.quick_capture_title')}</h2>
+          <p className="quick-capture-subtitle">{t(messages, 'module.dashboard.quick_capture_subtitle')}</p>
+        </div>
+        <span className="quick-capture-count" aria-label={t(messages, 'module.dashboard.quick_capture_inbox_count').replace('{count}', inboxItems.length)}>
+          <Inbox size={14} aria-hidden="true" /> {inboxItems.length}
+        </span>
+      </div>
+
+      <div className="quick-capture-form">
+        <textarea
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          placeholder={t(messages, 'module.dashboard.quick_capture_placeholder')}
+          rows={3}
+          maxLength={240}
+          className="quick-capture-input"
+        />
+        <div className="quick-capture-actions">
+          <button type="button" className="btn-sm quick-capture-primary" onClick={() => capture('inbox')} disabled={!canSubmit}>
+            <Inbox size={14} aria-hidden="true" /> {t(messages, 'module.dashboard.quick_capture_save_inbox')}
+          </button>
+          <button type="button" className="btn-sm" onClick={() => capture('task')} disabled={!canSubmit}>
+            <ListChecks size={14} aria-hidden="true" /> {t(messages, 'module.dashboard.quick_capture_add_task')}
+          </button>
+          <button type="button" className="btn-sm" onClick={() => capture('shopping')} disabled={!canSubmit}>
+            <ShoppingCart size={14} aria-hidden="true" /> {t(messages, 'module.dashboard.quick_capture_add_shopping')}
+          </button>
+        </div>
+      </div>
+
+      <div className="quick-capture-inbox">
+        <div className="quick-capture-inbox-title">{t(messages, 'module.dashboard.quick_capture_inbox_title')}</div>
+        {openItems.length === 0 ? (
+          <div className="bento-empty quick-capture-empty">{t(messages, 'module.dashboard.quick_capture_inbox_empty')}</div>
+        ) : openItems.map((item) => (
+          <div key={item.id} className="quick-capture-item">
+            <div className="quick-capture-item-text">{item.text}</div>
+            <div className="quick-capture-item-actions">
+              <button type="button" className="quick-capture-mini" onClick={() => convertItem(item.id, 'task')} disabled={triagingId === item.id}>
+                {t(messages, 'module.dashboard.quick_capture_to_task')}
+              </button>
+              <button type="button" className="quick-capture-mini" onClick={() => convertItem(item.id, 'shopping')} disabled={triagingId === item.id}>
+                {t(messages, 'module.dashboard.quick_capture_to_shopping')}
+              </button>
+              <button type="button" className="quick-capture-mini quick-capture-dismiss" onClick={() => dismissItem(item.id)} disabled={triagingId === item.id}>
+                <X size={13} aria-hidden="true" /> {t(messages, 'module.dashboard.quick_capture_dismiss')}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/contexts/AppContext.js
+++ b/frontend/contexts/AppContext.js
@@ -22,7 +22,7 @@ function AppOrchestrator({ children }) {
 
   const { loggedIn, demoMode, setMe, setLoggedIn, setDemoMode, setProfileImage, setNeedsSetup } = auth;
   const { familyId, setFamilyId, families, setFamilies, setMyFamilyRole, setMyFamilyIsAdult, loadMembers, setMembers } = family;
-  const { loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadNotifications, resetData, lastEventIdRef, setNotifications, setUnreadCount, setEvents, setTasks, setShoppingLists, setActivity, setContacts, setBirthdays, setSummary } = data;
+  const { loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadQuickCaptureInbox, loadNotifications, resetData, lastEventIdRef, setNotifications, setUnreadCount, setEvents, setTasks, setShoppingLists, setActivity, setQuickCaptureInbox, setContacts, setBirthdays, setSummary } = data;
   const { setLoading, setTheme, setLang, setActiveView: setActiveViewUI, restoreView, setIsMobile, setNavOrder, setTimeFormat, lang } = ui;
 
   // Wrap data loaders to inject familyId default and skip in demo mode
@@ -66,6 +66,11 @@ function AppOrchestrator({ children }) {
     return loadActivity(fid);
   }, [familyId, demoMode, loadActivity]);
 
+  const loadQuickCaptureInboxWrapped = useCallback(async (fid = familyId) => {
+    if (demoMode) return;
+    return loadQuickCaptureInbox(fid);
+  }, [familyId, demoMode, loadQuickCaptureInbox]);
+
   const loadNotificationsWrapped = useCallback(async () => {
     if (demoMode) return;
     return loadNotifications();
@@ -89,9 +94,9 @@ function AppOrchestrator({ children }) {
       setMyFamilyRole(selected.role);
       setMyFamilyIsAdult(selected.is_adult);
     }
-    await Promise.all([loadDashboard(fid), loadEvents(fid), loadMembers(fid), loadContacts(fid), loadBirthdays(fid), loadTasks(fid), loadShoppingLists(fid), loadActivity(fid)]);
+    await Promise.all([loadDashboard(fid), loadEvents(fid), loadMembers(fid), loadContacts(fid), loadBirthdays(fid), loadTasks(fid), loadShoppingLists(fid), loadActivity(fid), loadQuickCaptureInbox(fid)]);
     setLoading(false);
-  }, [families, loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, setLoading, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult]);
+  }, [families, loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadQuickCaptureInbox, setLoading, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult]);
 
   const loadFamilyDataInBackground = useCallback((fid) => {
     void Promise.allSettled([
@@ -103,12 +108,13 @@ function AppOrchestrator({ children }) {
       loadTasks(fid),
       loadShoppingLists(fid),
       loadActivity(fid),
+      loadQuickCaptureInbox(fid),
       loadNavOrderWrapped(),
       api.apiGetTimeFormat().then(({ ok, data: tfData }) => {
         if (ok && tfData?.time_format) setTimeFormat(tfData.time_format);
       }),
     ]);
-  }, [loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadNavOrderWrapped, setTimeFormat]);
+  }, [loadDashboard, loadEvents, loadMembers, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadQuickCaptureInbox, loadNavOrderWrapped, setTimeFormat]);
 
   const enterDemo = useCallback(() => {
     const demo = buildDemoData(lang);
@@ -123,12 +129,13 @@ function AppOrchestrator({ children }) {
     setTasks(demo.tasks);
     setShoppingLists(demo.shoppingLists);
     setActivity(demo.activity || []);
+    setQuickCaptureInbox(demo.quickCaptureInbox || []);
     setContacts(demo.contacts);
     setBirthdays(demo.birthdays);
     setSummary(demo.summary);
     setLoggedIn(true);
     setLoading(false);
-  }, [lang, setDemoMode, setMe, setFamilies, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult, setMembers, setEvents, setTasks, setShoppingLists, setActivity, setContacts, setBirthdays, setSummary, setLoggedIn, setLoading]);
+  }, [lang, setDemoMode, setMe, setFamilies, setFamilyId, setMyFamilyRole, setMyFamilyIsAdult, setMembers, setEvents, setTasks, setShoppingLists, setActivity, setQuickCaptureInbox, setContacts, setBirthdays, setSummary, setLoggedIn, setLoading]);
 
   const logout = useCallback(async () => {
     await auth.logout();
@@ -334,6 +341,7 @@ function AppOrchestrator({ children }) {
     loadTasks: loadTasksWrapped,
     loadShoppingLists: loadShoppingListsWrapped,
     loadActivity: loadActivityWrapped,
+    loadQuickCaptureInbox: loadQuickCaptureInboxWrapped,
     loadNotifications: loadNotificationsWrapped,
     loadNavOrder: loadNavOrderWrapped,
     // Cross-domain

--- a/frontend/contexts/DataContext.js
+++ b/frontend/contexts/DataContext.js
@@ -12,6 +12,7 @@ export function DataProvider({ children }) {
   const [tasks, setTasks] = useState([]);
   const [shoppingLists, setShoppingLists] = useState([]);
   const [activity, setActivity] = useState([]);
+  const [quickCaptureInbox, setQuickCaptureInbox] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const lastEventIdRef = useRef(0);
@@ -51,6 +52,11 @@ export function DataProvider({ children }) {
     if (ok) setActivity(Array.isArray(data?.items) ? data.items : []);
   }, []);
 
+  const loadQuickCaptureInbox = useCallback(async (fid) => {
+    const { ok, data } = await api.apiGetQuickCaptureInbox(fid, 10, 0);
+    if (ok) setQuickCaptureInbox(Array.isArray(data?.items) ? data.items : []);
+  }, []);
+
   const loadNotifications = useCallback(async () => {
     const { ok, data } = await api.apiGetNotifications(50, 0);
     if (ok) {
@@ -70,6 +76,7 @@ export function DataProvider({ children }) {
     setTasks([]);
     setShoppingLists([]);
     setActivity([]);
+    setQuickCaptureInbox([]);
     setNotifications([]);
     setUnreadCount(0);
   }, []);
@@ -82,10 +89,11 @@ export function DataProvider({ children }) {
     tasks, setTasks,
     shoppingLists, setShoppingLists,
     activity, setActivity,
+    quickCaptureInbox, setQuickCaptureInbox,
     notifications, setNotifications,
     unreadCount, setUnreadCount,
     lastEventIdRef,
-    loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadNotifications,
+    loadDashboard, loadEvents, loadContacts, loadBirthdays, loadTasks, loadShoppingLists, loadActivity, loadQuickCaptureInbox, loadNotifications,
     resetData,
   };
 

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -49,4 +49,16 @@ test.describe('Dashboard', () => {
     await expect(activityCard).toContainText(`${testUser.displayName} created task "E2E Activity Task"`, { timeout: 10000 });
     await expect(activityCard).not.toContainText('private detail');
   });
+
+  test('captures a quick note and triages it from the dashboard inbox', async ({ authedPage: page }) => {
+    const quickCapture = page.getByRole('region', { name: 'Quick capture' });
+    await expect(quickCapture).toBeVisible({ timeout: 10000 });
+
+    await quickCapture.getByPlaceholder('Note an event, task, or shopping thought…').fill('Buy apples from market');
+    await quickCapture.getByRole('button', { name: 'Save to inbox' }).click();
+
+    await expect(quickCapture).toContainText('Buy apples from market', { timeout: 10000 });
+    await quickCapture.locator('.quick-capture-item-actions').getByRole('button', { name: 'Shopping' }).click();
+    await expect(quickCapture).not.toContainText('Buy apples from market', { timeout: 10000 });
+  });
 });

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -61,5 +61,17 @@
   "module.dashboard.daily_loop_empty": "Plane ein Essen, ergänze den Einkauf oder lege eine wiederkehrende Aufgabe an, damit der Tag gut startet.",
   "module.dashboard.activity_title": "Letzte Aktivitäten",
   "module.dashboard.activity_empty": "Noch keine Haushaltsaktivitäten.",
-  "module.dashboard.activity_unknown_actor": "Jemand"
+  "module.dashboard.activity_unknown_actor": "Jemand",
+  "module.dashboard.quick_capture_title": "Schnell erfassen",
+  "module.dashboard.quick_capture_subtitle": "Gedanken festhalten und später einsortieren.",
+  "module.dashboard.quick_capture_placeholder": "Termin, Aufgabe oder Einkaufsnotiz notieren…",
+  "module.dashboard.quick_capture_save_inbox": "In Inbox speichern",
+  "module.dashboard.quick_capture_add_task": "Aufgabe",
+  "module.dashboard.quick_capture_add_shopping": "Einkauf",
+  "module.dashboard.quick_capture_inbox_title": "Inbox",
+  "module.dashboard.quick_capture_inbox_empty": "Nichts zum Einsortieren.",
+  "module.dashboard.quick_capture_to_task": "Aufgabe",
+  "module.dashboard.quick_capture_to_shopping": "Einkauf",
+  "module.dashboard.quick_capture_dismiss": "Verwerfen",
+  "module.dashboard.quick_capture_inbox_count": "{count} offene Schnellnotizen"
 }

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -61,5 +61,17 @@
   "module.dashboard.daily_loop_empty": "Plan a meal, add groceries, or set a recurring task to get today started.",
   "module.dashboard.activity_title": "Recent activity",
   "module.dashboard.activity_empty": "No household activity yet.",
-  "module.dashboard.activity_unknown_actor": "Someone"
+  "module.dashboard.activity_unknown_actor": "Someone",
+  "module.dashboard.quick_capture_title": "Quick capture",
+  "module.dashboard.quick_capture_subtitle": "Save thoughts now and sort them later.",
+  "module.dashboard.quick_capture_placeholder": "Note an event, task, or shopping thought…",
+  "module.dashboard.quick_capture_save_inbox": "Save to inbox",
+  "module.dashboard.quick_capture_add_task": "Task",
+  "module.dashboard.quick_capture_add_shopping": "Shopping",
+  "module.dashboard.quick_capture_inbox_title": "Inbox",
+  "module.dashboard.quick_capture_inbox_empty": "Nothing to sort.",
+  "module.dashboard.quick_capture_to_task": "Task",
+  "module.dashboard.quick_capture_to_shopping": "Shopping",
+  "module.dashboard.quick_capture_dismiss": "Dismiss",
+  "module.dashboard.quick_capture_inbox_count": "{count} quick notes open"
 }

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -121,6 +121,22 @@ export function apiGetActivity(familyId, limit = 10, offset = 0) {
   return request(`/activity?family_id=${familyId}&limit=${limit}&offset=${offset}`);
 }
 
+export function apiCreateQuickCapture(payload) {
+  return post('/quick-capture', payload);
+}
+
+export function apiGetQuickCaptureInbox(familyId, limit = 10, offset = 0) {
+  return request(`/quick-capture/inbox?family_id=${familyId}&limit=${limit}&offset=${offset}`);
+}
+
+export function apiConvertQuickCapture(itemId, payload) {
+  return post(`/quick-capture/inbox/${itemId}/convert`, payload);
+}
+
+export function apiDismissQuickCapture(itemId) {
+  return post(`/quick-capture/inbox/${itemId}/dismiss`, {});
+}
+
 // Calendar
 export async function apiGetEvents(familyId, rangeStart, rangeEnd) {
   let url = `/calendar/events?family_id=${familyId}`;

--- a/frontend/lib/demo-data.js
+++ b/frontend/lib/demo-data.js
@@ -309,5 +309,24 @@ export function buildDemoData(lang = 'en') {
     },
   ];
 
-  return { me, families, members, events, tasks, contacts, birthdays, shoppingLists, activity, summary };
+  const quickCaptureInbox = [
+    {
+      id: nextId(),
+      text: lang === 'de' ? 'Geburtstagsgeschenk für Oma klären' : 'Check birthday gift for grandma',
+      status: 'open',
+      converted_to: null,
+      created_at: dateAt(0, 9, 5),
+      updated_at: dateAt(0, 9, 5),
+    },
+    {
+      id: nextId(),
+      text: lang === 'de' ? 'Neue Hallenschuhe besorgen' : 'Buy new indoor shoes',
+      status: 'open',
+      converted_to: null,
+      created_at: dateAt(-1, 17, 30),
+      updated_at: dateAt(-1, 17, 30),
+    },
+  ];
+
+  return { me, families, members, events, tasks, contacts, birthdays, shoppingLists, activity, quickCaptureInbox, summary };
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -729,7 +729,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-grid { display: grid; grid-template-columns: repeat(12, 1fr); column-gap: var(--space-md); row-gap: var(--space-lg); }
 .bento-card { padding: var(--space-lg); background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); transition: all 0.2s; }
 .bento-card:hover { border-color: rgba(120, 130, 180, 0.2); }
-.bento-daily-loop { grid-column: span 12; }
+.bento-daily-loop { grid-column: span 6; }
+.bento-quick-capture { grid-column: span 6; }
 .bento-events { grid-column: span 6; }
 .bento-tasks { grid-column: span 6; }
 .bento-birthdays { grid-column: span 6; }
@@ -760,6 +761,24 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-empty { color: var(--text-muted); font-size: 0.85rem; padding: var(--space-md) 0; display: flex; align-items: center; gap: var(--space-sm); }
 .bento-empty-action { background: none; border: none; color: var(--amethyst); cursor: pointer; font-family: inherit; font-size: 0.85rem; font-weight: 500; padding: 8px 12px; min-height: 44px; display: inline-flex; align-items: center; border-radius: var(--radius-sm); transition: opacity 0.2s; }
 .bento-empty-action:hover { opacity: 0.7; }
+.quick-capture-card, .bento-quick-capture { display: grid; align-content: start; gap: var(--space-md); }
+.quick-capture-intro, .quick-capture-subtitle { margin: 6px 0 0; color: var(--text-muted); font-size: 0.88rem; }
+.quick-capture-form { display: grid; gap: var(--space-sm); }
+.quick-capture-input { width: 100%; min-height: 76px; resize: vertical; border: 1px solid rgba(120, 130, 180, 0.16); border-radius: var(--radius-md); padding: 12px; background: rgba(120, 130, 180, 0.06); color: var(--text-primary); font: inherit; line-height: 1.4; }
+.quick-capture-input:focus { outline: 2px solid rgba(139, 92, 246, 0.24); border-color: rgba(139, 92, 246, 0.36); }
+.quick-capture-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.quick-capture-action { min-height: 40px; border: 1px solid rgba(120, 130, 180, 0.14); border-radius: var(--radius-pill); padding: 8px 12px; background: var(--void-surface); color: var(--text-primary); font: inherit; font-size: 0.82rem; font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 7px; box-shadow: var(--shadow-sm); }
+.quick-capture-action.primary, .quick-capture-primary { background: linear-gradient(135deg, var(--amethyst), var(--sapphire)); color: white; border-color: transparent; }
+.quick-capture-action:disabled { opacity: 0.55; cursor: not-allowed; }
+.quick-capture-inbox { display: grid; gap: 8px; }
+.quick-capture-inbox-head, .quick-capture-inbox-title { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); color: var(--text-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+.quick-capture-count { text-transform: none; letter-spacing: 0; font-weight: 500; }
+.quick-capture-item { display: grid; gap: 8px; padding: 10px; border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); border: 1px solid rgba(120, 130, 180, 0.08); }
+.quick-capture-text, .quick-capture-item-text { color: var(--text-primary); font-size: 0.9rem; overflow-wrap: anywhere; }
+.quick-capture-item-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+.quick-capture-item-actions button { min-height: 34px; border: 0; border-radius: var(--radius-pill); padding: 6px 10px; background: rgba(139, 92, 246, 0.1); color: var(--amethyst); font: inherit; font-size: 0.75rem; font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 5px; }
+.quick-capture-item-actions button:last-child { background: rgba(120, 130, 180, 0.08); color: var(--text-muted); }
+.quick-capture-error { color: var(--danger); font-size: 0.82rem; }
 
 
 /* ─── Admin ─── */
@@ -1668,7 +1687,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    RESPONSIVE
    ═══════════════════════════════════════════ */
 @media (max-width: 1100px) {
-  .bento-daily-loop { grid-column: span 12; }
+  .bento-daily-loop, .bento-quick-capture { grid-column: span 12; }
   .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards { grid-column: span 6; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .calendar-layout { grid-template-columns: 1fr; }
@@ -1681,7 +1700,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .mobile-header { display: flex; }
   .bottom-nav { display: block; }
   .bento-grid { grid-template-columns: 1fr; row-gap: var(--space-md); }
-  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards, .bento-daily-loop { grid-column: span 1; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards, .bento-daily-loop, .bento-quick-capture { grid-column: span 1; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .daily-loop-item { grid-template-columns: auto 1fr; }
   .daily-loop-action { grid-column: 1 / -1; justify-self: stretch; text-align: center; }


### PR DESCRIPTION
## Summary
- Add a universal quick capture API with inbox, task, shopping, and dismiss flows
- Add the dashboard Quick Capture card with desktop side-by-side layout next to Today in motion
- Add backend, frontend, and Playwright coverage for capture and triage flows

## Validation
- Backend targeted tests: 34 passed
- Frontend targeted Jest: 33 passed
- QuickCaptureCard focused Jest: 3 passed
- Next build passed
- Dashboard Playwright: 8 listed, 8 passed
- Browser UI review passed for desktop layout and public-safe display

Closes #244
