### PR TITLE
Add Home Assistant integration package

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Use the document that matches your intent:
 | [README](README.md) | Product overview, screenshots, positioning, and quick start |
 | [Contributing](CONTRIBUTING.md) | Local dev setup, testing, project boundaries, and PR expectations |
 | [Self-Hosting Guide](docs/self-hosting.md) | Configuration, reverse proxy, backups, updating, and troubleshooting |
+| [Home Assistant](docs/home-assistant.md) | REST sensors, quick capture commands, webhook automation, and dashboard examples for Home Assistant |
 | [Wiki](https://github.com/itsDNNS/tribu/wiki) | Architecture, roadmap, changelog, plugin details, and reference pages |
 | [Releases](https://github.com/itsDNNS/tribu/releases) | Versioned builds and release notes |
 | [Security](SECURITY.md) | Security policy and responsible disclosure |

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -1,0 +1,181 @@
+# Home Assistant integration
+
+Tribu can connect to Home Assistant without a cloud service. The first supported path is a Home Assistant package that combines Tribu's REST API with outbound webhook events.
+
+Use this when you want Home Assistant dashboards or automations to show family status from Tribu.
+
+## What this provides
+
+The package in [`integrations/home-assistant/tribu_package.yaml`](../integrations/home-assistant/tribu_package.yaml) provides these Home Assistant entities:
+
+- `sensor.tribu_next_event`
+- `sensor.tribu_open_tasks`
+- `sensor.tribu_open_shopping_items`
+- `sensor.tribu_upcoming_birthdays`
+
+It also includes:
+
+- a Home Assistant webhook automation that receives Tribu outbound webhook events
+- `rest_command.tribu_add_quick_capture` for adding a note to Tribu from Home Assistant
+- a dashboard card example in [`integrations/home-assistant/dashboard-card.yaml`](../integrations/home-assistant/dashboard-card.yaml)
+
+## Prerequisites
+
+- A running Tribu instance reachable from Home Assistant.
+- A Tribu adult or admin account.
+- A Tribu personal access token with the smallest practical scope set.
+- Home Assistant packages enabled, or a place where you can paste package YAML.
+
+## Tribu scopes used by the package
+
+Create a dedicated personal access token for Home Assistant. Do not reuse your normal browser session.
+
+Recommended scopes for the package:
+
+- `calendar:read` for `sensor.tribu_next_event` and birthdays from the dashboard summary endpoint
+- `tasks:read` for `sensor.tribu_open_tasks`
+- `shopping:read` for `sensor.tribu_open_shopping_items`
+- `quick_capture:write` only if you want Home Assistant to call `rest_command.tribu_add_quick_capture`
+- `admin:write` only if the same token also manages outbound webhook endpoints through the Tribu API
+
+If you only want read-only sensors, do not grant write scopes.
+
+## Setup
+
+### 1. Create a Tribu token
+
+In Tribu, create a personal access token for Home Assistant and copy it once. Store it in Home Assistant `secrets.yaml`, not in the package file.
+
+Example `secrets.yaml` values:
+
+```yaml
+tribu_url: https://tribu.example.com
+tribu_family_id: 1
+tribu_token: replace-with-the-token-shown-once
+tribu_authorization_header: "Bearer replace-with-the-token-shown-once"
+tribu_dashboard_summary_url: "https://tribu.example.com/api/dashboard/summary?family_id=1"
+tribu_open_tasks_url: "https://tribu.example.com/api/tasks?family_id=1&status=open&limit=1"
+tribu_shopping_lists_url: "https://tribu.example.com/api/shopping/lists?family_id=1"
+tribu_quick_capture_url: "https://tribu.example.com/api/quick-capture"
+tribu_webhook_id: choose-a-long-random-home-assistant-webhook-id
+```
+
+Do not paste token values into screenshots, GitHub issues, logs, or support requests.
+
+A redacted Authorization header should look like this in docs or logs:
+
+```text
+Authorization: Bearer *** tribu_token
+```
+
+When an example supports direct Home Assistant secret substitution, prefer references such as `!secret tribu_url`, `!secret tribu_token`, and `!secret tribu_family_id` instead of copying raw values.
+
+### 2. Enable packages in Home Assistant
+
+If packages are not enabled yet, add this to Home Assistant `configuration.yaml`:
+
+```yaml
+homeassistant:
+  packages: !include_dir_named packages
+```
+
+Create the directory if needed:
+
+```bash
+mkdir -p /config/packages
+```
+
+Copy [`tribu_package.yaml`](../integrations/home-assistant/tribu_package.yaml) into `/config/packages/tribu.yaml` and restart Home Assistant.
+
+### 3. Add the dashboard card
+
+Copy the contents of [`dashboard-card.yaml`](../integrations/home-assistant/dashboard-card.yaml) into a Lovelace manual card. The card displays:
+
+- next Tribu event
+- open tasks
+- open shopping items
+- upcoming birthdays
+
+## Quick capture from Home Assistant
+
+The package includes `rest_command.tribu_add_quick_capture`. Use it from a script, button, or automation like this:
+
+```yaml
+action: rest_command.tribu_add_quick_capture
+data:
+  family_id: !secret tribu_family_id
+  text: "Buy oat milk"
+  destination: shopping
+```
+
+Allowed destinations are `inbox`, `task`, and `shopping`. Start with `inbox` when testing a new token.
+
+## Outbound webhook events from Tribu
+
+Tribu can send outbound webhooks to Home Assistant. Create a Home Assistant webhook automation with a secret `tribu_webhook_id`, then create a Tribu webhook endpoint that points to:
+
+```text
+https://home-assistant.example.com/api/webhook/<tribu_webhook_id>
+```
+
+Subscribe that endpoint to useful Tribu events, for example:
+
+- `calendar.event.created`
+- `task.created`
+- `task.updated`
+- `shopping.item.created`
+- `shopping.item.updated`
+- `quick_capture.created`
+- `birthday.created`
+
+The package includes a simple persistent notification automation so you can verify that Home Assistant receives events. Replace it with your own automations when the connection works.
+
+## Dashboard example
+
+The dashboard example is intentionally small. Start with this first, then build your own room dashboard or family overview once the sensors update correctly.
+
+```yaml
+type: entities
+title: Tribu household
+entities:
+  - entity: sensor.tribu_next_event
+  - entity: sensor.tribu_open_tasks
+  - entity: sensor.tribu_open_shopping_items
+  - entity: sensor.tribu_upcoming_birthdays
+```
+
+## Privacy boundaries
+
+- Tribu data shown in Home Assistant becomes visible to people and integrations that can access your Home Assistant instance.
+- The package reads only family summary, open task count, shopping list counts, and upcoming birthday count by default.
+- The quick-capture command is opt-in and requires `quick_capture:write`.
+- Do not put full Tribu tokens, webhook IDs, or real private URLs into package YAML committed to a repository.
+- Keep Home Assistant diagnostics and screenshots redacted when asking for help.
+
+## Troubleshooting
+
+### Sensors are unavailable
+
+- Check that `tribu_url` points to the externally reachable Tribu URL.
+- Check that the REST URLs include `/api/` when you access Tribu through the frontend/reverse proxy.
+- Check that the token has the required read scopes.
+- Confirm Home Assistant can reach Tribu from inside the HA container or host.
+
+### Sensors show zero or empty data
+
+- Confirm `tribu_family_id` matches your family id.
+- Open the matching Tribu API URL in a browser while authenticated, or test with curl using the redacted pattern above.
+- For shopping, make sure the package points to `/api/shopping/lists?family_id=...`.
+
+### Webhook events do not arrive
+
+- Confirm the Home Assistant automation uses the same `tribu_webhook_id` stored in `secrets.yaml`.
+- Confirm the Tribu webhook endpoint uses `/api/webhook/<id>` on the Home Assistant side.
+- Use the Tribu webhook test button first. The Tribu UI should show a delivery status without exposing the full URL or token.
+- Check Home Assistant automation traces for the webhook automation.
+
+### Quick capture fails
+
+- Make sure the token includes `quick_capture:write`.
+- Make sure the payload includes the current `tribu_family_id`.
+- Start with destination `inbox`, then try `task` or `shopping` after the basic command works.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -6,6 +6,7 @@ Everything you need to run Tribu on your own server.
 
 - installing Tribu on your own infrastructure
 - configuring environment variables, reverse proxy, and phone sync
+- connecting Home Assistant through REST sensors and Tribu webhooks
 - backups, updates, and troubleshooting in production-like setups
 
 If you want the public overview, start with the [README](../README.md).
@@ -31,6 +32,10 @@ docker compose up -d
 ```
 
 Open [localhost:3000](http://localhost:3000) and register. The first user becomes the family admin.
+
+## Home Assistant
+
+Tribu ships a Home Assistant package for REST sensors, a webhook automation example, a quick-capture REST command, and a small dashboard card. See [Home Assistant integration](home-assistant.md) for setup and privacy notes.
 
 ## Configuration Reference
 

--- a/integrations/home-assistant/dashboard-card.yaml
+++ b/integrations/home-assistant/dashboard-card.yaml
@@ -1,0 +1,17 @@
+type: entities
+title: Tribu household
+show_header_toggle: false
+entities:
+  - entity: sensor.tribu_next_event
+    name: Next event
+  - entity: sensor.tribu_open_tasks
+    name: Open tasks
+  - entity: sensor.tribu_open_shopping_items
+    name: Open shopping items
+  - entity: sensor.tribu_upcoming_birthdays
+    name: Upcoming birthdays
+footer:
+  type: buttons
+  entities:
+    - entity: sensor.tribu_next_event
+      name: Open Tribu

--- a/integrations/home-assistant/tribu_package.yaml
+++ b/integrations/home-assistant/tribu_package.yaml
@@ -1,0 +1,100 @@
+# Tribu Home Assistant package
+#
+# Add this file to your Home Assistant packages directory and define the
+# referenced secrets in secrets.yaml. Keep token values out of this file.
+
+rest:
+  - resource: !secret tribu_dashboard_summary_url
+    scan_interval: 300
+    headers:
+      Authorization: !secret tribu_authorization_header
+      Accept: application/json
+    sensor:
+      - name: Tribu Next Event
+        unique_id: tribu_next_event
+        value_template: >-
+          {% set events = value_json.next_events | default([]) %}
+          {{ events[0].title if events | length > 0 else 'None' }}
+        json_attributes_path: "$.next_events[0]"
+        json_attributes:
+          - id
+          - starts_at
+          - ends_at
+          - location_name
+          - address
+          - source
+      - name: Tribu Upcoming Birthdays
+        unique_id: tribu_upcoming_birthdays
+        value_template: "{{ value_json.upcoming_birthdays | default([]) | length }}"
+        json_attributes:
+          - upcoming_birthdays
+
+  - resource: !secret tribu_open_tasks_url
+    scan_interval: 300
+    headers:
+      Authorization: !secret tribu_authorization_header
+      Accept: application/json
+    sensor:
+      - name: Tribu Open Tasks
+        unique_id: tribu_open_tasks
+        value_template: "{{ value_json.total | default(0) }}"
+        unit_of_measurement: tasks
+        json_attributes:
+          - total
+          - items
+
+  - resource: !secret tribu_shopping_lists_url
+    scan_interval: 300
+    headers:
+      Authorization: !secret tribu_authorization_header
+      Accept: application/json
+    sensor:
+      - name: Tribu Open Shopping Items
+        unique_id: tribu_open_shopping_items
+        value_template: >-
+          {% set lists = value_json if value_json is sequence else [] %}
+          {{ lists | map(attribute='item_count') | sum - lists | map(attribute='checked_count') | sum }}
+        unit_of_measurement: items
+        json_attributes:
+          - lists
+
+# Entity ids created by the REST sensors above:
+# - sensor.tribu_next_event
+# - sensor.tribu_open_tasks
+# - sensor.tribu_open_shopping_items
+# - sensor.tribu_upcoming_birthdays
+
+rest_command:
+  tribu_add_quick_capture:
+    # Endpoint path: /api/quick-capture
+    url: !secret tribu_quick_capture_url
+    method: POST
+    headers:
+      Authorization: !secret tribu_authorization_header
+      Content-Type: application/json
+    # Pass family_id from the calling script or automation.
+    # Example caller value: family_id: !secret tribu_family_id
+    payload: >-
+      {"family_id": {{ family_id }}, "text": "{{ text }}", "destination": "{{ destination | default('inbox') }}"}
+
+# Tribu can send outbound webhooks to Home Assistant at:
+# https://home-assistant.example/api/webhook/<tribu_webhook_id>
+automation:
+  - alias: Tribu webhook event received
+    id: tribu_webhook_event_received
+    mode: queued
+    trigger:
+      - platform: webhook
+        webhook_id: !secret tribu_webhook_id
+        allowed_methods:
+          - POST
+        local_only: false
+    condition:
+      - condition: template
+        value_template: "{{ trigger.json.source == 'tribu' }}"
+    action:
+      - service: persistent_notification.create
+        data:
+          title: "Tribu {{ trigger.json.event_type }}"
+          message: >-
+            Event {{ trigger.json.event_type }} received for family {{ trigger.json.family_id }}.

--- a/tests/test_home_assistant_docs.py
+++ b/tests/test_home_assistant_docs.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "home-assistant.md"
+PACKAGE = ROOT / "integrations" / "home-assistant" / "tribu_package.yaml"
+DASHBOARD = ROOT / "integrations" / "home-assistant" / "dashboard-card.yaml"
+
+
+def test_home_assistant_package_documents_required_entities_and_actions():
+    doc = DOC.read_text()
+    package = PACKAGE.read_text()
+
+    required_entities = [
+        "sensor.tribu_next_event",
+        "sensor.tribu_open_tasks",
+        "sensor.tribu_open_shopping_items",
+        "sensor.tribu_upcoming_birthdays",
+    ]
+    for entity in required_entities:
+        assert entity in doc
+        assert entity in package
+
+    assert "rest_command:" in package
+    assert "tribu_add_quick_capture" in package
+    assert "/api/quick-capture" in package
+    assert "webhook_id: !secret tribu_webhook_id" in package
+    assert "event_type" in package
+
+
+def test_home_assistant_docs_use_secret_placeholders_not_real_tokens():
+    combined = "\n".join(
+        path.read_text()
+        for path in (DOC, PACKAGE, DASHBOARD)
+    )
+
+    assert "tribu_pat_" not in combined
+    redacted_header = "Authorization: Bearer " + "*" * 3 + " tribu_token"
+    assert redacted_header in combined
+    assert "!secret tribu_token" in combined
+    assert "!secret tribu_url" in combined
+    assert "!secret tribu_family_id" in combined
+    assert "Do not paste token values" in combined
+
+
+def test_home_assistant_docs_cover_privacy_troubleshooting_and_dashboard_example():
+    doc = DOC.read_text()
+    dashboard = DASHBOARD.read_text()
+
+    for section in (
+        "## Privacy boundaries",
+        "## Troubleshooting",
+        "## Tribu scopes used by the package",
+        "## Dashboard example",
+    ):
+        assert section in doc
+
+    assert "type: entities" in dashboard
+    assert "sensor.tribu_next_event" in dashboard
+    assert "sensor.tribu_open_tasks" in dashboard
+    assert "sensor.tribu_open_shopping_items" in dashboard
+    assert "sensor.tribu_upcoming_birthdays" in dashboard


### PR DESCRIPTION
## Summary
- Add a Home Assistant package with REST sensors for core Tribu household status
- Include a quick capture REST command, webhook automation example, and Lovelace dashboard card
- Document setup, required token scopes, privacy boundaries, and troubleshooting

## Test plan
- `uv run --with pytest pytest tests/test_docker_workflow.py tests/test_home_assistant_docs.py -q`
- `DATABASE_URL=sqlite:////tmp/tribu-issue-269/backend/test_home_assistant.db JWT_SECRET=test-secret uv run --with-requirements backend/requirements.txt --with pytest pytest backend/tests/test_webhooks.py backend/tests/test_quick_capture.py -q`

Closes #269
