### PR TITLE
Add outbound automation webhooks

### DIFF
--- a/backend/alembic/versions/0044_add_webhooks.py
+++ b/backend/alembic/versions/0044_add_webhooks.py
@@ -1,0 +1,72 @@
+"""add webhooks
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-04-29 23:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0044"
+down_revision: Union[str, None] = "0043"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "webhook_endpoints",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("family_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.Column("events", sa.JSON(), server_default="[]", nullable=False),
+        sa.Column("active", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("secret_header_name", sa.String(length=80), nullable=True),
+        sa.Column("secret_header_value", sa.Text(), nullable=True),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_webhook_endpoints_family_active", "webhook_endpoints", ["family_id", "active"], unique=False)
+    op.create_index("ix_webhook_endpoints_family_id", "webhook_endpoints", ["family_id"], unique=False)
+    op.create_index("ix_webhook_endpoints_id", "webhook_endpoints", ["id"], unique=False)
+
+    op.create_table(
+        "webhook_deliveries",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("endpoint_id", sa.Integer(), nullable=False),
+        sa.Column("family_id", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=80), nullable=False),
+        sa.Column("status", sa.String(length=20), server_default="pending", nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=True),
+        sa.Column("error", sa.String(length=240), nullable=True),
+        sa.Column("attempted_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["endpoint_id"], ["webhook_endpoints.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_webhook_deliveries_endpoint_created", "webhook_deliveries", ["endpoint_id", "created_at"], unique=False)
+    op.create_index("ix_webhook_deliveries_endpoint_id", "webhook_deliveries", ["endpoint_id"], unique=False)
+    op.create_index("ix_webhook_deliveries_family_id", "webhook_deliveries", ["family_id"], unique=False)
+    op.create_index("ix_webhook_deliveries_id", "webhook_deliveries", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_webhook_deliveries_id", table_name="webhook_deliveries")
+    op.drop_index("ix_webhook_deliveries_family_id", table_name="webhook_deliveries")
+    op.drop_index("ix_webhook_deliveries_endpoint_id", table_name="webhook_deliveries")
+    op.drop_index("ix_webhook_deliveries_endpoint_created", table_name="webhook_deliveries")
+    op.drop_table("webhook_deliveries")
+    op.drop_index("ix_webhook_endpoints_id", table_name="webhook_endpoints")
+    op.drop_index("ix_webhook_endpoints_family_id", table_name="webhook_endpoints")
+    op.drop_index("ix_webhook_endpoints_family_active", table_name="webhook_endpoints")
+    op.drop_table("webhook_endpoints")

--- a/backend/app/core/scopes.py
+++ b/backend/app/core/scopes.py
@@ -32,8 +32,8 @@ SCOPE_DESCRIPTIONS: dict[str, str] = {
     "meal_plans:write": "Create, update, and delete meal plan entries; push ingredients to shopping lists",
     "recipes:read": "View family recipes",
     "recipes:write": "Create, update, and delete recipes; push recipe ingredients to shopping lists",
-    "admin:read": "View backup config, admin settings, and system status",
-    "admin:write": "Manage backups, update admin settings, and trigger system operations",
+    "admin:read": "View backup config, admin settings, automation webhooks, and system status",
+    "admin:write": "Manage backups, automation webhooks, admin settings, and trigger system operations",
 }
 
 VALID_SCOPES = set(SCOPE_DESCRIPTIONS.keys())

--- a/backend/app/core/webhooks.py
+++ b/backend/app/core/webhooks.py
@@ -1,0 +1,112 @@
+"""Outbound webhook delivery helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.core.utils import utcnow
+from app.models import WebhookDelivery, WebhookEndpoint
+
+WEBHOOK_TIMEOUT_SECONDS = 3.0
+REDACTED_URL = "[redacted]"
+
+
+def redact_webhook_url(url: str) -> str:
+    """Return a URL that is useful for diagnostics without leaking query secrets."""
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return REDACTED_URL
+    if not parsed.scheme or not parsed.netloc:
+        return REDACTED_URL
+    return urlunsplit((parsed.scheme, parsed.netloc, "/[redacted]", "", ""))
+
+
+def endpoint_response(endpoint: WebhookEndpoint) -> dict[str, Any]:
+    return {
+        "id": endpoint.id,
+        "family_id": endpoint.family_id,
+        "name": endpoint.name,
+        "url_redacted": redact_webhook_url(endpoint.url),
+        "events": endpoint.events or [],
+        "active": endpoint.active,
+        "secret_header_name": endpoint.secret_header_name,
+        "has_secret": bool(endpoint.secret_header_value),
+        "created_at": endpoint.created_at,
+        "updated_at": endpoint.updated_at,
+    }
+
+
+def _delivery_payload(*, family_id: int, event_type: str, data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source": "tribu",
+        "event_type": event_type,
+        "family_id": family_id,
+        "occurred_at": utcnow().isoformat(),
+        "data": data,
+    }
+
+
+def deliver_to_endpoint(
+    db: Session,
+    endpoint: WebhookEndpoint,
+    *,
+    event_type: str,
+    data: dict[str, Any],
+) -> WebhookDelivery:
+    """Deliver one webhook synchronously and persist redacted status metadata."""
+    delivery = WebhookDelivery(
+        endpoint_id=endpoint.id,
+        family_id=endpoint.family_id,
+        event_type=event_type,
+        status="pending",
+    )
+    db.add(delivery)
+    db.flush()
+
+    headers = {"Content-Type": "application/json", "User-Agent": "Tribu-Webhooks/1.0"}
+    if endpoint.secret_header_name and endpoint.secret_header_value:
+        headers[endpoint.secret_header_name] = endpoint.secret_header_value
+
+    try:
+        response = httpx.post(
+            endpoint.url,
+            json=_delivery_payload(family_id=endpoint.family_id, event_type=event_type, data=data),
+            headers=headers,
+            timeout=WEBHOOK_TIMEOUT_SECONDS,
+            follow_redirects=False,
+        )
+        delivery.status_code = response.status_code
+        delivery.status = "delivered" if 200 <= response.status_code < 300 else "failed"
+        if delivery.status == "failed":
+            delivery.error = f"HTTP {response.status_code}"
+    except httpx.HTTPError as exc:
+        delivery.status = "failed"
+        delivery.error = exc.__class__.__name__
+    except Exception as exc:  # pragma: no cover - defensive guard around network delivery
+        delivery.status = "failed"
+        delivery.error = exc.__class__.__name__
+    delivery.attempted_at = utcnow()
+    db.commit()
+    db.refresh(delivery)
+    return delivery
+
+
+def dispatch_webhook_event(db: Session, *, family_id: int, event_type: str, data: dict[str, Any]) -> list[WebhookDelivery]:
+    """Send an event to all active endpoints subscribed to the event type."""
+    endpoints = (
+        db.query(WebhookEndpoint)
+        .filter(WebhookEndpoint.family_id == family_id, WebhookEndpoint.active.is_(True))
+        .all()
+    )
+    deliveries: list[WebhookDelivery] = []
+    for endpoint in endpoints:
+        events = endpoint.events or []
+        if event_type not in events:
+            continue
+        deliveries.append(deliver_to_endpoint(db, endpoint, event_type=event_type, data=data))
+    return deliveries

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from app.core.compat import patch_asyncio_iscoroutinefunction
 from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.orm import Session
@@ -57,6 +58,7 @@ from app.modules.meal_plans_router import router as meal_plans_router
 from app.modules.recipes_router import router as recipes_router
 from app.modules.display_router import admin_router as display_admin_router, display_router as display_runtime_router
 from app.modules.mobile_router import router as mobile_router
+from app.modules.webhooks_router import router as webhooks_router
 from app.core.scheduler import configure_backup_schedule, start_notification_job, start_scheduler, shutdown_scheduler
 from app.core import ws_broadcast
 from app.schemas import (
@@ -238,6 +240,32 @@ app = FastAPI(
 )
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+
+def _redact_validation_errors(value):
+    if isinstance(value, BaseException):
+        return str(value)
+    if isinstance(value, list):
+        return [_redact_validation_errors(item) for item in value]
+    if isinstance(value, dict):
+        sensitive_input = any(part in {"url", "secret_header_value"} for part in value.get("loc", []))
+        redacted = {}
+        for key, item in value.items():
+            if key == "input" and sensitive_input:
+                redacted[key] = "[redacted]"
+            elif key == "input" and isinstance(item, str) and "://" in item:
+                redacted[key] = "[redacted]"
+            else:
+                redacted[key] = _redact_validation_errors(item)
+        return redacted
+    return value
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(_request: Request, exc: RequestValidationError):
+    return JSONResponse(status_code=422, content={"detail": _redact_validation_errors(exc.errors())})
+
+
 app.add_middleware(SlowAPIMiddleware)
 
 app.add_middleware(
@@ -622,6 +650,7 @@ app.include_router(recipes_router)
 app.include_router(display_admin_router)
 app.include_router(display_runtime_router)
 app.include_router(mobile_router)
+app.include_router(webhooks_router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -48,6 +48,7 @@ class Family(Base):
     household_activities = relationship("HouseholdActivity", back_populates="family", cascade="all, delete-orphan")
     quick_capture_items = relationship("QuickCaptureItem", back_populates="family", cascade="all, delete-orphan")
     setup_checklist = relationship("FamilySetupChecklist", back_populates="family", uselist=False, cascade="all, delete-orphan")
+    webhook_endpoints = relationship("WebhookEndpoint", back_populates="family", cascade="all, delete-orphan")
 
 
 class Membership(Base):
@@ -594,6 +595,44 @@ class SystemSetting(Base):
     key = Column(String, primary_key=True)
     value = Column(Text, nullable=False)
     updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+
+
+class WebhookEndpoint(Base):
+    __tablename__ = "webhook_endpoints"
+    __table_args__ = (Index("ix_webhook_endpoints_family_active", "family_id", "active"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String(120), nullable=False)
+    url = Column(Text, nullable=False)
+    events = Column(JSON, nullable=False, default=list, server_default="[]")
+    active = Column(Boolean, nullable=False, default=True, server_default="true")
+    secret_header_name = Column(String(80), nullable=True)
+    secret_header_value = Column(Text, nullable=True)
+    created_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=utcnow, onupdate=utcnow, server_default=func.now())
+
+    family = relationship("Family", back_populates="webhook_endpoints")
+    created_by = relationship("User")
+    deliveries = relationship("WebhookDelivery", back_populates="endpoint", cascade="all, delete-orphan")
+
+
+class WebhookDelivery(Base):
+    __tablename__ = "webhook_deliveries"
+    __table_args__ = (Index("ix_webhook_deliveries_endpoint_created", "endpoint_id", "created_at"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    endpoint_id = Column(Integer, ForeignKey("webhook_endpoints.id", ondelete="CASCADE"), nullable=False, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    event_type = Column(String(80), nullable=False)
+    status = Column(String(20), nullable=False, default="pending", server_default="pending")
+    status_code = Column(Integer, nullable=True)
+    error = Column(String(240), nullable=True)
+    attempted_at = Column(DateTime, nullable=False, server_default=func.now())
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    endpoint = relationship("WebhookEndpoint", back_populates="deliveries")
 
 
 # ── Reward System ─────────────────────────────────────────

--- a/backend/app/modules/birthdays_router.py
+++ b/backend/app/modules/birthdays_router.py
@@ -5,6 +5,7 @@ from app.core import cache
 from app.core.clock import utcnow
 from app.core.deps import current_user, ensure_family_membership
 from app.core.scopes import require_scope
+from app.core.webhooks import dispatch_webhook_event
 from app.database import get_db
 from app.models import FamilyBirthday, User
 from app.schemas import AUTH_RESPONSES, CRUD_RESPONSES, BirthdayCreate, BirthdayUpdate, BirthdayResponse
@@ -72,6 +73,12 @@ def create_birthday(
     db.commit()
     db.refresh(birthday)
     cache.invalidate_pattern(f"tribu:dashboard:{payload.family_id}:*")
+    dispatch_webhook_event(
+        db,
+        family_id=birthday.family_id,
+        event_type="birthday.created",
+        data={"birthday_id": birthday.id, "person_name": birthday.person_name, "month": birthday.month, "day": birthday.day},
+    )
     return birthday
 
 

--- a/backend/app/modules/calendar_router.py
+++ b/backend/app/modules/calendar_router.py
@@ -17,6 +17,7 @@ from app.core.deps import current_user, current_user_via_token_param, ensure_adu
 from app.core.ics_utils import events_to_ics, ics_to_event_dicts
 from app.core.recurrence import VALID_RECURRENCES, expand_event
 from app.core.scopes import require_scope
+from app.core.webhooks import dispatch_webhook_event
 from app.database import get_db
 from app.models import CalendarEvent, CalendarSubscription, CalendarSubscriptionSync, Membership, Notification, User
 from app.schemas import AUTH_RESPONSES, NOT_FOUND_RESPONSE, CalendarEventCreate, CalendarEventResponse, CalendarEventUpdate, CalendarIcsImport, CalendarIcsSubscribe, CalendarSubscriptionCreate, CalendarSubscriptionResponse, PaginatedCalendarEvents
@@ -740,6 +741,12 @@ def create_calendar_event(
     db.commit()
     db.refresh(event)
     cache.invalidate_pattern(f"tribu:dashboard:{payload.family_id}:*")
+    dispatch_webhook_event(
+        db,
+        family_id=event.family_id,
+        event_type="calendar.event.created",
+        data={"event_id": event.id, "title": event.title, "starts_at": event.starts_at.isoformat(), "all_day": event.all_day},
+    )
     return event
 
 

--- a/backend/app/modules/quick_capture_router.py
+++ b/backend/app/modules/quick_capture_router.py
@@ -7,6 +7,7 @@ from app.core.activity import record_activity
 from app.core.deps import current_user, ensure_adult
 from app.core.errors import error_detail
 from app.core.scopes import require_scope
+from app.core.webhooks import dispatch_webhook_event
 from app.database import get_db
 from app.models import QuickCaptureItem, ShoppingItem, ShoppingList, Task, User
 from app.schemas import (
@@ -135,12 +136,24 @@ def create_quick_capture(
         task = _create_task(db, family_id=payload.family_id, user=user, text=text)
         db.commit()
         db.refresh(task)
+        dispatch_webhook_event(
+            db,
+            family_id=payload.family_id,
+            event_type="task.created",
+            data={"task_id": task.id, "title": task.title, "status": task.status, "source": "quick_capture"},
+        )
         return _created_payload(payload.destination, task)
 
     if payload.destination == QuickCaptureDestination.shopping:
         item = _create_shopping_item(db, family_id=payload.family_id, user=user, text=text)
         db.commit()
         db.refresh(item)
+        dispatch_webhook_event(
+            db,
+            family_id=payload.family_id,
+            event_type="shopping.item.created",
+            data={"list_id": item.list_id, "item_id": item.id, "name": item.name, "source": "quick_capture"},
+        )
         return _created_payload(payload.destination, item)
 
     item = QuickCaptureItem(
@@ -151,6 +164,12 @@ def create_quick_capture(
     db.add(item)
     db.commit()
     db.refresh(item)
+    dispatch_webhook_event(
+        db,
+        family_id=payload.family_id,
+        event_type="quick_capture.created",
+        data={"quick_capture_id": item.id, "status": item.status},
+    )
     return QuickCaptureResponse(destination=QuickCaptureDestination.inbox, inbox_item=item)
 
 

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -17,6 +17,7 @@ from app.core.ws_broadcast import (
     broadcast_list_created,
     broadcast_list_deleted,
 )
+from app.core.webhooks import dispatch_webhook_event
 from app.schemas import (
     AUTH_RESPONSES,
     NOT_FOUND_RESPONSE,
@@ -324,6 +325,12 @@ def create_list(
     db.refresh(sl)
     resp = _list_response(sl)
     broadcast_list_created(sl.family_id, resp.model_dump(mode="json"))
+    dispatch_webhook_event(
+        db,
+        family_id=sl.family_id,
+        event_type="shopping.list.created",
+        data={"list_id": sl.id, "name": sl.name, "created_by_user_id": user.id},
+    )
     return resp
 
 
@@ -424,6 +431,12 @@ def add_item(
         db.refresh(checked_match)
         resp = ShoppingItemResponse.model_validate(checked_match).model_dump(mode="json")
         broadcast_item_updated(list_id, resp)
+        dispatch_webhook_event(
+            db,
+            family_id=sl.family_id,
+            event_type="shopping.item.updated",
+            data={"list_id": list_id, "item_id": checked_match.id, "name": checked_match.name, "checked": checked_match.checked},
+        )
         return checked_match
 
     item = ShoppingItem(
@@ -450,6 +463,12 @@ def add_item(
     db.commit()
     db.refresh(item)
     broadcast_item_added(list_id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
+    dispatch_webhook_event(
+        db,
+        family_id=sl.family_id,
+        event_type="shopping.item.created",
+        data={"list_id": list_id, "item_id": item.id, "name": item.name, "checked": item.checked},
+    )
     return item
 
 
@@ -504,6 +523,12 @@ def update_item(
     db.commit()
     db.refresh(item)
     broadcast_item_updated(item.list_id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
+    dispatch_webhook_event(
+        db,
+        family_id=sl.family_id,
+        event_type="shopping.item.updated",
+        data={"list_id": item.list_id, "item_id": item.id, "name": item.name, "checked": item.checked},
+    )
     return item
 
 

--- a/backend/app/modules/tasks_router.py
+++ b/backend/app/modules/tasks_router.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.core.deps import current_user, ensure_adult, ensure_family_membership, to_utc_naive
 from app.core.activity import record_activity
+from app.core.webhooks import dispatch_webhook_event
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import Membership, RewardCurrency, Task, TokenTransaction, User
@@ -119,6 +120,12 @@ def create_task(
     )
     db.commit()
     db.refresh(task)
+    dispatch_webhook_event(
+        db,
+        family_id=task.family_id,
+        event_type="task.created",
+        data={"task_id": task.id, "title": task.title, "status": task.status, "assigned_to_user_id": task.assigned_to_user_id},
+    )
     return task
 
 
@@ -233,6 +240,12 @@ def update_task(
     db.refresh(task)
     if next_task:
         db.refresh(next_task)
+    dispatch_webhook_event(
+        db,
+        family_id=task.family_id,
+        event_type="task.updated",
+        data={"task_id": task.id, "title": task.title, "status": task.status, "assigned_to_user_id": task.assigned_to_user_id},
+    )
     return task
 
 

--- a/backend/app/modules/webhooks_router.py
+++ b/backend/app/modules/webhooks_router.py
@@ -1,0 +1,180 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.deps import current_user, ensure_adult
+from app.core.scopes import require_scope
+from app.core.webhooks import deliver_to_endpoint, endpoint_response
+from app.database import get_db
+from app.models import User, WebhookDelivery, WebhookEndpoint
+from app.schemas import (
+    AUTH_RESPONSES,
+    NOT_FOUND_RESPONSE,
+    WebhookDeliveryResponse,
+    WebhookEndpointCreate,
+    WebhookEndpointResponse,
+    WebhookEndpointUpdate,
+    WebhookTestResponse,
+)
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"], responses={**AUTH_RESPONSES})
+
+
+def _get_endpoint_or_404(db: Session, endpoint_id: int) -> WebhookEndpoint:
+    endpoint = db.query(WebhookEndpoint).filter(WebhookEndpoint.id == endpoint_id).first()
+    if not endpoint:
+        raise HTTPException(status_code=404, detail="Webhook endpoint not found")
+    return endpoint
+
+
+@router.get(
+    "",
+    response_model=list[WebhookEndpointResponse],
+    summary="List webhook endpoints",
+    description="Return configured outbound webhook endpoints for a family. Adult only. Scope: `admin:read`.",
+)
+def list_webhooks(
+    family_id: int = Query(...),
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("admin:read"),
+):
+    ensure_adult(db, user.id, family_id)
+    endpoints = (
+        db.query(WebhookEndpoint)
+        .filter(WebhookEndpoint.family_id == family_id)
+        .order_by(WebhookEndpoint.created_at.desc(), WebhookEndpoint.id.desc())
+        .all()
+    )
+    return [endpoint_response(endpoint) for endpoint in endpoints]
+
+
+@router.post(
+    "",
+    response_model=WebhookEndpointResponse,
+    summary="Create webhook endpoint",
+    description="Create an outbound webhook endpoint. Adult only. Scope: `admin:write`.",
+)
+def create_webhook(
+    payload: WebhookEndpointCreate,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("admin:write"),
+):
+    ensure_adult(db, user.id, payload.family_id)
+    endpoint = WebhookEndpoint(
+        family_id=payload.family_id,
+        name=payload.name.strip(),
+        url=payload.url,
+        events=payload.events,
+        active=payload.active,
+        secret_header_name=payload.secret_header_name,
+        secret_header_value=payload.secret_header_value,
+        created_by_user_id=user.id,
+    )
+    db.add(endpoint)
+    db.commit()
+    db.refresh(endpoint)
+    return endpoint_response(endpoint)
+
+
+@router.patch(
+    "/{endpoint_id}",
+    response_model=WebhookEndpointResponse,
+    summary="Update webhook endpoint",
+    description="Update an outbound webhook endpoint. Adult only. Scope: `admin:write`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def update_webhook(
+    endpoint_id: int,
+    payload: WebhookEndpointUpdate,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("admin:write"),
+):
+    endpoint = _get_endpoint_or_404(db, endpoint_id)
+    ensure_adult(db, user.id, endpoint.family_id)
+    updates = payload.model_dump(exclude_unset=True)
+    if "name" in updates and payload.name is not None:
+        endpoint.name = payload.name.strip()
+    if "url" in updates and payload.url is not None:
+        endpoint.url = payload.url
+    if "events" in updates and payload.events is not None:
+        endpoint.events = payload.events
+    if "active" in updates and payload.active is not None:
+        endpoint.active = payload.active
+    if "secret_header_name" in updates:
+        endpoint.secret_header_name = payload.secret_header_name
+    if "secret_header_value" in updates:
+        endpoint.secret_header_value = payload.secret_header_value
+    db.commit()
+    db.refresh(endpoint)
+    return endpoint_response(endpoint)
+
+
+@router.delete(
+    "/{endpoint_id}",
+    summary="Delete webhook endpoint",
+    description="Delete an outbound webhook endpoint and its delivery history. Adult only. Scope: `admin:write`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def delete_webhook(
+    endpoint_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("admin:write"),
+):
+    endpoint = _get_endpoint_or_404(db, endpoint_id)
+    ensure_adult(db, user.id, endpoint.family_id)
+    db.delete(endpoint)
+    db.commit()
+    return {"status": "deleted", "endpoint_id": endpoint_id}
+
+
+@router.get(
+    "/{endpoint_id}/deliveries",
+    response_model=list[WebhookDeliveryResponse],
+    summary="List webhook delivery status",
+    description="Return recent redacted delivery attempts for an endpoint. Adult only. Scope: `admin:read`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def list_deliveries(
+    endpoint_id: int,
+    limit: int = Query(20, ge=1, le=100),
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("admin:read"),
+):
+    endpoint = _get_endpoint_or_404(db, endpoint_id)
+    ensure_adult(db, user.id, endpoint.family_id)
+    deliveries = (
+        db.query(WebhookDelivery)
+        .filter(WebhookDelivery.endpoint_id == endpoint.id)
+        .order_by(WebhookDelivery.created_at.desc(), WebhookDelivery.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return deliveries
+
+
+@router.post(
+    "/{endpoint_id}/test",
+    response_model=WebhookTestResponse,
+    summary="Send test webhook",
+    description="Send a redacted test payload to one endpoint. Adult only. Scope: `admin:write`.",
+    responses={**NOT_FOUND_RESPONSE},
+)
+def test_webhook(
+    endpoint_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+    _scope=require_scope("admin:write"),
+):
+    endpoint = _get_endpoint_or_404(db, endpoint_id)
+    ensure_adult(db, user.id, endpoint.family_id)
+    delivery = deliver_to_endpoint(
+        db,
+        endpoint,
+        event_type="webhook.test",
+        data={"message": "Tribu webhook test", "endpoint_id": endpoint.id},
+    )
+    return {"status": delivery.status, "delivery": delivery}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1786,3 +1786,164 @@ class DisplayDashboardResponse(BaseModel):
     next_events: list[DisplayDashboardEvent] = Field(..., description="Upcoming events within 14 days (display-safe fields only)")
     upcoming_birthdays: list[DisplayDashboardBirthday] = Field(..., description="Upcoming birthdays within 28 days")
     config: DisplayDeviceConfig = Field(..., description="Resolved display render config")
+
+
+# ---------------------------------------------------------------------------
+# Webhooks
+# ---------------------------------------------------------------------------
+
+WEBHOOK_EVENT_TYPES = {
+    "calendar.event.created",
+    "task.created",
+    "task.updated",
+    "shopping.list.created",
+    "shopping.item.created",
+    "shopping.item.updated",
+    "quick_capture.created",
+    "birthday.created",
+    "webhook.test",
+}
+
+
+def _clean_webhook_events(events: list[str]) -> list[str]:
+    cleaned = sorted({event.strip() for event in events if event and event.strip()})
+    invalid = [event for event in cleaned if event not in WEBHOOK_EVENT_TYPES]
+    if invalid:
+        raise ValueError(f"Unsupported webhook event: {', '.join(invalid)}")
+    return cleaned
+
+
+DENIED_WEBHOOK_SECRET_HEADERS = {
+    "authorization",
+    "connection",
+    "content-length",
+    "content-type",
+    "host",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "user-agent",
+}
+
+
+def _validate_webhook_url(value: str) -> str:
+    cleaned = value.strip()
+    parsed = urlparse(cleaned)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("Webhook URL must be an HTTPS URL")
+    if parsed.username or parsed.password:
+        raise ValueError("Webhook URL must not include credentials")
+    return cleaned
+
+
+def _clean_webhook_secret_header_name(value: Optional[str]) -> Optional[str]:
+    if value is None or not value.strip():
+        return None
+    cleaned = value.strip()
+    if not re.fullmatch(r"[A-Za-z0-9-]{1,80}", cleaned):
+        raise ValueError("Secret header name may only contain letters, digits, and dashes")
+    if cleaned.lower() in DENIED_WEBHOOK_SECRET_HEADERS:
+        raise ValueError("Secret header name must be a custom header")
+    return cleaned
+
+
+class WebhookEndpointCreate(BaseModel):
+    family_id: int = Field(..., description="Family ID")
+    name: str = Field(..., min_length=1, max_length=120, description="Webhook display name")
+    url: str = Field(..., min_length=8, max_length=2000, description="HTTPS endpoint URL")
+    events: list[str] = Field(default_factory=list, description="Subscribed event types")
+    active: bool = Field(True, description="Whether deliveries are enabled")
+    secret_header_name: Optional[str] = Field(None, max_length=80, description="Optional custom secret header name")
+    secret_header_value: Optional[str] = Field(None, max_length=500, description="Optional custom secret header value")
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        return _validate_webhook_url(value)
+
+    @field_validator("events")
+    @classmethod
+    def validate_events(cls, value: list[str]) -> list[str]:
+        return _clean_webhook_events(value)
+
+    @field_validator("secret_header_name")
+    @classmethod
+    def validate_header_name(cls, value: Optional[str]) -> Optional[str]:
+        return _clean_webhook_secret_header_name(value)
+
+    @field_validator("secret_header_value")
+    @classmethod
+    def clean_header_value(cls, value: Optional[str]) -> Optional[str]:
+        if value is None or not value.strip():
+            return None
+        return value.strip()
+
+
+class WebhookEndpointUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=120)
+    url: Optional[str] = Field(None, min_length=8, max_length=2000)
+    events: Optional[list[str]] = None
+    active: Optional[bool] = None
+    secret_header_name: Optional[str] = Field(None, max_length=80)
+    secret_header_value: Optional[str] = Field(None, max_length=500)
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        return _validate_webhook_url(value)
+
+    @field_validator("events")
+    @classmethod
+    def validate_events(cls, value: Optional[list[str]]) -> Optional[list[str]]:
+        if value is None:
+            return None
+        return _clean_webhook_events(value)
+
+    @field_validator("secret_header_name")
+    @classmethod
+    def validate_header_name(cls, value: Optional[str]) -> Optional[str]:
+        return _clean_webhook_secret_header_name(value)
+
+    @field_validator("secret_header_value")
+    @classmethod
+    def clean_header_value(cls, value: Optional[str]) -> Optional[str]:
+        if value is None or not value.strip():
+            return None
+        return value.strip()
+
+
+class WebhookEndpointResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    family_id: int
+    name: str
+    url_redacted: str
+    events: list[str]
+    active: bool
+    secret_header_name: Optional[str] = None
+    has_secret: bool = False
+    created_at: datetime
+    updated_at: datetime
+
+
+class WebhookDeliveryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    endpoint_id: int
+    family_id: int
+    event_type: str
+    status: str
+    status_code: Optional[int] = None
+    error: Optional[str] = None
+    attempted_at: datetime
+
+
+class WebhookTestResponse(BaseModel):
+    status: str
+    delivery: WebhookDeliveryResponse

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,5 +14,6 @@ apscheduler==3.11.2
 python-multipart==0.0.26
 redis==5.2.1
 pywebpush==2.0.1
+httpx==0.28.1
 radicale==3.7.1
 a2wsgi==1.10.7

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -1,0 +1,337 @@
+"""Outbound webhook endpoint and delivery tests."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401 - ensure all models are registered before create_all
+from app.database import Base, get_db
+from app.main import app
+from app.models import Family, Membership, PersonalAccessToken, ShoppingList, User, WebhookDelivery, WebhookEndpoint
+from app.security import PAT_PREFIX, hash_password
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_admin(scopes: str = "admin:read,admin:write,shopping:write") -> tuple[str, int, int]:
+    db = TestSession()
+    try:
+        family = Family(name="Webhook Family")
+        user = User(email="webhooks@example.com", password_hash=hash_password("Password123"), display_name="Webhook Admin")
+        db.add_all([family, user])
+        db.flush()
+        db.add(Membership(user_id=user.id, family_id=family.id, role="admin", is_adult=True))
+        plain = f"{PAT_PREFIX}webhook-admin"
+        lookup = hashlib.sha256(plain.encode()).hexdigest()
+        db.add(
+            PersonalAccessToken(
+                user_id=user.id,
+                name="webhook-pat",
+                token_hash=lookup,
+                token_lookup=lookup,
+                scopes=scopes,
+            )
+        )
+        db.commit()
+        return plain, family.id, user.id
+    finally:
+        db.close()
+
+
+def test_create_webhook_redacts_url_and_secret():
+    token, family_id, _ = _seed_admin()
+
+    resp = client.post(
+        "/webhooks",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Home Assistant",
+            "url": "https://ha.example/[redacted]?secret=private",
+            "events": ["shopping.item.created", "task.created"],
+            "secret_header_name": "X-Tribu-Secret",
+            "secret_header_value": "super-secret",
+        },
+    )
+
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["name"] == "Home Assistant"
+    assert body["url_redacted"] == "https://ha.example/[redacted]"
+    assert body["has_secret"] is True
+    assert "super-secret" not in str(body)
+    assert "secret=private" not in str(body)
+    assert "api/webhook/token" not in str(body)
+
+
+def test_rejects_invalid_webhook_url_without_echoing_secret_path():
+    token, family_id, _ = _seed_admin()
+    secret_url = "http://ha.example/api/webhook/private-token?secret=private-secret"
+
+    resp = client.post(
+        "/webhooks",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Unsafe endpoint",
+            "url": secret_url,
+            "events": ["webhook.test"],
+        },
+    )
+
+    assert resp.status_code == 422
+    body_text = str(resp.json())
+    assert "private-token" not in body_text
+    assert "private-secret" not in body_text
+    assert secret_url not in body_text
+    assert "[redacted]" in body_text
+
+
+def test_rejects_reserved_secret_header_name():
+    token, family_id, _ = _seed_admin()
+
+    resp = client.post(
+        "/webhooks",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Reserved header",
+            "url": "https://ha.example/webhook",
+            "events": ["webhook.test"],
+            "secret_header_name": "Authorization",
+            "secret_header_value": "secret-value",
+        },
+    )
+
+    assert resp.status_code == 422
+    assert "secret-value" not in str(resp.json())
+
+
+def test_test_webhook_sends_redacted_delivery(monkeypatch):
+    token, family_id, _ = _seed_admin()
+    db = TestSession()
+    endpoint = WebhookEndpoint(
+        family_id=family_id,
+        name="Receiver",
+        url="https://receiver.example/hook?token=private",
+        events=["webhook.test"],
+        active=True,
+        secret_header_name="X-Tribu-Secret",
+        secret_header_value="secret-value",
+    )
+    db.add(endpoint)
+    db.commit()
+    endpoint_id = endpoint.id
+    db.close()
+
+    calls = []
+
+    class FakeResponse:
+        status_code = 204
+
+    def fake_post(url, *, json, headers, timeout, follow_redirects=False):
+        calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        return FakeResponse()
+
+    from app.core import webhooks as webhooks_core
+
+    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+
+    resp = client.post(f"/webhooks/{endpoint_id}/test", headers=_auth(token))
+
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["status"] == "delivered"
+    assert body["delivery"]["status_code"] == 204
+    assert calls[0]["url"] == "https://receiver.example/hook?token=private"
+    assert calls[0]["headers"]["X-Tribu-Secret"] == "secret-value"
+    assert calls[0]["json"]["event_type"] == "webhook.test"
+    assert "receiver.example" not in str(body)
+    assert "secret-value" not in str(body)
+
+
+def test_subscribed_shopping_event_creates_delivery(monkeypatch):
+    token, family_id, user_id = _seed_admin()
+    db = TestSession()
+    shopping_list = ShoppingList(family_id=family_id, name="Groceries", created_by_user_id=user_id)
+    endpoint = WebhookEndpoint(
+        family_id=family_id,
+        name="Shopping Automation",
+        url="https://automation.example/hook",
+        events=["shopping.item.created"],
+        active=True,
+    )
+    db.add_all([shopping_list, endpoint])
+    db.commit()
+    list_id = shopping_list.id
+    db.close()
+
+    sent_payloads = []
+
+    class FakeResponse:
+        status_code = 200
+
+    def fake_post(url, *, json, headers, timeout, follow_redirects=False):
+        sent_payloads.append(json)
+        return FakeResponse()
+
+    from app.core import webhooks as webhooks_core
+
+    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+
+    resp = client.post(
+        f"/shopping/lists/{list_id}/items",
+        headers=_auth(token),
+        json={"name": "Milch"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert sent_payloads[0]["event_type"] == "shopping.item.created"
+    assert sent_payloads[0]["family_id"] == family_id
+    assert sent_payloads[0]["data"]["name"] == "Milch"
+
+    db = TestSession()
+    try:
+        delivery = db.query(WebhookDelivery).one()
+        assert delivery.status == "delivered"
+        assert delivery.status_code == 200
+    finally:
+        db.close()
+
+
+def test_task_event_creates_delivery(monkeypatch):
+    token, family_id, _ = _seed_admin("admin:read,admin:write,tasks:write")
+    db = TestSession()
+    endpoint = WebhookEndpoint(
+        family_id=family_id,
+        name="Task Automation",
+        url="https://automation.example/tasks",
+        events=["task.created"],
+        active=True,
+    )
+    db.add(endpoint)
+    db.commit()
+    db.close()
+
+    sent_payloads = []
+
+    class FakeResponse:
+        status_code = 202
+
+    def fake_post(url, *, json, headers, timeout, follow_redirects=False):
+        sent_payloads.append(json)
+        return FakeResponse()
+
+    from app.core import webhooks as webhooks_core
+
+    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+
+    resp = client.post(
+        "/tasks",
+        headers=_auth(token),
+        json={"family_id": family_id, "title": "Pack sports bag"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert sent_payloads[0]["event_type"] == "task.created"
+    assert sent_payloads[0]["family_id"] == family_id
+    assert sent_payloads[0]["data"]["title"] == "Pack sports bag"
+
+    db = TestSession()
+    try:
+        delivery = db.query(WebhookDelivery).one()
+        assert delivery.status == "delivered"
+        assert delivery.status_code == 202
+    finally:
+        db.close()
+
+
+def test_inactive_or_unsubscribed_webhooks_are_skipped(monkeypatch):
+    token, family_id, user_id = _seed_admin()
+    db = TestSession()
+    shopping_list = ShoppingList(family_id=family_id, name="Groceries", created_by_user_id=user_id)
+    db.add_all(
+        [
+            shopping_list,
+            WebhookEndpoint(
+                family_id=family_id,
+                name="Inactive",
+                url="https://inactive.example/hook",
+                events=["shopping.item.created"],
+                active=False,
+            ),
+            WebhookEndpoint(
+                family_id=family_id,
+                name="Other Event",
+                url="https://other.example/hook",
+                events=["task.created"],
+                active=True,
+            ),
+        ]
+    )
+    db.commit()
+    list_id = shopping_list.id
+    db.close()
+
+    from app.core import webhooks as webhooks_core
+
+    def fake_post(*args, **kwargs):
+        raise AssertionError("No webhook should be sent")
+
+    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+
+    resp = client.post(
+        f"/shopping/lists/{list_id}/items",
+        headers=_auth(token),
+        json={"name": "Bread"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    db = TestSession()
+    try:
+        assert db.query(WebhookDelivery).count() == 0
+    finally:
+        db.close()

--- a/frontend/__tests__/components/WebhooksTab.test.js
+++ b/frontend/__tests__/components/WebhooksTab.test.js
@@ -1,0 +1,93 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WebhooksTab from '../../components/settings/WebhooksTab';
+import * as api from '../../lib/api';
+
+let mockAppState = {};
+const toastSuccess = jest.fn();
+const toastError = jest.fn();
+
+jest.mock('../../lib/api');
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+jest.mock('../../contexts/ToastContext', () => ({
+  useToast: () => ({ success: toastSuccess, error: toastError }),
+}));
+
+describe('WebhooksTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAppState = { familyId: 1 };
+    api.apiListWebhooks.mockResolvedValue({ ok: true, data: [] });
+    api.apiCreateWebhook.mockResolvedValue({ ok: true, data: { id: 1 } });
+    api.apiUpdateWebhook.mockResolvedValue({ ok: true, data: { id: 1 } });
+    api.apiDeleteWebhook.mockResolvedValue({ ok: true, data: { status: 'deleted' } });
+    api.apiTestWebhook.mockResolvedValue({ ok: true, data: { status: 'delivered' } });
+  });
+
+  it('lists configured webhooks with redacted target URLs only', async () => {
+    api.apiListWebhooks.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 42,
+        name: 'Home Assistant',
+        url_redacted: 'https://ha.example/hooks/[redacted]',
+        events: ['calendar.event.created', 'task.created'],
+        active: true,
+        has_secret: true,
+        secret_header_name: 'X-Tribu-Secret',
+      }],
+    });
+
+    render(<WebhooksTab />);
+
+    expect(await screen.findByText('Home Assistant')).toBeInTheDocument();
+    expect(screen.getByText('https://ha.example/hooks/[redacted]')).toBeInTheDocument();
+    expect(screen.queryByText(/token=secret/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Secret Header: X-Tribu-Secret')).toBeInTheDocument();
+  });
+
+  it('creates a webhook for the active family', async () => {
+    render(<WebhooksTab />);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Node-RED' } });
+    fireEvent.change(screen.getByLabelText('Webhook URL'), { target: { value: 'https://node-red.example/webhook/abc?token=private' } });
+    fireEvent.change(screen.getByLabelText('Optionaler Secret Header'), { target: { value: 'X-Tribu-Secret' } });
+    fireEvent.change(screen.getByPlaceholderText('Secret Wert'), { target: { value: 'super-secret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Webhook hinzufügen' }));
+
+    await waitFor(() => expect(api.apiCreateWebhook).toHaveBeenCalledTimes(1));
+    expect(api.apiCreateWebhook).toHaveBeenCalledWith(expect.objectContaining({
+      family_id: 1,
+      name: 'Node-RED',
+      url: 'https://node-red.example/webhook/abc?token=private',
+      secret_header_name: 'X-Tribu-Secret',
+      secret_header_value: 'super-secret',
+    }));
+    expect(toastSuccess).toHaveBeenCalledWith('Webhook gespeichert');
+  });
+
+  it('sends a test webhook without showing secret values', async () => {
+    api.apiListWebhooks.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 7,
+        name: 'Gotify',
+        url_redacted: 'https://gotify.example/message?[redacted]',
+        events: ['shopping.item.created'],
+        active: true,
+        has_secret: false,
+      }],
+    });
+
+    render(<WebhooksTab />);
+
+    const testButton = await screen.findByRole('button', { name: 'Test senden' });
+    fireEvent.click(testButton);
+
+    await waitFor(() => expect(api.apiTestWebhook).toHaveBeenCalledWith(7));
+    expect(toastSuccess).toHaveBeenCalledWith('Test-Webhook gesendet');
+    expect(screen.queryByText(/super-secret/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/settings/WebhooksTab.js
+++ b/frontend/components/settings/WebhooksTab.js
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useState } from 'react';
+import { PlugZap, Trash2 } from 'lucide-react';
+import { useApp } from '../../contexts/AppContext';
+import { useToast } from '../../contexts/ToastContext';
+import * as api from '../../lib/api';
+
+const WEBHOOK_EVENTS = [
+  ['calendar.event.created', 'Termin erstellt'],
+  ['task.created', 'Aufgabe erstellt'],
+  ['task.updated', 'Aufgabe aktualisiert'],
+  ['shopping.list.created', 'Einkaufsliste erstellt'],
+  ['shopping.item.created', 'Einkaufsartikel erstellt'],
+  ['shopping.item.updated', 'Einkaufsartikel aktualisiert'],
+  ['quick_capture.created', 'Quick Capture erstellt'],
+  ['birthday.created', 'Geburtstag erstellt'],
+];
+
+const emptyForm = {
+  name: '',
+  url: '',
+  events: ['calendar.event.created', 'task.created', 'shopping.item.created'],
+  active: true,
+  secret_header_name: '',
+  secret_header_value: '',
+};
+
+export default function WebhooksTab() {
+  const { familyId } = useApp();
+  const { success: toastSuccess, error: toastError } = useToast();
+  const [webhooks, setWebhooks] = useState([]);
+  const [form, setForm] = useState(emptyForm);
+  const [busy, setBusy] = useState(false);
+
+  const loadWebhooks = useCallback(async () => {
+    if (!familyId) return;
+    const res = await api.apiListWebhooks(familyId);
+    if (res.ok) setWebhooks(res.data || []);
+  }, [familyId]);
+
+  useEffect(() => { loadWebhooks(); }, [loadWebhooks]);
+
+  function toggleEvent(eventName) {
+    setForm((current) => {
+      const hasEvent = current.events.includes(eventName);
+      return {
+        ...current,
+        events: hasEvent
+          ? current.events.filter((event) => event !== eventName)
+          : [...current.events, eventName],
+      };
+    });
+  }
+
+  async function handleCreate(event) {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      const payload = {
+        family_id: Number(familyId),
+        name: form.name,
+        url: form.url,
+        events: form.events,
+        active: form.active,
+        secret_header_name: form.secret_header_name || null,
+        secret_header_value: form.secret_header_value || null,
+      };
+      const res = await api.apiCreateWebhook(payload);
+      if (res.ok) {
+        toastSuccess('Webhook gespeichert');
+        setForm(emptyForm);
+        await loadWebhooks();
+      } else {
+        toastError('Webhook konnte nicht gespeichert werden');
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleToggle(endpoint) {
+    const res = await api.apiUpdateWebhook(endpoint.id, { active: !endpoint.active });
+    if (res.ok) await loadWebhooks();
+  }
+
+  async function handleDelete(endpoint) {
+    const res = await api.apiDeleteWebhook(endpoint.id);
+    if (res.ok) {
+      toastSuccess('Webhook gelöscht');
+      await loadWebhooks();
+    }
+  }
+
+  async function handleTest(endpoint) {
+    const res = await api.apiTestWebhook(endpoint.id);
+    if (res.ok) {
+      toastSuccess(res.data.status === 'delivered' ? 'Test-Webhook gesendet' : 'Test-Webhook fehlgeschlagen');
+      await loadWebhooks();
+    } else {
+      toastError('Test-Webhook konnte nicht gesendet werden');
+    }
+  }
+
+  return (
+    <div className="settings-grid">
+      <div className="settings-section">
+        <div className="settings-section-title"><PlugZap size={16} /> Automation Webhooks</div>
+        <p className="settings-help">
+          Sende Tribu-Ereignisse an Home Assistant, Node-RED, ntfy, Gotify oder andere Automatisierungsplattformen.
+          URLs und Secret-Werte werden in der Oberfläche nicht vollständig angezeigt.
+        </p>
+
+        <form className="settings-form" onSubmit={handleCreate}>
+          <div className="form-field">
+            <label className="set-label" htmlFor="webhook-name">Name</label>
+            <input
+              id="webhook-name"
+              className="form-input"
+              value={form.name}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+              placeholder="Home Assistant"
+              required
+            />
+          </div>
+          <div className="form-field">
+            <label className="set-label" htmlFor="webhook-url">Webhook URL</label>
+            <input
+              id="webhook-url"
+              className="form-input"
+              type="url"
+              value={form.url}
+              onChange={(event) => setForm((current) => ({ ...current, url: event.target.value }))}
+              placeholder="https://example.local/api/webhook/..."
+              required
+            />
+          </div>
+          <div className="form-field">
+            <label className="set-label" htmlFor="webhook-secret-header">Optionaler Secret Header</label>
+            <div className="set-time-row">
+              <input
+                id="webhook-secret-header"
+                className="form-input"
+                value={form.secret_header_name}
+                onChange={(event) => setForm((current) => ({ ...current, secret_header_name: event.target.value }))}
+                placeholder="X-Tribu-Secret"
+              />
+              <input
+                className="form-input"
+                type="password"
+                value={form.secret_header_value}
+                onChange={(event) => setForm((current) => ({ ...current, secret_header_value: event.target.value }))}
+                placeholder="Secret Wert"
+              />
+            </div>
+          </div>
+          <fieldset className="settings-checklist">
+            <legend className="set-label">Ereignisse</legend>
+            {WEBHOOK_EVENTS.map(([eventName, label]) => (
+              <label key={eventName} className="set-checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={form.events.includes(eventName)}
+                  onChange={() => toggleEvent(eventName)}
+                />
+                <span>{label}</span>
+              </label>
+            ))}
+          </fieldset>
+          <label className="set-checkbox-label">
+            <input
+              type="checkbox"
+              checked={form.active}
+              onChange={(event) => setForm((current) => ({ ...current, active: event.target.checked }))}
+            />
+            Aktiv
+          </label>
+          <button className="btn-sm" disabled={busy || form.events.length === 0} type="submit">Webhook hinzufügen</button>
+        </form>
+      </div>
+
+      <div className="settings-section">
+        <div className="settings-section-title">Konfigurierte Webhooks</div>
+        {webhooks.length === 0 ? (
+          <p className="settings-help">Noch keine Webhooks konfiguriert.</p>
+        ) : (
+          <div className="settings-list">
+            {webhooks.map((endpoint) => (
+              <div key={endpoint.id} className="settings-list-item">
+                <div>
+                  <strong>{endpoint.name}</strong>
+                  <div className="muted-text">{endpoint.url_redacted}</div>
+                  <div className="muted-text">{endpoint.events.join(', ')}</div>
+                  {endpoint.has_secret && <div className="muted-text">Secret Header: {endpoint.secret_header_name || 'gesetzt'}</div>}
+                </div>
+                <div className="settings-row-actions">
+                  <button className="btn-ghost" onClick={() => handleToggle(endpoint)}>
+                    {endpoint.active ? 'Deaktivieren' : 'Aktivieren'}
+                  </button>
+                  <button className="btn-sm" onClick={() => handleTest(endpoint)}>Test senden</button>
+                  <button className="btn-ghost" aria-label={`${endpoint.name} löschen`} onClick={() => handleDelete(endpoint)}>
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/settings/index.js
+++ b/frontend/components/settings/index.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { User, Navigation, Bell, Database, Key, Heart, Smartphone, ChevronRight, ArrowLeft } from 'lucide-react';
+import { User, Navigation, Bell, Database, Key, Heart, Smartphone, ChevronRight, ArrowLeft, PlugZap } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { t } from '../../lib/i18n';
 import AccountTab from './AccountTab';
@@ -7,6 +7,7 @@ import NavigationTab from './NavigationTab';
 import NotificationsTab from './NotificationsTab';
 import DataTab from './DataTab';
 import ApiTokensTab from './ApiTokensTab';
+import WebhooksTab from './WebhooksTab';
 import PhoneSyncTab from './PhoneSyncTab';
 import AboutTab from './AboutTab';
 
@@ -17,6 +18,7 @@ const TABS = [
   { key: 'phone_sync',    labelKey: 'phone_sync_title',      icon: Smartphone, component: PhoneSyncTab,     visible: ({ demoMode }) => !demoMode,             group: 'personal' },
   { key: 'data',          labelKey: 'data_management',       icon: Database,   component: DataTab,          visible: ({ isChild, demoMode }) => !isChild && !demoMode, group: 'personal' },
   { key: 'tokens',        labelKey: 'api_tokens',            icon: Key,        component: ApiTokensTab,     visible: ({ isChild, demoMode }) => !isChild && !demoMode, group: 'system' },
+  { key: 'webhooks',      labelKey: 'automation_webhooks',   icon: PlugZap,    component: WebhooksTab,      visible: ({ isChild, demoMode }) => !isChild && !demoMode, group: 'system' },
   { key: 'about',         labelKey: 'about_support',         icon: Heart,      component: AboutTab,         visible: () => true,                              group: 'system' },
 ];
 

--- a/frontend/e2e/tests/settings.spec.js
+++ b/frontend/e2e/tests/settings.spec.js
@@ -52,4 +52,27 @@ test.describe('Settings', () => {
     await expect(page.getByText('Ask an admin to add VAPID keys on the server and restart Tribu.')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Enable push notifications' })).toBeDisabled();
   });
+
+  test('creates an automation webhook without exposing URL tokens', async ({ authedPage: page }) => {
+    await navigateTo(page, 'Settings');
+
+    const webhooksItem = page.locator('.settings-mobile-item', { hasText: 'Automation Webhooks' });
+    if (await webhooksItem.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await webhooksItem.click();
+    } else {
+      await page.locator('.settings-sidebar-item', { hasText: 'Automation Webhooks' }).click();
+    }
+
+    await page.getByLabel('Name').fill('Home Assistant');
+    await page.getByLabel('Webhook URL').fill('https://ha.example/api/webhook/private-token?secret=private');
+    await page.getByLabel('Optionaler Secret Header').fill('X-Tribu-Secret');
+    await page.getByPlaceholder('Secret Wert').fill('super-secret');
+    await page.getByRole('button', { name: 'Webhook hinzufügen' }).click();
+
+    await expect(page.getByText('https://ha.example/[redacted]')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Secret Header: X-Tribu-Secret')).toBeVisible();
+    await expect(page.getByText(/private-token/)).toHaveCount(0);
+    await expect(page.getByText(/super-secret/)).toHaveCount(0);
+  });
+
 });

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -108,6 +108,7 @@
   "admin_self_hint": "Eigene Rolle kann nicht geändert werden",
   "password_hint": "Mind. 8 Zeichen, 1 Großbuchstabe, 1 Zahl",
   "api_tokens": "API Tokens",
+  "automation_webhooks": "Automation Webhooks",
   "api_tokens_desc": "Persönliche Zugangstoken für Drittanbieter-Apps und Skripte.",
   "create_token": "Token erstellen",
   "token_name": "Token-Name",

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -108,6 +108,7 @@
   "admin_self_hint": "You cannot change your own role",
   "password_hint": "Min. 8 characters, 1 uppercase letter, 1 number",
   "api_tokens": "API Tokens",
+  "automation_webhooks": "Automation Webhooks",
   "api_tokens_desc": "Personal access tokens for third-party apps and scripts.",
   "create_token": "Create token",
   "token_name": "Token name",

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -529,6 +529,31 @@ export function apiSetBaseUrl(base_url) {
   });
 }
 
+// Automation webhooks
+export function apiListWebhooks(familyId) {
+  return request(`/webhooks?family_id=${familyId}`);
+}
+
+export function apiCreateWebhook(payload) {
+  return post('/webhooks', payload);
+}
+
+export function apiUpdateWebhook(endpointId, payload) {
+  return patch(`/webhooks/${endpointId}`, payload);
+}
+
+export function apiDeleteWebhook(endpointId) {
+  return del(`/webhooks/${endpointId}`);
+}
+
+export function apiTestWebhook(endpointId) {
+  return post(`/webhooks/${endpointId}/test`, {});
+}
+
+export function apiListWebhookDeliveries(endpointId, limit = 20) {
+  return request(`/webhooks/${endpointId}/deliveries?limit=${limit}`);
+}
+
 // OIDC / SSO — public
 export function apiGetOidcPublicConfig() {
   return request('/auth/oidc/public-config');

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -3810,3 +3810,12 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .template-preview-grid { grid-template-columns: 1fr; }
   .templates-header { display: grid; }
 }
+
+.settings-help { color: var(--text-muted); font-size: 0.9rem; line-height: 1.5; margin: 0 0 var(--space-md); }
+.settings-form { display: grid; gap: var(--space-md); }
+.settings-checklist { display: grid; gap: var(--space-xs); padding: var(--space-sm); border: 1px solid var(--glass-border); border-radius: var(--radius-md); }
+.settings-list { display: grid; gap: var(--space-sm); }
+.settings-list-item { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-md); padding: var(--space-md); border: 1px solid var(--glass-border); border-radius: var(--radius-md); }
+.settings-row-actions { display: flex; flex-wrap: wrap; gap: var(--space-xs); justify-content: flex-end; }
+.muted-text { color: var(--text-muted); font-size: 0.82rem; margin-top: 2px; }
+@media (max-width: 768px) { .settings-list-item { flex-direction: column; } .settings-row-actions { justify-content: flex-start; } }


### PR DESCRIPTION
## Summary
- Adds family-scoped outbound webhook endpoints with delivery history and test delivery support.
- Adds event dispatch for calendar events, tasks, shopping, quick capture, and birthdays.
- Adds an Automation Webhooks settings tab with redacted target URLs and secret-header handling.
- Redacts target URL path/query values in API/UI responses and validation errors; delivery logs store status metadata only.

Closes #268

## Test Plan
- `DATABASE_URL=sqlite:///./test_webhooks.db JWT_SECRET=[REDACTED] uv run pytest tests/test_webhooks.py -q`
- `DATABASE_URL=sqlite:///./test_webhooks_related.db JWT_SECRET=[REDACTED] uv run pytest tests/test_webhooks.py tests/test_quick_capture.py tests/test_shopping_item_reuse.py -q`
- `DATABASE_URL=sqlite:///./test_full_webhooks.db JWT_SECRET=[REDACTED] uv run pytest -q`
- `uv run ruff check app/core/webhooks.py app/modules/webhooks_router.py app/modules/shopping_router.py app/modules/tasks_router.py app/modules/calendar_router.py app/modules/birthdays_router.py app/modules/quick_capture_router.py tests/test_webhooks.py app/schemas.py app/models.py`
- `uv run ruff check app/main.py --ignore E402`
- `npm test -- --runInBand __tests__/components/WebhooksTab.test.js`
- `npm test -- --runInBand`
- `npm run build`
- `timeout 300s nice -n 19 ionice -c3 npx playwright test e2e/tests/settings.spec.js --reporter=list`
- Alembic smoke for this revision: `alembic stamp 0043 && alembic upgrade head`
- `git diff --check`
- changed-file secret scan
