### PR TITLE
Reuse checked shopping items on quick add

### DIFF
--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -42,6 +42,35 @@ from app.core.errors import (
 router = APIRouter(prefix="/shopping", tags=["shopping"], responses={**AUTH_RESPONSES})
 
 
+def _clean_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _capitalize_first(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        return cleaned
+    return f"{cleaned[:1].upper()}{cleaned[1:]}"
+
+
+def _normalize_item_name(value: str) -> str:
+    item_name = _capitalize_first(value)
+    if not item_name:
+        raise HTTPException(status_code=422, detail="Shopping item name cannot be blank")
+    return item_name
+
+
+def _same_item_name(left: str, right: str) -> bool:
+    return left.strip().casefold() == right.strip().casefold()
+
+
+def _same_optional_text(left: str | None, right: str | None) -> bool:
+    return _clean_optional_text(left) == _clean_optional_text(right)
+
+
 def _list_response(sl: ShoppingList) -> ShoppingListResponse:
     total = len(sl.items)
     checked = sum(1 for i in sl.items if i.checked)
@@ -371,11 +400,37 @@ def add_item(
     if not sl:
         raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
     ensure_adult(db, user.id, sl.family_id)
+    item_name = _normalize_item_name(payload.name)
+    item_spec = _clean_optional_text(payload.spec)
+    item_category = _clean_optional_text(payload.category)
+    checked_match = next(
+        (
+            existing
+            for existing in sl.items
+            if existing.checked
+            and _same_item_name(existing.name, item_name)
+            and _same_optional_text(existing.spec, item_spec)
+            and _same_optional_text(existing.category, item_category)
+        ),
+        None,
+    )
+    if checked_match:
+        checked_match.name = item_name
+        checked_match.spec = item_spec
+        checked_match.category = item_category
+        checked_match.checked = False
+        checked_match.checked_at = None
+        db.commit()
+        db.refresh(checked_match)
+        resp = ShoppingItemResponse.model_validate(checked_match).model_dump(mode="json")
+        broadcast_item_updated(list_id, resp)
+        return checked_match
+
     item = ShoppingItem(
         list_id=list_id,
-        name=payload.name,
-        spec=payload.spec,
-        category=payload.category,
+        name=item_name,
+        spec=item_spec,
+        category=item_category,
         added_by_user_id=user.id,
     )
     db.add(item)
@@ -424,11 +479,11 @@ def update_item(
             raise HTTPException(status_code=403, detail=error_detail(ADULT_REQUIRED))
 
     if payload.name is not None:
-        item.name = payload.name
+        item.name = _normalize_item_name(payload.name)
     if payload.spec is not None:
-        item.spec = payload.spec
+        item.spec = _clean_optional_text(payload.spec)
     if payload.category is not None:
-        item.category = payload.category
+        item.category = _clean_optional_text(payload.category)
     if payload.checked is not None:
         was_checked = item.checked
         item.checked = payload.checked
@@ -496,7 +551,7 @@ def clear_checked(
     ensure_adult(db, user.id, sl.family_id)
     deleted = db.query(ShoppingItem).filter(
         ShoppingItem.list_id == list_id,
-        ShoppingItem.checked == True,
+        ShoppingItem.checked,
     ).delete(synchronize_session="fetch")
     db.commit()
     broadcast_items_cleared(list_id, deleted)

--- a/backend/tests/test_shopping_item_reuse.py
+++ b/backend/tests/test_shopping_item_reuse.py
@@ -1,0 +1,197 @@
+"""Regression tests for shopping item reuse and name normalization."""
+
+import hashlib
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.core.utils import utcnow
+from app.database import Base, get_db
+from app.main import app
+from app.models import Family, Membership, PersonalAccessToken, ShoppingItem, ShoppingList, User
+from app.security import PAT_PREFIX, hash_password
+
+
+engine = create_engine(
+    "sqlite:///./test-shopping-item-reuse.db",
+    connect_args={"check_same_thread": False},
+)
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_owner() -> tuple[str, int, int]:
+    db = TestSession()
+    user = User(
+        email="shopping-reuse-owner@example.com",
+        password_hash=hash_password("Password1"),
+        display_name="Shopping Owner",
+    )
+    db.add(user)
+    db.flush()
+    family = Family(name="Shopping Reuse Family")
+    db.add(family)
+    db.flush()
+    db.add(Membership(user_id=user.id, family_id=family.id, role="admin", is_adult=True))
+    shopping_list = ShoppingList(family_id=family.id, name="Groceries", created_by_user_id=user.id)
+    db.add(shopping_list)
+    plain = f"{PAT_PREFIX}shopping-reuse-owner"
+    fingerprint = hashlib.sha256(plain.encode()).hexdigest()
+    db.add(PersonalAccessToken(
+        user_id=user.id,
+        name="shopping-reuse-pat",
+        token_hash=fingerprint,
+        token_lookup=fingerprint,
+        scopes="shopping:read,shopping:write",
+    ))
+    db.commit()
+    list_id = shopping_list.id
+    family_id = family.id
+    db.close()
+    return plain, family_id, list_id
+
+
+def test_add_item_reactivates_checked_match_without_creating_duplicate():
+    token, _family_id, list_id = _seed_owner()
+    db = TestSession()
+    checked_item = ShoppingItem(
+        list_id=list_id,
+        name="Milk",
+        spec=None,
+        checked=True,
+        checked_at=utcnow(),
+    )
+    db.add(checked_item)
+    db.commit()
+    existing_id = checked_item.id
+    db.close()
+
+    response = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "  milk  "},
+        headers=_auth(token),
+    )
+
+    assert response.status_code == 200, response.json()
+    assert response.json()["id"] == existing_id
+    assert response.json()["name"] == "Milk"
+    assert response.json()["checked"] is False
+    assert response.json()["checked_at"] is None
+
+    items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token))
+    assert items.status_code == 200
+    assert [(item["id"], item["name"], item["checked"]) for item in items.json()] == [
+        (existing_id, "Milk", False),
+    ]
+
+
+def test_add_item_keeps_separate_rows_when_details_differ_and_capitalizes_names():
+    token, _family_id, list_id = _seed_owner()
+    db = TestSession()
+    checked_item = ShoppingItem(
+        list_id=list_id,
+        name="Milk",
+        spec="1 L",
+        checked=True,
+        checked_at=utcnow(),
+    )
+    db.add(checked_item)
+    db.commit()
+    existing_id = checked_item.id
+    db.close()
+
+    response = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "milk", "spec": "2 L"},
+        headers=_auth(token),
+    )
+
+    assert response.status_code == 200, response.json()
+    assert response.json()["id"] != existing_id
+    assert response.json()["name"] == "Milk"
+    assert response.json()["spec"] == "2 L"
+    assert response.json()["checked"] is False
+
+    items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token))
+    assert items.status_code == 200
+    assert [(item["name"], item["spec"], item["checked"]) for item in items.json()] == [
+        ("Milk", "2 L", False),
+        ("Milk", "1 L", True),
+    ]
+
+
+def test_update_item_capitalizes_name():
+    token, _family_id, list_id = _seed_owner()
+    created = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "bread"},
+        headers=_auth(token),
+    )
+    assert created.status_code == 200, created.json()
+
+    updated = client.patch(
+        f"/shopping/items/{created.json()['id']}",
+        json={"name": "butter"},
+        headers=_auth(token),
+    )
+
+    assert updated.status_code == 200, updated.json()
+    assert updated.json()["name"] == "Butter"
+
+
+def test_blank_after_trim_names_are_rejected():
+    token, _family_id, list_id = _seed_owner()
+
+    created = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "   "},
+        headers=_auth(token),
+    )
+    assert created.status_code == 422
+
+    valid = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "bread"},
+        headers=_auth(token),
+    )
+    assert valid.status_code == 200, valid.json()
+
+    updated = client.patch(
+        f"/shopping/items/{valid.json()['id']}",
+        json={"name": "   "},
+        headers=_auth(token),
+    )
+    assert updated.status_code == 422

--- a/frontend/__tests__/components/ShoppingView.test.js
+++ b/frontend/__tests__/components/ShoppingView.test.js
@@ -93,6 +93,25 @@ function setup(overrides = {}) {
   return render(<ShoppingView />);
 }
 
+describe('ShoppingView quick add', () => {
+  test('offers checked items as quick-add suggestions', () => {
+    setup({
+      items: [
+        { id: 1, name: 'Milk', spec: null, checked: true },
+        { id: 2, name: 'Bread', spec: null, checked: false },
+        { id: 3, name: 'Milk', spec: null, checked: false },
+      ],
+      checkedItems: [{ id: 1, name: 'Milk', spec: null, checked: true }],
+      uncheckedItems: [{ id: 2, name: 'Bread', spec: null, checked: false }, { id: 3, name: 'Milk', spec: null, checked: false }],
+    });
+
+    const input = screen.getByPlaceholderText('Add an item...');
+    expect(input).toHaveAttribute('list', 'shopping-item-suggestions');
+    const options = Array.from(document.querySelectorAll('#shopping-item-suggestions option')).map((option) => option.value);
+    expect(options).toEqual(['Bread', 'Milk']);
+  });
+});
+
 describe('ShoppingView templates', () => {
   test('renders saved templates and can apply one to the active list', () => {
     setup();

--- a/frontend/__tests__/hooks/useShoppingHelpers.test.js
+++ b/frontend/__tests__/hooks/useShoppingHelpers.test.js
@@ -1,0 +1,21 @@
+import { findReusableCheckedItem, formatShoppingItemName } from '../../hooks/useShopping';
+
+describe('shopping item helpers', () => {
+  test('capitalizes the first product name letter and trims whitespace', () => {
+    expect(formatShoppingItemName('  milch  ')).toBe('Milch');
+    expect(formatShoppingItemName('Äpfel')).toBe('Äpfel');
+  });
+
+  test('finds a reusable checked item by normalized name and matching details', () => {
+    const items = [
+      { id: 1, name: 'Milch', spec: null, category: null, checked: true },
+      { id: 2, name: 'Milch', spec: '2 L', category: null, checked: true },
+      { id: 3, name: 'Brot', spec: null, category: null, checked: false },
+    ];
+
+    expect(findReusableCheckedItem(items, { name: ' milch ', spec: '', category: null })).toEqual(items[0]);
+    expect(findReusableCheckedItem(items, { name: 'milch', spec: '2 L', category: null })).toEqual(items[1]);
+    expect(findReusableCheckedItem(items, { name: 'brot', spec: null, category: null })).toBeNull();
+    expect(findReusableCheckedItem(items, { name: 'milch', spec: '1 L', category: null })).toBeNull();
+  });
+});

--- a/frontend/components/ShoppingView.js
+++ b/frontend/components/ShoppingView.js
@@ -205,6 +205,7 @@ export default function ShoppingView() {
   const [confirmAction, setConfirmAction] = useState(null);
   const [showTemplateForm, setShowTemplateForm] = useState(false);
   const [editingTemplate, setEditingTemplate] = useState(null);
+  const itemSuggestions = Array.from(new Set((sh.items || []).map((item) => item.name).filter(Boolean))).sort((a, b) => a.localeCompare(b));
 
   function openTemplateForm(template = null) {
     setEditingTemplate(template);
@@ -370,8 +371,12 @@ export default function ShoppingView() {
                     value={sh.newItemName}
                     onChange={(e) => sh.setNewItemName(e.target.value)}
                     onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); sh.itemInputRef.current?.form?.requestSubmit(); } }}
+                    list="shopping-item-suggestions"
                     required
                   />
+                  <datalist id="shopping-item-suggestions">
+                    {itemSuggestions.map((name) => <option key={name} value={name}>{name}</option>)}
+                  </datalist>
                   <input
                     className="quick-add-input shopping-spec-input"
                     placeholder={t(messages, 'module.shopping.item_spec_placeholder')}

--- a/frontend/e2e/tests/meal-plans.spec.js
+++ b/frontend/e2e/tests/meal-plans.spec.js
@@ -70,11 +70,11 @@ test.describe('Meal plan', () => {
 
       await expect(page.getByText('Weekly Groceries')).toBeVisible({ timeout: 90000 });
       await page.locator('.shopping-list-card', { hasText: 'Weekly Groceries' }).click();
-      await expect(page.getByText('Flour')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByRole('checkbox', { name: 'Flour' })).toBeVisible({ timeout: 30000 });
       await expect(page.getByText('750 g')).toBeVisible({ timeout: 30000 });
-      await expect(page.getByText('Milk')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByRole('checkbox', { name: 'Milk' })).toBeVisible({ timeout: 30000 });
       await expect(page.getByText('1 l')).toBeVisible({ timeout: 30000 });
-      await expect(page.getByText('Basil')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByRole('checkbox', { name: 'Basil' })).toBeVisible({ timeout: 30000 });
     } finally {
       await workerUser.api.dispose();
     }

--- a/frontend/e2e/tests/recipes.spec.js
+++ b/frontend/e2e/tests/recipes.spec.js
@@ -67,8 +67,8 @@ test.describe('Recipes', () => {
 
     await navigateTo(page, 'Shopping');
     await page.getByText('Recipe Shopping List').click();
-    await expect(page.getByText('Flour')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('Milk')).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: 'Flour' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('checkbox', { name: 'Milk' })).toBeVisible();
 
     await navigateTo(page, 'Meal plan');
     await page.getByRole('button', { name: 'Plan a meal' }).click();

--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -29,8 +29,33 @@ test.describe('Shopping', () => {
     await page.locator('.shopping-spec-input').fill('whole wheat');
     await page.locator('[aria-label="Add item"]').click();
 
-    await expect(page.getByText('Bread')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[role="checkbox"][aria-label="Bread"]')).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('whole wheat')).toBeVisible();
+  });
+
+  test('reactivates checked items and normalizes quick-add names', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    const list = await seedShoppingList(apiCtx, familyId, 'Reuse Checked List');
+    const milk = await seedShoppingItem(apiCtx, list.id, 'Milk');
+    await apiCtx.patch(`/api/shopping/items/${milk.id}`, { data: { checked: true } });
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
+    await navigateTo(page, 'Shopping');
+
+    await page.getByText('Reuse Checked List').click();
+    await expect(page.locator('[role="checkbox"][aria-label="Milk"]')).toHaveAttribute('aria-checked', 'true', { timeout: 10000 });
+
+    await page.locator('input[placeholder="Add an item..."]').fill('milch');
+    await page.locator('[aria-label="Add item"]').click();
+    await expect(page.locator('[role="checkbox"][aria-label="Milch"]')).toHaveAttribute('aria-checked', 'false', { timeout: 10000 });
+
+    await page.locator('input[placeholder="Add an item..."]').fill('milk');
+    await page.locator('[aria-label="Add item"]').click();
+    const milkRows = page.locator('[role="checkbox"][aria-label="Milk"]');
+    await expect(milkRows).toHaveCount(1, { timeout: 10000 });
+    await expect(milkRows.first()).toHaveAttribute('aria-checked', 'false');
   });
 
   test('toggle an item checked / unchecked', async ({ authedPage: page, apiCtx }) => {

--- a/frontend/hooks/useShopping.js
+++ b/frontend/hooks/useShopping.js
@@ -5,6 +5,38 @@ import { t } from '../lib/i18n';
 import * as api from '../lib/api';
 import { useWebSocket } from './useWebSocket';
 
+export function formatShoppingItemName(value) {
+  const cleaned = value.trim();
+  if (!cleaned) return cleaned;
+  return `${cleaned.charAt(0).toUpperCase()}${cleaned.slice(1)}`;
+}
+
+function cleanOptionalText(value) {
+  if (value == null) return null;
+  const cleaned = String(value).trim();
+  return cleaned || null;
+}
+
+function sameItemName(left, right) {
+  return left.trim().toLocaleLowerCase() === right.trim().toLocaleLowerCase();
+}
+
+function sameOptionalText(left, right) {
+  return cleanOptionalText(left) === cleanOptionalText(right);
+}
+
+export function findReusableCheckedItem(items, payload) {
+  const itemName = formatShoppingItemName(payload.name);
+  const itemSpec = cleanOptionalText(payload.spec);
+  const itemCategory = cleanOptionalText(payload.category);
+  return items.find((item) => (
+    item.checked
+    && sameItemName(item.name, itemName)
+    && sameOptionalText(item.spec, itemSpec)
+    && sameOptionalText(item.category, itemCategory)
+  )) || null;
+}
+
 export function useShopping() {
   const {
     shoppingLists, setShoppingLists, familyId, messages,
@@ -177,24 +209,43 @@ export function useShopping() {
   async function addItem(e) {
     e.preventDefault();
     if (!newItemName.trim() || !activeListId) return;
-    const payload = { name: newItemName.trim(), spec: newItemSpec.trim() || null };
+    const payload = { name: formatShoppingItemName(newItemName), spec: cleanOptionalText(newItemSpec) };
+    const reusableCheckedItem = findReusableCheckedItem(items, payload);
     if (demoMode) {
-      const newItem = {
-        id: Date.now(),
-        list_id: activeListId,
-        ...payload,
-        checked: false,
-        checked_at: null,
-        added_by_user_id: 1,
-        created_at: new Date().toISOString(),
-      };
-      setItems((prev) => [...prev, newItem]);
-      setShoppingLists((prev) =>
-        prev.map((l) => l.id === activeListId
-          ? { ...l, item_count: l.item_count + 1, items: [...(l.items || []), newItem] }
-          : l
-        ),
-      );
+      if (reusableCheckedItem) {
+        setItems((prev) => prev.map((item) => item.id === reusableCheckedItem.id
+          ? { ...item, ...payload, checked: false, checked_at: null }
+          : item));
+        setShoppingLists((prev) =>
+          prev.map((l) => l.id === activeListId
+            ? {
+                ...l,
+                checked_count: Math.max((l.checked_count || 0) - 1, 0),
+                items: (l.items || []).map((item) => item.id === reusableCheckedItem.id
+                  ? { ...item, ...payload, checked: false, checked_at: null }
+                  : item),
+              }
+            : l
+          ),
+        );
+      } else {
+        const newItem = {
+          id: Date.now(),
+          list_id: activeListId,
+          ...payload,
+          checked: false,
+          checked_at: null,
+          added_by_user_id: 1,
+          created_at: new Date().toISOString(),
+        };
+        setItems((prev) => [...prev, newItem]);
+        setShoppingLists((prev) =>
+          prev.map((l) => l.id === activeListId
+            ? { ...l, item_count: l.item_count + 1, items: [...(l.items || []), newItem] }
+            : l
+          ),
+        );
+      }
     } else {
       const { ok } = await api.apiAddShoppingItem(activeListId, payload);
       if (!ok) {


### PR DESCRIPTION
## Summary
- Reuse a matching checked shopping item when it is added again, instead of creating a duplicate open row
- Normalize quick-added shopping item names so the first letter is uppercase
- Add quick-add suggestions from existing list items, including checked items

## Test plan
- Backend: `uv run pytest tests/test_shopping_item_reuse.py tests/test_shopping_templates.py -q`
- Backend lint: `uv run ruff check app/modules/shopping_router.py tests/test_shopping_item_reuse.py`
- Frontend: `npm test -- --runInBand __tests__/hooks/useShoppingHelpers.test.js __tests__/components/ShoppingView.test.js`
- Frontend build: `npm run build`
- Playwright: `npx playwright test --list e2e/tests/shopping.spec.js`
- Playwright: `npx playwright test e2e/tests/shopping.spec.js --reporter=list`

Closes #259
