### PR TITLE
Add mobile daily snapshot API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,7 @@ from app.modules.gifts_router import router as gifts_router
 from app.modules.meal_plans_router import router as meal_plans_router
 from app.modules.recipes_router import router as recipes_router
 from app.modules.display_router import admin_router as display_admin_router, display_router as display_runtime_router
+from app.modules.mobile_router import router as mobile_router
 from app.core.scheduler import configure_backup_schedule, start_notification_job, start_scheduler, shutdown_scheduler
 from app.core import ws_broadcast
 from app.schemas import (
@@ -187,6 +188,7 @@ TAG_METADATA = [
     {"name": "meal_plans", "description": "Weekly meal planning across fixed morning/noon/evening slots. Available to all family members."},
     {"name": "recipes", "description": "Lightweight family recipe library connected to meal planning and shopping lists."},
     {"name": "display", "description": "Shared-home display devices: admin CRUD for tokens and a curated read-only dashboard authenticated by a per-device `tribu_display_` bearer token."},
+    {"name": "mobile", "description": "Mobile-client aggregate contracts for native app screens."},
     {"name": "health", "description": "Health check and service info."},
 ]
 
@@ -619,6 +621,7 @@ app.include_router(meal_plans_router)
 app.include_router(recipes_router)
 app.include_router(display_admin_router)
 app.include_router(display_runtime_router)
+app.include_router(mobile_router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/modules/mobile_router.py
+++ b/backend/app/modules/mobile_router.py
@@ -1,0 +1,273 @@
+"""Mobile-oriented aggregate endpoints.
+
+The native app work starts with backend contracts that are stable and small.
+This module keeps those contracts separate from the web dashboard so mobile
+clients do not need to stitch together screen-shaped web responses.
+"""
+
+from datetime import date, datetime, time, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.core.deps import current_user, ensure_family_membership
+from app.core.errors import error_detail, INSUFFICIENT_SCOPE
+from app.core.recurrence import expand_event
+from app.core.utils import utcnow
+from app.database import get_db
+from app.models import CalendarEvent, Membership, Notification, QuickCaptureItem, ShoppingItem, ShoppingList, Task, User
+from app.schemas import AUTH_RESPONSES
+
+
+router = APIRouter(prefix="/mobile", tags=["mobile"], responses={**AUTH_RESPONSES})
+
+MOBILE_DAILY_REQUIRED_SCOPES = {
+    "calendar:read",
+    "tasks:read",
+    "shopping:read",
+    "quick_capture:read",
+    "families:read",
+    "profile:read",
+}
+
+
+class MobileDailySync(BaseModel):
+    scope: str = Field("mobile_daily", description="Snapshot contract identifier")
+    generated_at: datetime = Field(..., description="Server timestamp when the snapshot was generated")
+
+
+class MobileDailyMember(BaseModel):
+    user_id: int
+    display_name: str
+    color: Optional[str] = None
+
+
+class MobileDailyAgendaEvent(BaseModel):
+    id: int
+    title: str
+    starts_at: datetime
+    ends_at: Optional[datetime] = None
+    all_day: bool = False
+    assigned_to: list[int] = Field(default_factory=list)
+    color: Optional[str] = None
+    category: Optional[str] = None
+    recurrence: Optional[str] = None
+
+
+class MobileDailyTask(BaseModel):
+    id: int
+    title: str
+    priority: str
+    due_date: datetime
+    due_state: str
+    assigned_to_user_id: Optional[int] = None
+
+
+class MobileDailyShoppingList(BaseModel):
+    id: int
+    name: str
+    item_count: int
+    checked_count: int
+    open_count: int
+
+
+class MobileDailyCount(BaseModel):
+    open_count: int = 0
+
+
+class MobileDailyNotificationCount(BaseModel):
+    unread_count: int = 0
+
+
+class MobileDailySnapshot(BaseModel):
+    family_id: int
+    date: date
+    server_time: datetime
+    sync: MobileDailySync
+    members: list[MobileDailyMember]
+    agenda: list[MobileDailyAgendaEvent]
+    tasks: list[MobileDailyTask]
+    shopping_lists: list[MobileDailyShoppingList]
+    quick_capture: MobileDailyCount
+    notifications: MobileDailyNotificationCount
+
+
+def require_mobile_daily_scopes(request: Request):
+    pat_scopes = getattr(request.state, "pat_scopes", None)
+    if pat_scopes is None or "*" in pat_scopes:
+        return
+    missing = sorted(MOBILE_DAILY_REQUIRED_SCOPES - set(pat_scopes))
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=error_detail(INSUFFICIENT_SCOPE, scope=",".join(missing)),
+        )
+
+
+def _day_bounds(snapshot_date: date) -> tuple[datetime, datetime]:
+    start = datetime.combine(snapshot_date, time.min)
+    return start, start + timedelta(days=1)
+
+
+def _event_overlaps_day(row: dict, start: datetime, end: datetime) -> bool:
+    starts_at = row["starts_at"]
+    ends_at = row.get("ends_at")
+    if starts_at >= end:
+        return False
+    if ends_at is None:
+        return starts_at >= start
+    return ends_at > start
+
+
+def _recurring_expansion_start(event: CalendarEvent, start: datetime) -> datetime:
+    if event.starts_at and event.ends_at and event.ends_at > event.starts_at:
+        return start - (event.ends_at - event.starts_at)
+    return start
+
+
+def _agenda_for_day(db: Session, family_id: int, start: datetime, end: datetime) -> list[MobileDailyAgendaEvent]:
+    non_recurring = (
+        db.query(CalendarEvent)
+        .filter(
+            CalendarEvent.family_id == family_id,
+            CalendarEvent.recurrence.is_(None),
+            CalendarEvent.starts_at < end,
+        )
+        .filter((CalendarEvent.ends_at > start) | (CalendarEvent.ends_at.is_(None) & (CalendarEvent.starts_at >= start)))
+        .all()
+    )
+    recurring = (
+        db.query(CalendarEvent)
+        .filter(
+            CalendarEvent.family_id == family_id,
+            CalendarEvent.recurrence.isnot(None),
+        )
+        .all()
+    )
+    occurrences: list[dict] = []
+    for event in non_recurring:
+        occurrences.extend(row for row in expand_event(event, start, end) if _event_overlaps_day(row, start, end))
+    for event in recurring:
+        expansion_start = _recurring_expansion_start(event, start)
+        occurrences.extend(row for row in expand_event(event, expansion_start, end) if _event_overlaps_day(row, start, end))
+    occurrences.sort(key=lambda row: row["starts_at"])
+    return [
+        MobileDailyAgendaEvent(
+            id=row["id"],
+            title=row["title"],
+            starts_at=row["starts_at"],
+            ends_at=row.get("ends_at"),
+            all_day=row.get("all_day") or False,
+            assigned_to=row.get("assigned_to") or [],
+            color=row.get("color"),
+            category=row.get("category"),
+            recurrence=row.get("recurrence"),
+        )
+        for row in occurrences
+    ]
+
+
+def _tasks_due_for_day(db: Session, family_id: int, start: datetime, end: datetime) -> list[MobileDailyTask]:
+    rows = (
+        db.query(Task)
+        .filter(
+            Task.family_id == family_id,
+            Task.status == "open",
+            Task.due_date.isnot(None),
+            Task.due_date < end,
+        )
+        .order_by(Task.due_date.asc(), Task.id.asc())
+        .all()
+    )
+    return [
+        MobileDailyTask(
+            id=task.id,
+            title=task.title,
+            priority=task.priority,
+            due_date=task.due_date,
+            due_state="overdue" if task.due_date < start else "today",
+            assigned_to_user_id=task.assigned_to_user_id,
+        )
+        for task in rows
+    ]
+
+
+def _shopping_summaries(db: Session, family_id: int) -> list[MobileDailyShoppingList]:
+    lists = db.query(ShoppingList).filter(ShoppingList.family_id == family_id).order_by(ShoppingList.created_at.asc(), ShoppingList.id.asc()).all()
+    summaries: list[MobileDailyShoppingList] = []
+    for shopping_list in lists:
+        items = db.query(ShoppingItem).filter(ShoppingItem.list_id == shopping_list.id).all()
+        item_count = len(items)
+        checked_count = sum(1 for item in items if item.checked)
+        summaries.append(MobileDailyShoppingList(
+            id=shopping_list.id,
+            name=shopping_list.name,
+            item_count=item_count,
+            checked_count=checked_count,
+            open_count=item_count - checked_count,
+        ))
+    return summaries
+
+
+@router.get(
+    "/daily",
+    response_model=MobileDailySnapshot,
+    summary="Get mobile daily snapshot",
+    description=(
+        "Return the family-scoped data a native mobile Today screen needs in one authenticated request. "
+        "Personal Access Tokens must include calendar, tasks, shopping, quick capture, families, and profile read scopes."
+    ),
+    response_description="Mobile daily snapshot",
+)
+def mobile_daily_snapshot(
+    family_id: int,
+    snapshot_date: date | None = Query(None, alias="date"),
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=Depends(require_mobile_daily_scopes),
+):
+    ensure_family_membership(db, user.id, family_id)
+    day = snapshot_date or date.today()
+    start, end = _day_bounds(day)
+
+    memberships = (
+        db.query(Membership)
+        .filter(Membership.family_id == family_id)
+        .join(User, User.id == Membership.user_id)
+        .order_by(User.display_name.asc(), User.id.asc())
+        .all()
+    )
+    members = [
+        MobileDailyMember(
+            user_id=membership.user.id,
+            display_name=membership.user.display_name,
+            color=membership.color,
+        )
+        for membership in memberships
+    ]
+
+    open_quick_capture = db.query(QuickCaptureItem).filter(
+        QuickCaptureItem.family_id == family_id,
+        QuickCaptureItem.status == "open",
+    ).count()
+    unread_notifications = db.query(Notification).filter(
+        Notification.family_id == family_id,
+        Notification.user_id == user.id,
+        Notification.read.is_(False),
+    ).count()
+    generated_at = utcnow()
+
+    return MobileDailySnapshot(
+        family_id=family_id,
+        date=day,
+        server_time=generated_at,
+        sync=MobileDailySync(generated_at=generated_at),
+        members=members,
+        agenda=_agenda_for_day(db, family_id, start, end),
+        tasks=_tasks_due_for_day(db, family_id, start, end),
+        shopping_lists=_shopping_summaries(db, family_id),
+        quick_capture=MobileDailyCount(open_count=open_quick_capture),
+        notifications=MobileDailyNotificationCount(unread_count=unread_notifications),
+    )

--- a/backend/tests/test_mobile_daily.py
+++ b/backend/tests/test_mobile_daily.py
@@ -1,0 +1,215 @@
+"""Mobile daily snapshot API tests."""
+
+import hashlib
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import (
+    CalendarEvent,
+    Family,
+    Membership,
+    Notification,
+    PersonalAccessToken,
+    QuickCaptureItem,
+    ShoppingItem,
+    ShoppingList,
+    Task,
+    User,
+)
+from app.security import PAT_PREFIX, hash_password
+
+
+engine = create_engine(
+    "sqlite:///./test-mobile-daily.db",
+    connect_args={"check_same_thread": False},
+)
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_member(scopes: str, suffix: str, *, family_id: int | None = None, role: str = "admin") -> tuple[str, int, int]:
+    db = TestSession()
+    user = User(
+        email=f"mobile-{suffix}@example.com",
+        password_hash=hash_password("Password123"),
+        display_name=f"Mobile {suffix}",
+    )
+    db.add(user)
+    db.flush()
+    if family_id is None:
+        family = Family(name=f"Mobile Family {suffix}")
+        db.add(family)
+        db.flush()
+        family_id = family.id
+    db.add(Membership(user_id=user.id, family_id=family_id, role=role, is_adult=True, color="#7c3aed"))
+    plain = f"{PAT_PREFIX}mobile-{suffix}-{scopes.replace(',', '-').replace(':', '_').replace('*', 'star')}"
+    lookup = hashlib.sha256(plain.encode()).hexdigest()
+    db.add(PersonalAccessToken(
+        user_id=user.id,
+        name="mobile-daily-pat",
+        token_hash=lookup,
+        token_lookup=lookup,
+        scopes=scopes,
+    ))
+    db.commit()
+    user_id = user.id
+    db.close()
+    return plain, family_id, user_id
+
+
+def test_mobile_daily_snapshot_collects_today_loop_without_secrets():
+    token, family_id, user_id = _seed_member("*", "owner")
+    _, _, child_user_id = _seed_member("*", "child", family_id=family_id, role="member")
+    target_day = datetime(2026, 5, 4, 9, 0, 0)
+
+    db = TestSession()
+    db.add_all([
+        CalendarEvent(
+            family_id=family_id,
+            title="Morning practice",
+            starts_at=datetime(2026, 5, 4, 8, 30, 0),
+            ends_at=datetime(2026, 5, 4, 9, 30, 0),
+            assigned_to=[child_user_id],
+            color="#7c3aed",
+            category="sports",
+            created_by_user_id=user_id,
+        ),
+        CalendarEvent(
+            family_id=family_id,
+            title="Daily medication",
+            starts_at=datetime(2026, 5, 1, 7, 0, 0),
+            ends_at=datetime(2026, 5, 1, 7, 15, 0),
+            recurrence="daily",
+            recurrence_end=datetime(2026, 5, 6, 0, 0, 0),
+            created_by_user_id=user_id,
+        ),
+        CalendarEvent(
+            family_id=family_id,
+            title="Ends at midnight",
+            starts_at=datetime(2026, 5, 3, 23, 0, 0),
+            ends_at=datetime(2026, 5, 4, 0, 0, 0),
+            created_by_user_id=user_id,
+        ),
+        CalendarEvent(
+            family_id=family_id,
+            title="Overnight recurring care",
+            starts_at=datetime(2026, 5, 1, 23, 30, 0),
+            ends_at=datetime(2026, 5, 2, 0, 30, 0),
+            recurrence="daily",
+            recurrence_end=datetime(2026, 5, 6, 0, 0, 0),
+            created_by_user_id=user_id,
+        ),
+        CalendarEvent(
+            family_id=family_id,
+            title="Tomorrow only",
+            starts_at=datetime(2026, 5, 5, 10, 0, 0),
+            ends_at=datetime(2026, 5, 5, 11, 0, 0),
+            created_by_user_id=user_id,
+        ),
+        Task(family_id=family_id, title="Pack bag", status="open", priority="high", due_date=datetime(2026, 5, 4, 18, 0, 0), assigned_to_user_id=child_user_id),
+        Task(family_id=family_id, title="Return library books", status="open", priority="normal", due_date=datetime(2026, 5, 3, 12, 0, 0)),
+        Task(family_id=family_id, title="Already done", status="done", priority="normal", due_date=target_day, completed_at=target_day),
+        Task(family_id=family_id, title="Later this week", status="open", priority="normal", due_date=datetime(2026, 5, 7, 12, 0, 0)),
+        QuickCaptureItem(family_id=family_id, text="Open note", status="open", created_by_user_id=user_id),
+        QuickCaptureItem(family_id=family_id, text="Done note", status="dismissed", created_by_user_id=user_id),
+        Notification(user_id=user_id, family_id=family_id, type="task", title="Unread", body="Task due", read=False),
+        Notification(user_id=user_id, family_id=family_id, type="task", title="Read", body="Done", read=True),
+    ])
+    shopping = ShoppingList(family_id=family_id, name="Groceries", created_by_user_id=user_id)
+    db.add(shopping)
+    db.flush()
+    db.add_all([
+        ShoppingItem(list_id=shopping.id, name="Milk", checked=False, position=1),
+        ShoppingItem(list_id=shopping.id, name="Bread", checked=True, position=2),
+    ])
+    db.commit()
+    shopping_id = shopping.id
+    db.close()
+
+    resp = client.get(f"/mobile/daily?family_id={family_id}&date=2026-05-04", headers=_auth(token))
+
+    assert resp.status_code == 200, resp.json()
+    data = resp.json()
+    assert data["family_id"] == family_id
+    assert data["date"] == "2026-05-04"
+    assert data["sync"]["scope"] == "mobile_daily"
+    assert {m["user_id"] for m in data["members"]} == {user_id, child_user_id}
+    assert [event["title"] for event in data["agenda"]] == ["Overnight recurring care", "Daily medication", "Morning practice", "Overnight recurring care"]
+    assert data["agenda"][0]["starts_at"].startswith("2026-05-03T23:30:00")
+    assert data["agenda"][1]["starts_at"].startswith("2026-05-04T07:00:00")
+    assert data["agenda"][3]["starts_at"].startswith("2026-05-04T23:30:00")
+    assert [task["title"] for task in data["tasks"]] == ["Return library books", "Pack bag"]
+    assert data["tasks"][0]["due_state"] == "overdue"
+    assert data["tasks"][1]["due_state"] == "today"
+    assert data["shopping_lists"] == [{
+        "id": shopping_id,
+        "name": "Groceries",
+        "item_count": 2,
+        "checked_count": 1,
+        "open_count": 1,
+    }]
+    assert data["quick_capture"]["open_count"] == 1
+    assert data["notifications"]["unread_count"] == 1
+    serialized = str(data).lower()
+    assert "token" not in serialized
+    assert "password" not in serialized
+    assert "display_device" not in serialized
+    assert "role" not in data["members"][0]
+    assert "is_adult" not in data["members"][0]
+
+
+def test_mobile_daily_enforces_family_scope_and_required_read_scopes():
+    owner_token, family_id, _ = _seed_member("*", "owner-scope")
+    intruder_token, _, _ = _seed_member("*", "intruder")
+    limited_token, limited_family_id, _ = _seed_member("calendar:read,tasks:read", "limited")
+
+    denied = client.get(f"/mobile/daily?family_id={family_id}&date=2026-05-04", headers=_auth(intruder_token))
+    assert denied.status_code == 403
+
+    limited = client.get(f"/mobile/daily?family_id={limited_family_id}&date=2026-05-04", headers=_auth(limited_token))
+    assert limited.status_code == 403
+
+    ok = client.get(f"/mobile/daily?family_id={family_id}&date=2026-05-04", headers=_auth(owner_token))
+    assert ok.status_code == 200, ok.json()
+    assert ok.json()["agenda"] == []
+    assert ok.json()["tasks"] == []
+    assert ok.json()["shopping_lists"] == []
+    assert ok.json()["quick_capture"]["open_count"] == 0
+    assert ok.json()["notifications"]["unread_count"] == 0


### PR DESCRIPTION
## Summary
- Add a new authenticated `GET /mobile/daily` aggregate endpoint for native mobile Today screens.
- Return a family-scoped snapshot with members, agenda, due tasks, shopping summaries, quick capture count, and unread notification count.
- Keep the mobile payload curated by excluding tokens, display-device data, and admin-only member metadata.

## Verification
- `DATABASE_URL=sqlite:///./test-mobile-daily.db JWT_SECRET=[REDACTED] uv run pytest tests/test_mobile_daily.py tests/test_quick_capture.py tests/test_notification_reliability.py tests/test_recurrence.py -q`
- `DATABASE_URL=sqlite:///./test-mobile-daily.db JWT_SECRET=[REDACTED] uv run pytest -q`
- `DATABASE_URL=sqlite:///./test-mobile-daily.db JWT_SECRET=[REDACTED] uv run ruff check app/modules/mobile_router.py tests/test_mobile_daily.py`
- `git diff --check`

Closes #255
