### PR TITLE
Add print-ready weekly plan view

### DIFF
--- a/frontend/__tests__/components/DashboardHero.test.js
+++ b/frontend/__tests__/components/DashboardHero.test.js
@@ -40,6 +40,7 @@ const messages = {
   'module.dashboard.quick_task': 'Task',
   'module.dashboard.quick_shopping': 'Shopping',
   'module.dashboard.quick_invite': 'Invite',
+  'module.dashboard.quick_weekly_plan': 'Weekly plan',
   'module.dashboard.quick_actions_label': 'Quick actions',
   'module.dashboard.quick_my_tasks': 'My tasks',
   'module.dashboard.quick_rewards': 'Rewards',
@@ -119,6 +120,7 @@ describe('DashboardView hero', () => {
     expect(within(region).getByRole('button', { name: 'Task' })).toBeVisible();
     expect(within(region).getByRole('button', { name: 'Shopping' })).toBeVisible();
     expect(within(region).getByRole('button', { name: 'Invite' })).toBeVisible();
+    expect(within(region).getByRole('button', { name: 'Weekly plan' })).toBeVisible();
   });
 
   it('navigates from the labeled quick action pills to the correct views', () => {
@@ -130,10 +132,12 @@ describe('DashboardView hero', () => {
     fireEvent.click(within(region).getByRole('button', { name: 'Task' }));
     fireEvent.click(within(region).getByRole('button', { name: 'Shopping' }));
     fireEvent.click(within(region).getByRole('button', { name: 'Invite' }));
+    fireEvent.click(within(region).getByRole('button', { name: 'Weekly plan' }));
     expect(setActiveView).toHaveBeenCalledWith('calendar');
     expect(setActiveView).toHaveBeenCalledWith('tasks');
     expect(setActiveView).toHaveBeenCalledWith('shopping');
     expect(setActiveView).toHaveBeenCalledWith('admin');
+    expect(setActiveView).toHaveBeenCalledWith('weekly_plan');
   });
 
   it('does not render the icon-only header quick action buttons anymore', () => {

--- a/frontend/__tests__/components/WeeklyPlanView.test.js
+++ b/frontend/__tests__/components/WeeklyPlanView.test.js
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WeeklyPlanView, { buildWeeklyPlanSections, getWeekRange } from '../../components/WeeklyPlanView';
+import { apiGetEvents } from '../../lib/api';
+
+let mockAppState = {};
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+jest.mock('../../lib/i18n', () => ({
+  t: (messages, key) => messages?.[key] || key,
+}));
+
+jest.mock('../../lib/api', () => ({
+  apiGetEvents: jest.fn().mockResolvedValue({ data: [] }),
+  apiListMealPlans: jest.fn().mockResolvedValue({ data: { items: [] } }),
+}));
+
+const messages = {
+  'module.weekly_plan.title': 'Weekly plan',
+  'module.weekly_plan.subtitle': 'Print-ready household overview',
+  'module.weekly_plan.this_week': 'This week',
+  'module.weekly_plan.next_week': 'Next week',
+  'module.weekly_plan.previous_week': 'Previous week',
+  'module.weekly_plan.print': 'Print',
+  'module.weekly_plan.back_dashboard': 'Back to dashboard',
+  'module.weekly_plan.events': 'Events',
+  'module.weekly_plan.tasks': 'Tasks and routines',
+  'module.weekly_plan.meals': 'Meals',
+  'module.weekly_plan.shopping': 'Shopping reminders',
+  'module.weekly_plan.birthdays': 'Birthdays',
+  'module.weekly_plan.empty_section': 'Nothing planned',
+  'module.weekly_plan.no_due_date': 'No due date',
+  'module.weekly_plan.filters': 'Filters',
+  'module.weekly_plan.filter_member': 'Member',
+  'module.weekly_plan.filter_all_members': 'All members',
+  'module.weekly_plan.filter_sections': 'Sections',
+};
+
+function baseApp(overrides = {}) {
+  return {
+    summary: { next_events: [], upcoming_birthdays: [] },
+    events: [],
+    tasks: [],
+    shoppingLists: [],
+    birthdays: [],
+    members: [],
+    familyId: 7,
+    messages,
+    lang: 'en',
+    timeFormat: '24h',
+    setActiveView: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('weekly plan helpers', () => {
+  it('composes only events, tasks, meals, birthdays, and shopping reminders inside the selected week', () => {
+    const week = getWeekRange(new Date('2026-05-06T12:00:00'));
+    const sections = buildWeeklyPlanSections({
+      weekStart: week.start,
+      events: [
+        { id: 1, title: 'Football', starts_at: '2026-05-08T17:00:00' },
+        { id: 2, title: 'Later', starts_at: '2026-05-18T17:00:00' },
+      ],
+      tasks: [
+        { id: 3, title: 'Pack bags', status: 'open', due_date: '2026-05-07' },
+        { id: 4, title: 'Done task', status: 'done', due_date: '2026-05-07' },
+      ],
+      meals: [
+        { id: 5, meal_name: 'Pasta', plan_date: '2026-05-09', slot: 'dinner' },
+      ],
+      birthdays: [
+        { id: 6, person_name: 'Martin', month: 5, day: 7 },
+        { id: 7, person_name: 'June', month: 6, day: 1 },
+      ],
+      shoppingLists: [
+        { id: 8, name: 'Groceries', item_count: 5, checked_count: 2 },
+      ],
+    });
+
+    expect(sections.events).toHaveLength(1);
+    expect(sections.tasks).toHaveLength(1);
+    expect(sections.meals).toHaveLength(1);
+    expect(sections.birthdays).toHaveLength(1);
+    expect(sections.shopping).toEqual([{ id: 8, title: 'Groceries', detail: '3 open', count: 3 }]);
+  });
+
+  it('includes birthdays when the selected week crosses into a new year', () => {
+    const week = getWeekRange(new Date('2026-12-30T12:00:00'));
+    const sections = buildWeeklyPlanSections({
+      weekStart: week.start,
+      birthdays: [
+        { id: 1, person_name: 'New Year Child', month: 1, day: 2 },
+        { id: 2, person_name: 'Spring Child', month: 4, day: 2 },
+      ],
+    });
+
+    expect(sections.birthdays).toEqual([{ id: 1, person_name: 'New Year Child', month: 1, day: 2 }]);
+  });
+});
+
+describe('WeeklyPlanView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAppState = baseApp();
+    window.print = jest.fn();
+  });
+
+  it('renders a print-ready weekly plan and hides app navigation controls behind print classes', () => {
+    mockAppState = baseApp({
+      events: [{ id: 1, title: 'Football', starts_at: '2026-05-08T17:00:00' }],
+      tasks: [{ id: 2, title: 'Pack bags', status: 'open', due_date: '2026-05-08' }],
+      birthdays: [{ id: 3, person_name: 'Martin', month: 5, day: 9 }],
+      shoppingLists: [{ id: 4, name: 'Groceries', item_count: 3, checked_count: 1 }],
+    });
+
+    const { container } = render(<WeeklyPlanView initialDate={new Date('2026-05-06T12:00:00')} initialEvents={mockAppState.events} initialMeals={[{ id: 5, meal_name: 'Pasta', plan_date: '2026-05-08', slot: 'dinner' }]} />);
+
+    expect(screen.getByRole('heading', { name: 'Weekly plan' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Print' })).toHaveClass('no-print');
+    expect(container.querySelector('.weekly-plan-page')).toHaveClass('print-surface');
+    expect(within(screen.getByRole('region', { name: 'Events' })).getByText('Football')).toBeVisible();
+    expect(within(screen.getByRole('region', { name: 'Tasks and routines' })).getByText('Pack bags')).toBeVisible();
+    expect(within(screen.getByRole('region', { name: 'Meals' })).getByText('Pasta')).toBeVisible();
+    expect(within(screen.getByRole('region', { name: 'Birthdays' })).getByText('Martin')).toBeVisible();
+    expect(within(screen.getByRole('region', { name: 'Shopping reminders' })).getByText('Groceries')).toBeVisible();
+  });
+
+  it('filters printable sections and member-specific assignments without exposing controls in print', () => {
+    mockAppState = baseApp({
+      members: [
+        { user_id: 10, display_name: 'Mia' },
+        { user_id: 11, display_name: 'Leo' },
+      ],
+      events: [
+        { id: 1, title: 'Mia training', starts_at: '2026-05-08T17:00:00', assigned_to: [10] },
+        { id: 2, title: 'Leo training', starts_at: '2026-05-08T18:00:00', assigned_to: [11] },
+      ],
+      tasks: [
+        { id: 3, title: 'Mia bag', status: 'open', due_date: '2026-05-08', assigned_to_user_id: 10 },
+        { id: 4, title: 'Leo bag', status: 'open', due_date: '2026-05-08', assigned_to_user_id: 11 },
+      ],
+    });
+
+    render(<WeeklyPlanView initialDate={new Date('2026-05-06T12:00:00')} initialEvents={mockAppState.events} initialMeals={[]} />);
+
+    const filters = screen.getByRole('group', { name: 'Filters' });
+    expect(filters).toHaveClass('no-print');
+    fireEvent.change(screen.getByLabelText('Member'), { target: { value: '10' } });
+    expect(screen.getByText('Mia training')).toBeVisible();
+    expect(screen.queryByText('Leo training')).not.toBeInTheDocument();
+    expect(screen.getByText('Mia bag')).toBeVisible();
+    expect(screen.queryByText('Leo bag')).not.toBeInTheDocument();
+
+    fireEvent.click(within(screen.getByLabelText('Sections')).getByLabelText('Tasks and routines'));
+    expect(screen.queryByRole('region', { name: 'Tasks and routines' })).not.toBeInTheDocument();
+  });
+
+  it('fetches ranged calendar events for the selected printable week', async () => {
+    apiGetEvents.mockResolvedValueOnce({ data: [{ id: 9, title: 'Recurring training', starts_at: '2026-05-08T17:00:00' }] });
+    mockAppState = baseApp({ events: [{ id: 1, title: 'Cached later event', starts_at: '2026-06-08T17:00:00' }] });
+
+    render(<WeeklyPlanView initialDate={new Date('2026-05-06T12:00:00')} initialMeals={[]} />);
+
+    await waitFor(() => expect(apiGetEvents).toHaveBeenCalledWith(7, expect.stringContaining('2026-05-04'), expect.stringContaining('2026-05-10')));
+    expect(await screen.findByText('Recurring training')).toBeVisible();
+    expect(screen.queryByText('Cached later event')).not.toBeInTheDocument();
+  });
+
+  it('prints and navigates back without creating a public share link', () => {
+    const setActiveView = jest.fn();
+    mockAppState = baseApp({ setActiveView });
+    render(<WeeklyPlanView initialDate={new Date('2026-05-06T12:00:00')} initialEvents={mockAppState.events} initialMeals={[]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Print' }));
+    expect(window.print).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to dashboard' }));
+    expect(setActiveView).toHaveBeenCalledWith('dashboard');
+    expect(screen.queryByRole('link', { name: /share/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -18,6 +18,7 @@ import RecipesView from './RecipesView';
 import ShoppingView from './ShoppingView';
 import SettingsView from './settings';
 import AdminView from './admin';
+import WeeklyPlanView from './WeeklyPlanView';
 import NotificationCenter from './NotificationCenter';
 import ForcePasswordChange from './ForcePasswordChange';
 import OnboardingWizard from './OnboardingWizard';
@@ -37,6 +38,7 @@ const views = {
   notifications: NotificationCenter,
   settings: SettingsView,
   admin: AdminView,
+  weekly_plan: WeeklyPlanView,
 };
 
 function DashboardSkeleton() {

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles } from 'lucide-react';
+import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
@@ -216,6 +216,7 @@ export default function DashboardView() {
     { key: 'event', label: t(messages, 'module.dashboard.quick_event'), icon: Calendar, onClick: () => setActiveView('calendar') },
     { key: 'task', label: t(messages, 'module.dashboard.quick_task'), icon: CheckSquare, onClick: () => setActiveView('tasks') },
     { key: 'shopping', label: t(messages, 'module.dashboard.quick_shopping'), icon: ShoppingCart, onClick: () => setActiveView('shopping') },
+    { key: 'weekly-plan', label: t(messages, 'module.dashboard.quick_weekly_plan'), icon: Printer, onClick: () => setActiveView('weekly_plan') },
     ...(isAdmin ? [{ key: 'invite', label: t(messages, 'module.dashboard.quick_invite'), icon: UserPlus, onClick: () => setActiveView('admin') }] : []),
   ];
 

--- a/frontend/components/WeeklyPlanView.js
+++ b/frontend/components/WeeklyPlanView.js
@@ -1,0 +1,272 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CalendarDays, ChevronLeft, ChevronRight, ListChecks, Printer, ShoppingCart, Utensils, Cake, ArrowLeft } from 'lucide-react';
+import { useApp } from '../contexts/AppContext';
+import { apiGetEvents, apiListMealPlans } from '../lib/api';
+import { parseDate } from '../lib/helpers';
+import { t } from '../lib/i18n';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toIsoDate(date) {
+  const d = parseDate(date);
+  if (!d) return '';
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
+function normalizeDateOnly(value) {
+  if (!value) return null;
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value)) return value.slice(0, 10);
+  return toIsoDate(value) || null;
+}
+
+function addDays(date, days) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function getWeekRange(anchor = new Date()) {
+  const start = new Date(anchor);
+  start.setHours(0, 0, 0, 0);
+  const day = start.getDay() || 7;
+  start.setDate(start.getDate() - day + 1);
+  const end = addDays(start, 6);
+  end.setHours(23, 59, 59, 999);
+  return { start, end, startIso: toIsoDate(start), endIso: toIsoDate(end) };
+}
+
+function isWithinWeek(value, weekStart) {
+  const iso = normalizeDateOnly(value);
+  if (!iso) return false;
+  const week = getWeekRange(weekStart);
+  return iso >= week.startIso && iso <= week.endIso;
+}
+
+function eventDate(event) {
+  return event?.starts_at || event?.start || event?.date;
+}
+
+function taskDate(task) {
+  return task?.due_date || task?.due_at;
+}
+
+function mealDate(meal) {
+  return meal?.plan_date || meal?.date || meal?.planned_for || meal?.meal_date;
+}
+
+function birthdayDate(birthday, weekStart) {
+  const range = getWeekRange(weekStart);
+  const startYear = range.start.getFullYear();
+  const endYear = range.end.getFullYear();
+  const years = [...new Set([startYear, endYear])];
+  let monthDay = null;
+
+  if (birthday?.month && birthday?.day) {
+    monthDay = `${String(birthday.month).padStart(2, '0')}-${String(birthday.day).padStart(2, '0')}`;
+  } else {
+    const raw = birthday?.date || birthday?.birthday || birthday?.next_date;
+    const iso = normalizeDateOnly(raw);
+    if (iso) monthDay = iso.slice(5, 10);
+  }
+
+  if (!monthDay) return null;
+  return years.map((year) => `${year}-${monthDay}`).find((candidate) => candidate >= range.startIso && candidate <= range.endIso) || `${startYear}-${monthDay}`;
+}
+
+function openShoppingCount(list) {
+  if (typeof list?.item_count === 'number' || typeof list?.checked_count === 'number') {
+    return Math.max(0, Number(list.item_count || 0) - Number(list.checked_count || 0));
+  }
+  return (Array.isArray(list?.items) ? list.items : []).filter((item) => !item?.checked && !item?.is_checked).length;
+}
+
+function compareByDate(getter) {
+  return (a, b) => String(normalizeDateOnly(getter(a)) || '').localeCompare(String(normalizeDateOnly(getter(b)) || ''));
+}
+
+function asStringId(value) {
+  return value === null || value === undefined || value === '' ? null : String(value);
+}
+
+function assignedListMatches(assignedTo, selectedMemberId) {
+  if (!selectedMemberId) return true;
+  if (!assignedTo || assignedTo === 'all') return true;
+  if (Array.isArray(assignedTo)) return assignedTo.map(String).includes(selectedMemberId);
+  return String(assignedTo) === selectedMemberId;
+}
+
+function assignedUserMatches(value, selectedMemberId) {
+  if (!selectedMemberId) return true;
+  const assigned = asStringId(value);
+  return !assigned || assigned === selectedMemberId;
+}
+
+const SECTION_CONFIG = [
+  { key: 'events', labelKey: 'module.weekly_plan.events', icon: CalendarDays },
+  { key: 'tasks', labelKey: 'module.weekly_plan.tasks', icon: ListChecks },
+  { key: 'meals', labelKey: 'module.weekly_plan.meals', icon: Utensils },
+  { key: 'birthdays', labelKey: 'module.weekly_plan.birthdays', icon: Cake },
+  { key: 'shopping', labelKey: 'module.weekly_plan.shopping', icon: ShoppingCart },
+];
+
+export function buildWeeklyPlanSections({ weekStart, events = [], tasks = [], meals = [], birthdays = [], shoppingLists = [], memberId = '' }) {
+  const selectedMemberId = asStringId(memberId);
+  const openShopping = (Array.isArray(shoppingLists) ? shoppingLists : [])
+    .map((list) => ({ id: list.id, title: list.name || list.title, detail: `${openShoppingCount(list)} open`, count: openShoppingCount(list) }))
+    .filter((item) => item.count > 0);
+
+  return {
+    events: (Array.isArray(events) ? events : [])
+      .filter((event) => isWithinWeek(eventDate(event), weekStart) && assignedListMatches(event?.assigned_to, selectedMemberId))
+      .sort(compareByDate(eventDate)),
+    tasks: (Array.isArray(tasks) ? tasks : [])
+      .filter((task) => task?.status === 'open' && isWithinWeek(taskDate(task), weekStart) && assignedUserMatches(task?.assigned_to_user_id, selectedMemberId))
+      .sort(compareByDate(taskDate)),
+    meals: (Array.isArray(meals) ? meals : [])
+      .filter((meal) => isWithinWeek(mealDate(meal), weekStart) && assignedUserMatches(meal?.assigned_to_user_id || meal?.member_id || meal?.user_id, selectedMemberId))
+      .sort(compareByDate(mealDate)),
+    birthdays: (Array.isArray(birthdays) ? birthdays : [])
+      .filter((birthday) => {
+        const next = birthdayDate(birthday, weekStart);
+        return next && isWithinWeek(next, weekStart) && assignedUserMatches(birthday?.user_id || birthday?.member_id, selectedMemberId);
+      })
+      .sort((a, b) => String(birthdayDate(a, weekStart)).localeCompare(String(birthdayDate(b, weekStart)))),
+    shopping: openShopping,
+  };
+}
+
+function formatDate(value, locale) {
+  const date = parseDate(value);
+  if (!date) return '';
+  return date.toLocaleDateString(locale, { weekday: 'short', day: '2-digit', month: '2-digit' });
+}
+
+function formatWeekLabel(range, locale) {
+  return `${range.start.toLocaleDateString(locale, { day: '2-digit', month: 'short' })} – ${range.end.toLocaleDateString(locale, { day: '2-digit', month: 'short', year: 'numeric' })}`;
+}
+
+function Section({ title, icon: Icon, items, emptyLabel, renderItem }) {
+  return (
+    <section className="weekly-plan-section" role="region" aria-label={title}>
+      <h2><Icon size={17} aria-hidden="true" /> {title}</h2>
+      {items.length ? <ul>{items.map(renderItem)}</ul> : <p className="weekly-plan-empty">{emptyLabel}</p>}
+    </section>
+  );
+}
+
+export default function WeeklyPlanView({ initialDate, initialMeals = null, initialEvents = null }) {
+  const { events = [], tasks = [], shoppingLists = [], birthdays = [], members = [], familyId, messages, lang, timeFormat, setActiveView } = useApp();
+  const locale = lang === 'de' ? 'de-DE' : 'en-US';
+  const [anchor, setAnchor] = useState(initialDate || new Date());
+  const [meals, setMeals] = useState(initialMeals || []);
+  const [weeklyEvents, setWeeklyEvents] = useState(initialEvents || events);
+  const [selectedMemberId, setSelectedMemberId] = useState('');
+  const [visibleSections, setVisibleSections] = useState(() => new Set(SECTION_CONFIG.map((section) => section.key)));
+  const range = useMemo(() => getWeekRange(anchor), [anchor]);
+
+  useEffect(() => {
+    if (initialEvents !== null) return;
+    setWeeklyEvents(events);
+  }, [events, initialEvents]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (initialEvents !== null || !familyId) return () => { cancelled = true; };
+    apiGetEvents(familyId, range.startIso, range.endIso).then((res) => {
+      if (cancelled) return;
+      setWeeklyEvents(Array.isArray(res?.data) ? res.data : []);
+    }).catch(() => {
+      if (!cancelled) setWeeklyEvents([]);
+    });
+    return () => { cancelled = true; };
+  }, [familyId, initialEvents, range.startIso, range.endIso]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (initialMeals || !familyId) return () => { cancelled = true; };
+    apiListMealPlans(familyId, range.startIso, range.endIso).then((res) => {
+      if (cancelled) return;
+      const items = Array.isArray(res?.data?.items) ? res.data.items : Array.isArray(res?.data) ? res.data : [];
+      setMeals(items);
+    }).catch(() => {
+      if (!cancelled) setMeals([]);
+    });
+    return () => { cancelled = true; };
+  }, [familyId, initialMeals, range.startIso, range.endIso]);
+
+  const sections = useMemo(() => buildWeeklyPlanSections({ weekStart: range.start, events: weeklyEvents, tasks, meals, birthdays, shoppingLists, memberId: selectedMemberId }), [range.start, weeklyEvents, tasks, meals, birthdays, shoppingLists, selectedMemberId]);
+  const timeOptions = timeFormat === '12h' ? { hour: 'numeric', minute: '2-digit' } : { hour: '2-digit', minute: '2-digit', hour12: false };
+  const toggleSection = (sectionKey) => {
+    setVisibleSections((current) => {
+      const next = new Set(current);
+      if (next.has(sectionKey)) {
+        next.delete(sectionKey);
+      } else {
+        next.add(sectionKey);
+      }
+      return next.size ? next : current;
+    });
+  };
+
+  return (
+    <main className="weekly-plan-page print-surface">
+      <div className="weekly-plan-toolbar no-print">
+        <button type="button" className="btn-secondary" onClick={() => setActiveView('dashboard')}><ArrowLeft size={16} /> {t(messages, 'module.weekly_plan.back_dashboard')}</button>
+        <div className="weekly-plan-nav">
+          <button type="button" className="btn-secondary" onClick={() => setAnchor(addDays(anchor, -7))}><ChevronLeft size={16} /> {t(messages, 'module.weekly_plan.previous_week')}</button>
+          <button type="button" className="btn-secondary" onClick={() => setAnchor(new Date())}>{t(messages, 'module.weekly_plan.this_week')}</button>
+          <button type="button" className="btn-secondary" onClick={() => setAnchor(addDays(anchor, 7))}>{t(messages, 'module.weekly_plan.next_week')} <ChevronRight size={16} /></button>
+        </div>
+        <button type="button" className="btn-primary no-print" onClick={() => window.print()}><Printer size={16} /> {t(messages, 'module.weekly_plan.print')}</button>
+      </div>
+      <fieldset className="weekly-plan-filters no-print" aria-label={t(messages, 'module.weekly_plan.filters')}>
+        <label className="weekly-plan-member-filter">
+          <span>{t(messages, 'module.weekly_plan.filter_member')}</span>
+          <select value={selectedMemberId} onChange={(event) => setSelectedMemberId(event.target.value)}>
+            <option value="">{t(messages, 'module.weekly_plan.filter_all_members')}</option>
+            {members.map((member) => (
+              <option key={member.user_id || member.id} value={member.user_id || member.id}>{member.display_name || member.name || member.email}</option>
+            ))}
+          </select>
+        </label>
+        <div className="weekly-plan-section-filters" aria-label={t(messages, 'module.weekly_plan.filter_sections')}>
+          {SECTION_CONFIG.map((section) => (
+            <label key={section.key}>
+              <input
+                type="checkbox"
+                checked={visibleSections.has(section.key)}
+                onChange={() => toggleSection(section.key)}
+              />
+              <span>{t(messages, section.labelKey)}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+      <header className="weekly-plan-header">
+        <p className="eyebrow">Tribu</p>
+        <h1>{t(messages, 'module.weekly_plan.title')}</h1>
+        <p>{t(messages, 'module.weekly_plan.subtitle')}</p>
+        <strong>{formatWeekLabel(range, locale)}</strong>
+      </header>
+      <div className="weekly-plan-grid">
+        {visibleSections.has('events') && <Section title={t(messages, 'module.weekly_plan.events')} icon={CalendarDays} items={sections.events} emptyLabel={t(messages, 'module.weekly_plan.empty_section')} renderItem={(event) => (
+          <li key={`event-${event.id || event.title}`}><span>{formatDate(eventDate(event), locale)} {parseDate(eventDate(event))?.toLocaleTimeString(locale, timeOptions)}</span><strong>{event.title}</strong></li>
+        )} />}
+        {visibleSections.has('tasks') && <Section title={t(messages, 'module.weekly_plan.tasks')} icon={ListChecks} items={sections.tasks} emptyLabel={t(messages, 'module.weekly_plan.empty_section')} renderItem={(task) => (
+          <li key={`task-${task.id || task.title}`}><span>{formatDate(taskDate(task), locale) || t(messages, 'module.weekly_plan.no_due_date')}</span><strong>{task.title}</strong></li>
+        )} />}
+        {visibleSections.has('meals') && <Section title={t(messages, 'module.weekly_plan.meals')} icon={Utensils} items={sections.meals} emptyLabel={t(messages, 'module.weekly_plan.empty_section')} renderItem={(meal) => (
+          <li key={`meal-${meal.id || meal.meal_name}`}><span>{formatDate(mealDate(meal), locale)} {meal.slot || meal.meal_type || ''}</span><strong>{meal.meal_name || meal.title || meal.name}</strong></li>
+        )} />}
+        {visibleSections.has('birthdays') && <Section title={t(messages, 'module.weekly_plan.birthdays')} icon={Cake} items={sections.birthdays} emptyLabel={t(messages, 'module.weekly_plan.empty_section')} renderItem={(birthday) => (
+          <li key={`birthday-${birthday.id || birthday.person_name || birthday.name}`}><span>{formatDate(birthdayDate(birthday, range.start), locale)}</span><strong>{birthday.person_name || birthday.name}</strong></li>
+        )} />}
+        {visibleSections.has('shopping') && <Section title={t(messages, 'module.weekly_plan.shopping')} icon={ShoppingCart} items={sections.shopping} emptyLabel={t(messages, 'module.weekly_plan.empty_section')} renderItem={(item) => (
+          <li key={`shopping-${item.id || item.title}`}><span>{item.detail}</span><strong>{item.title}</strong></li>
+        )} />}
+      </div>
+    </main>
+  );
+}

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -29,6 +29,17 @@ test.describe('Dashboard', () => {
     await navigateTo(page, 'Home');
     await page.getByRole('group', { name: 'Quick actions' }).waitFor({ timeout: 10000 });
 
+    // Weekly plan → print-ready weekly view
+    await page.getByTestId('quick-action-weekly-plan').click();
+    await expect(page.getByRole('heading', { name: 'Weekly plan' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Print' })).toHaveClass(/no-print/);
+    await expect(page.getByRole('group', { name: 'Filters' })).toHaveClass(/no-print/);
+    await expect(page.getByRole('region', { name: 'Events' })).toBeVisible();
+
+    // Back to Dashboard
+    await page.getByRole('button', { name: 'Back to dashboard' }).click();
+    await page.getByRole('group', { name: 'Quick actions' }).waitFor({ timeout: 10000 });
+
     // Invite → Admin
     await page.getByTestId('quick-action-invite').click();
     await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible({ timeout: 10000 });

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -10,6 +10,7 @@
   "module.dashboard.quick_task": "Aufgabe",
   "module.dashboard.quick_shopping": "Einkauf",
   "module.dashboard.quick_invite": "Einladen",
+  "module.dashboard.quick_weekly_plan": "Wochenplan",
   "module.dashboard.quick_contact": "Kontakt",
   "module.dashboard.quick_actions_label": "Schnellaktionen",
   "module.dashboard.context_chips_label": "Familie auf einen Blick",

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -10,6 +10,7 @@
   "module.dashboard.quick_task": "Task",
   "module.dashboard.quick_shopping": "Shopping",
   "module.dashboard.quick_invite": "Invite",
+  "module.dashboard.quick_weekly_plan": "Weekly plan",
   "module.dashboard.quick_contact": "Contact",
   "module.dashboard.quick_actions_label": "Quick actions",
   "module.dashboard.context_chips_label": "Family at a glance",

--- a/frontend/i18n/modules/weekly_plan/de.json
+++ b/frontend/i18n/modules/weekly_plan/de.json
@@ -1,0 +1,20 @@
+{
+  "module.weekly_plan.title": "Wochenplan",
+  "module.weekly_plan.subtitle": "Druckfertiger Überblick für Kalender, Aufgaben, Essen, Einkauf und Geburtstage.",
+  "module.weekly_plan.this_week": "Diese Woche",
+  "module.weekly_plan.next_week": "Nächste Woche",
+  "module.weekly_plan.previous_week": "Vorherige Woche",
+  "module.weekly_plan.print": "Drucken",
+  "module.weekly_plan.back_dashboard": "Zurück zum Dashboard",
+  "module.weekly_plan.events": "Termine",
+  "module.weekly_plan.tasks": "Aufgaben und Routinen",
+  "module.weekly_plan.meals": "Essen",
+  "module.weekly_plan.shopping": "Einkauf",
+  "module.weekly_plan.birthdays": "Geburtstage",
+  "module.weekly_plan.empty_section": "Nichts geplant",
+  "module.weekly_plan.no_due_date": "Ohne Fälligkeitsdatum",
+  "module.weekly_plan.filters": "Filter",
+  "module.weekly_plan.filter_member": "Mitglied",
+  "module.weekly_plan.filter_all_members": "Alle Mitglieder",
+  "module.weekly_plan.filter_sections": "Bereiche"
+}

--- a/frontend/i18n/modules/weekly_plan/en.json
+++ b/frontend/i18n/modules/weekly_plan/en.json
@@ -1,0 +1,20 @@
+{
+  "module.weekly_plan.title": "Weekly plan",
+  "module.weekly_plan.subtitle": "Print-ready overview for calendar, tasks, meals, shopping, and birthdays.",
+  "module.weekly_plan.this_week": "This week",
+  "module.weekly_plan.next_week": "Next week",
+  "module.weekly_plan.previous_week": "Previous week",
+  "module.weekly_plan.print": "Print",
+  "module.weekly_plan.back_dashboard": "Back to dashboard",
+  "module.weekly_plan.events": "Events",
+  "module.weekly_plan.tasks": "Tasks and routines",
+  "module.weekly_plan.meals": "Meals",
+  "module.weekly_plan.shopping": "Shopping reminders",
+  "module.weekly_plan.birthdays": "Birthdays",
+  "module.weekly_plan.empty_section": "Nothing planned",
+  "module.weekly_plan.no_due_date": "No due date",
+  "module.weekly_plan.filters": "Filters",
+  "module.weekly_plan.filter_member": "Member",
+  "module.weekly_plan.filter_all_members": "All members",
+  "module.weekly_plan.filter_sections": "Sections"
+}

--- a/frontend/lib/i18n.js
+++ b/frontend/lib/i18n.js
@@ -23,10 +23,12 @@ import mealPlansDe from '../i18n/modules/meal_plans/de.json';
 import mealPlansEn from '../i18n/modules/meal_plans/en.json';
 import recipesDe from '../i18n/modules/recipes/de.json';
 import recipesEn from '../i18n/modules/recipes/en.json';
+import weeklyPlanDe from '../i18n/modules/weekly_plan/de.json';
+import weeklyPlanEn from '../i18n/modules/weekly_plan/en.json';
 
 const moduleLocales = {
-  de: [calendarDe, dashboardDe, contactsDe, tasksDe, templatesDe, shoppingDe, birthdaysDe, rewardsDe, giftsDe, mealPlansDe, recipesDe],
-  en: [calendarEn, dashboardEn, contactsEn, tasksEn, templatesEn, shoppingEn, birthdaysEn, rewardsEn, giftsEn, mealPlansEn, recipesEn],
+  de: [calendarDe, dashboardDe, contactsDe, tasksDe, templatesDe, shoppingDe, birthdaysDe, rewardsDe, giftsDe, mealPlansDe, recipesDe, weeklyPlanDe],
+  en: [calendarEn, dashboardEn, contactsEn, tasksEn, templatesEn, shoppingEn, birthdaysEn, rewardsEn, giftsEn, mealPlansEn, recipesEn, weeklyPlanEn],
 };
 
 const coreLocales = { de: coreDe, en: coreEn };

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2386,6 +2386,32 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .sync-health-actions { justify-content: flex-start; }
 }
 
+/* ─── Weekly plan print view ─── */
+.weekly-plan-page { max-width: 1120px; margin: 0 auto; padding: var(--space-xl); color: var(--text-primary); }
+.weekly-plan-toolbar { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); margin-bottom: var(--space-lg); flex-wrap: wrap; }
+.weekly-plan-nav { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
+.weekly-plan-toolbar button { display: inline-flex; align-items: center; gap: var(--space-xs); }
+.weekly-plan-filters { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); margin: 0 0 var(--space-lg); padding: var(--space-md); border: 1px solid var(--border); border-radius: var(--radius-lg); background: rgba(255, 255, 255, 0.78); box-shadow: var(--shadow-sm); flex-wrap: wrap; }
+.weekly-plan-member-filter { display: inline-flex; align-items: center; gap: var(--space-sm); color: var(--text-secondary); font-size: 0.9rem; }
+.weekly-plan-member-filter select { min-width: 170px; border: 1px solid var(--border); border-radius: var(--radius-md); background: #fff; color: var(--text-primary); padding: 0.55rem 0.7rem; font: inherit; }
+.weekly-plan-section-filters { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
+.weekly-plan-section-filters label { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.45rem 0.7rem; border-radius: var(--radius-pill); background: var(--surface-muted); color: var(--text-secondary); font-size: 0.86rem; cursor: pointer; }
+.weekly-plan-section-filters input { accent-color: var(--amethyst); }
+.weekly-plan-header { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-xl); padding: var(--space-xl); margin-bottom: var(--space-lg); box-shadow: var(--shadow-sm); }
+.weekly-plan-header h1 { margin: 0 0 var(--space-xs); font-size: clamp(2rem, 5vw, 3.3rem); letter-spacing: -0.045em; }
+.weekly-plan-header p { margin: 0 0 var(--space-md); color: var(--text-secondary); max-width: 720px; }
+.weekly-plan-header strong { font-size: 1.1rem; }
+.weekly-plan-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-lg); align-items: start; }
+.weekly-plan-section { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--space-lg); box-shadow: var(--shadow-sm); break-inside: avoid; }
+.weekly-plan-section h2 { display: flex; align-items: center; gap: var(--space-xs); margin: 0 0 var(--space-md); font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-secondary); }
+.weekly-plan-section ul { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-sm); }
+.weekly-plan-section li { display: grid; gap: 0.15rem; padding: var(--space-sm); border-radius: var(--radius-md); background: var(--surface-muted); }
+.weekly-plan-section li span { color: var(--text-secondary); font-size: 0.84rem; }
+.weekly-plan-section li strong { color: var(--text-primary); font-weight: 650; }
+.weekly-plan-empty { margin: 0; color: var(--text-secondary); }
+@media (max-width: 760px) { .weekly-plan-page { padding: var(--space-md); } .weekly-plan-grid { grid-template-columns: 1fr; } }
+@media print { body { background: #fff !important; } .no-print, .pwa-banner, .sidebar, .mobile-header, .mobile-topbar, .bottom-nav, .app-sidebar, .app-header { display: none !important; } .app-layout, .main-content, .weekly-plan-page { display: block !important; width: 100% !important; max-width: none !important; padding: 0 !important; margin: 0 !important; background: #fff !important; } .weekly-plan-header, .weekly-plan-section { box-shadow: none !important; border-color: #d4d4d8 !important; } .weekly-plan-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; } }
+
 /* ─── Dashboard activation panel ─── */
 .activation-panel { background: var(--glass); backdrop-filter: blur(8px) saturate(1.2); -webkit-backdrop-filter: blur(8px) saturate(1.2); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); padding: var(--space-lg); margin-bottom: var(--space-lg); position: relative; overflow: hidden; }
 .activation-panel::before { content: ''; position: absolute; inset: 0; background: var(--grad-primary); opacity: 0.08; pointer-events: none; }


### PR DESCRIPTION
## Summary
- Adds a print-ready weekly plan view with week navigation, member filters, and section filters.
- Opens the weekly plan from the dashboard quick actions and keeps sharing inside the authenticated app.
- Includes events, tasks, meals, birthdays, and shopping reminders with print-specific styling.

## Validation
- npm test -- --runInBand __tests__/components/WeeklyPlanView.test.js __tests__/components/DashboardHero.test.js
- npm run build
- npx playwright test e2e/tests/dashboard.spec.js --reporter=list
- npx knip --reporter compact
- git diff --check

Closes #247
