### PR TITLE
docs: make wiki the primary documentation entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/itsDNNS/tribu/wiki"><strong>Documentation Wiki</strong></a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="#quick-start">Quick Start</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="#phone-sync">Phone Sync</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="#shared-home-display">Wall Display</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
-  <a href="https://github.com/itsDNNS/tribu/wiki">Wiki</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="CONTRIBUTING.md">Contributing</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/tribu/wiki/Roadmap">Roadmap</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="https://github.com/itsDNNS/tribu/wiki/Changelog">Changelog</a>
@@ -146,7 +146,7 @@ Tribu supports **CalDAV and CardDAV** for bidirectional phone sync, so calendars
 
 After setup, open **Settings → Phone sync** in Tribu to copy the CalDAV and CardDAV URLs for each family.
 
-[See the full phone sync setup guide →](docs/self-hosting.md#phone-sync-caldav--carddav)
+[See the full phone sync setup guide in the Wiki →](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#phone-sync-caldav--carddav)
 
 ## Shared Home Display
 
@@ -197,7 +197,7 @@ This is ideal for the “always visible” family screen in the kitchen, hallway
 - **Want it in your stack fast?** Jump to [Quick Start](#quick-start) and run it with Docker Compose on your server, NAS, or mini PC.
 - **Want phone integration from day one?** Use [Phone Sync](#phone-sync) for CalDAV and CardDAV setup with supported clients.
 - **Want a shared kitchen or wall dashboard?** Use [Shared Home Display](#shared-home-display) and pair a dedicated display device instead of a personal account.
-- **Want to inspect how it is built before you commit?** Start with the [Architecture](https://github.com/itsDNNS/tribu/wiki/Architecture) and [Self-Hosting Guide](docs/self-hosting.md).
+- **Want to inspect how it is built before you commit?** Start with the [Architecture](https://github.com/itsDNNS/tribu/wiki/Architecture) and [Self-Hosting Guide](https://github.com/itsDNNS/tribu/wiki/Self-Hosting).
 - **Want to contribute or extend it?** Start with [Contributing](CONTRIBUTING.md), then use the [Plugin Manifest](https://github.com/itsDNNS/tribu/wiki/Plugin-Manifest) for extension-specific details.
 
 ## Quick Start
@@ -309,17 +309,18 @@ Tribu is not only trying to be pleasant for families using it. It is also set up
 
 ## Documentation
 
-Use the document that matches your intent:
+Use the [GitHub Wiki](https://github.com/itsDNNS/tribu/wiki) as the primary documentation entry point for user-facing setup, self-hosting, operations, integrations, troubleshooting, roadmap, and release-oriented guides. Repo-local Markdown stays small and code-adjacent: the README gives the product overview and quick start, CONTRIBUTING covers local development, SECURITY covers responsible disclosure, and pointer stubs preserve important old links.
 
 | | |
 |---|---|
+| [Documentation Wiki](https://github.com/itsDNNS/tribu/wiki) | Primary home for user docs, self-hosting, integrations, operations, roadmap, changelog, and reference pages |
+| [Self-Hosting Guide](https://github.com/itsDNNS/tribu/wiki/Self-Hosting) | Configuration, reverse proxy, backups, phone sync, updating, and troubleshooting |
+| [Home Assistant](https://github.com/itsDNNS/tribu/wiki/Home-Assistant) | REST sensors, quick capture commands, webhook automation, and dashboard examples for Home Assistant |
 | [README](README.md) | Product overview, screenshots, positioning, and quick start |
 | [Contributing](CONTRIBUTING.md) | Local dev setup, testing, project boundaries, and PR expectations |
-| [Self-Hosting Guide](docs/self-hosting.md) | Configuration, reverse proxy, backups, updating, and troubleshooting |
-| [Home Assistant](docs/home-assistant.md) | REST sensors, quick capture commands, webhook automation, and dashboard examples for Home Assistant |
-| [Wiki](https://github.com/itsDNNS/tribu/wiki) | Architecture, roadmap, changelog, plugin details, and reference pages |
-| [Releases](https://github.com/itsDNNS/tribu/releases) | Versioned builds and release notes |
 | [Security](SECURITY.md) | Security policy and responsible disclosure |
+| [Docs ownership policy](docs/documentation-policy.md) | Inventory and placement rules for repo-local docs and Wiki pages |
+| [Releases](https://github.com/itsDNNS/tribu/releases) | Versioned builds and release notes |
 
 ## Support
 

--- a/docs/documentation-policy.md
+++ b/docs/documentation-policy.md
@@ -1,0 +1,36 @@
+# Documentation ownership policy
+
+The GitHub Wiki is the primary documentation entry point for Tribu users, self-hosters, operators, and integrations. Repo-local Markdown should stay small and close to the code unless the content must be versioned with a code change.
+
+## Ownership rule
+
+- **Wiki:** user guides, self-hosting, operations, integrations, troubleshooting, roadmap, changelog, release-oriented usage docs, and reference pages that should be easy to find from GitHub's Wiki tab.
+- **Repository Markdown:** README, contributor/developer workflow, security policy, architecture or API notes that need to be reviewed with code, and short pointer pages that preserve existing links.
+- **Pointer stubs:** repo pages that used to contain user-facing guides should link to the Wiki and keep major headings when practical so old anchors remain understandable.
+
+## Current inventory
+
+| File or page | Location | Category | Decision |
+|--------------|----------|----------|----------|
+| `README.md` | Repo | Product overview and quick start | Keep in repo, point prominently to the Wiki for full docs |
+| `CONTRIBUTING.md` | Repo | Contributor and local development workflow | Keep in repo because it is code-adjacent |
+| `SECURITY.md` | Repo | Security policy and responsible disclosure | Keep in repo because GitHub surfaces it directly |
+| `docs/self-hosting.md` | Repo | Self-hosting and operations | Replace detailed copy with a pointer stub to the Wiki guide |
+| `docs/home-assistant.md` | Repo | Home Assistant integration setup | Replace detailed copy with a pointer stub to the Wiki guide |
+| `Home` | Wiki | Documentation entry point | Make it the primary docs index |
+| `Self-Hosting` | Wiki | Installation, configuration, operations, updates, troubleshooting | Primary source of truth |
+| `Home Assistant` | Wiki | REST sensors, webhook automations, dashboard card, privacy notes | Primary source of truth |
+| `Shared Home Display` | Wiki | Shared display setup and security model | Primary source of truth |
+| `Backup & Restore` | Wiki | Backup, restore, storage, and scheduling | Primary source of truth |
+| `Single Sign-On (OIDC)` | Wiki | OIDC setup and provider notes | Primary source of truth |
+| `Architecture` | Wiki | Architecture overview and module map | Keep in Wiki unless a future contract must be tested with code |
+| `Plugin Manifest` | Wiki | Extension reference | Keep in Wiki unless a future manifest schema becomes versioned with tests |
+| `Roadmap` | Wiki | Product direction | Keep in Wiki |
+| `Changelog` | Wiki | Release history | Keep in Wiki |
+
+## Future documentation changes
+
+1. If the change helps users install, operate, integrate, or troubleshoot Tribu, update the Wiki first.
+2. If a repo-local pointer would otherwise become stale, update only the link or short description.
+3. If the content is needed for contributors to build, test, review, or safely change code, keep it in the repo.
+4. Avoid maintaining the same full guide in both places.

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -1,181 +1,57 @@
 # Home Assistant integration
 
-Tribu can connect to Home Assistant without a cloud service. The first supported path is a Home Assistant package that combines Tribu's REST API with outbound webhook events.
+The GitHub Wiki is the primary documentation entry point for Home Assistant setup.
 
-Use this when you want Home Assistant dashboards or automations to show family status from Tribu.
+Use the current guide here:
+
+[Open the Home Assistant integration guide in the Wiki →](https://github.com/itsDNNS/tribu/wiki/Home-Assistant)
+
+This repository page remains as a compatibility pointer for existing links. Keep Home Assistant setup, package usage, dashboard examples, webhook automation notes, troubleshooting, and privacy guidance in the Wiki.
 
 ## What this provides
 
-The package in [`integrations/home-assistant/tribu_package.yaml`](../integrations/home-assistant/tribu_package.yaml) provides these Home Assistant entities:
-
-- `sensor.tribu_next_event`
-- `sensor.tribu_open_tasks`
-- `sensor.tribu_open_shopping_items`
-- `sensor.tribu_upcoming_birthdays`
-
-It also includes:
-
-- a Home Assistant webhook automation that receives Tribu outbound webhook events
-- `rest_command.tribu_add_quick_capture` for adding a note to Tribu from Home Assistant
-- a dashboard card example in [`integrations/home-assistant/dashboard-card.yaml`](../integrations/home-assistant/dashboard-card.yaml)
+See [Home Assistant: What this provides](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#what-this-provides).
 
 ## Prerequisites
 
-- A running Tribu instance reachable from Home Assistant.
-- A Tribu adult or admin account.
-- A Tribu personal access token with the smallest practical scope set.
-- Home Assistant packages enabled, or a place where you can paste package YAML.
+See [Home Assistant: Prerequisites](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#prerequisites).
 
 ## Tribu scopes used by the package
 
-Create a dedicated personal access token for Home Assistant. Do not reuse your normal browser session.
-
-Recommended scopes for the package:
-
-- `calendar:read` for `sensor.tribu_next_event` and birthdays from the dashboard summary endpoint
-- `tasks:read` for `sensor.tribu_open_tasks`
-- `shopping:read` for `sensor.tribu_open_shopping_items`
-- `quick_capture:write` only if you want Home Assistant to call `rest_command.tribu_add_quick_capture`
-- `admin:write` only if the same token also manages outbound webhook endpoints through the Tribu API
-
-If you only want read-only sensors, do not grant write scopes.
+See [Home Assistant: Tribu scopes used by the package](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#tribu-scopes-used-by-the-package).
 
 ## Setup
 
+See [Home Assistant: Setup](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#setup).
+
 ### 1. Create a Tribu token
 
-In Tribu, create a personal access token for Home Assistant and copy it once. Store it in Home Assistant `secrets.yaml`, not in the package file.
-
-Example `secrets.yaml` values:
-
-```yaml
-tribu_url: https://tribu.example.com
-tribu_family_id: 1
-tribu_token: replace-with-the-token-shown-once
-tribu_authorization_header: "Bearer replace-with-the-token-shown-once"
-tribu_dashboard_summary_url: "https://tribu.example.com/api/dashboard/summary?family_id=1"
-tribu_open_tasks_url: "https://tribu.example.com/api/tasks?family_id=1&status=open&limit=1"
-tribu_shopping_lists_url: "https://tribu.example.com/api/shopping/lists?family_id=1"
-tribu_quick_capture_url: "https://tribu.example.com/api/quick-capture"
-tribu_webhook_id: choose-a-long-random-home-assistant-webhook-id
-```
-
-Do not paste token values into screenshots, GitHub issues, logs, or support requests.
-
-A redacted Authorization header should look like this in docs or logs:
-
-```text
-Authorization: Bearer *** tribu_token
-```
-
-When an example supports direct Home Assistant secret substitution, prefer references such as `!secret tribu_url`, `!secret tribu_token`, and `!secret tribu_family_id` instead of copying raw values.
+See [Home Assistant: Create a Tribu token](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#1-create-a-tribu-token).
 
 ### 2. Enable packages in Home Assistant
 
-If packages are not enabled yet, add this to Home Assistant `configuration.yaml`:
-
-```yaml
-homeassistant:
-  packages: !include_dir_named packages
-```
-
-Create the directory if needed:
-
-```bash
-mkdir -p /config/packages
-```
-
-Copy [`tribu_package.yaml`](../integrations/home-assistant/tribu_package.yaml) into `/config/packages/tribu.yaml` and restart Home Assistant.
+See [Home Assistant: Enable packages](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#2-enable-packages-in-home-assistant).
 
 ### 3. Add the dashboard card
 
-Copy the contents of [`dashboard-card.yaml`](../integrations/home-assistant/dashboard-card.yaml) into a Lovelace manual card. The card displays:
-
-- next Tribu event
-- open tasks
-- open shopping items
-- upcoming birthdays
+See [Home Assistant: Add the dashboard card](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#3-add-the-dashboard-card).
 
 ## Quick capture from Home Assistant
 
-The package includes `rest_command.tribu_add_quick_capture`. Use it from a script, button, or automation like this:
-
-```yaml
-action: rest_command.tribu_add_quick_capture
-data:
-  family_id: !secret tribu_family_id
-  text: "Buy oat milk"
-  destination: shopping
-```
-
-Allowed destinations are `inbox`, `task`, and `shopping`. Start with `inbox` when testing a new token.
+See [Home Assistant: Quick capture](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#quick-capture-from-home-assistant).
 
 ## Outbound webhook events from Tribu
 
-Tribu can send outbound webhooks to Home Assistant. Create a Home Assistant webhook automation with a secret `tribu_webhook_id`, then create a Tribu webhook endpoint that points to:
-
-```text
-https://home-assistant.example.com/api/webhook/<tribu_webhook_id>
-```
-
-Subscribe that endpoint to useful Tribu events, for example:
-
-- `calendar.event.created`
-- `task.created`
-- `task.updated`
-- `shopping.item.created`
-- `shopping.item.updated`
-- `quick_capture.created`
-- `birthday.created`
-
-The package includes a simple persistent notification automation so you can verify that Home Assistant receives events. Replace it with your own automations when the connection works.
+See [Home Assistant: Outbound webhook events](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#outbound-webhook-events-from-tribu).
 
 ## Dashboard example
 
-The dashboard example is intentionally small. Start with this first, then build your own room dashboard or family overview once the sensors update correctly.
-
-```yaml
-type: entities
-title: Tribu household
-entities:
-  - entity: sensor.tribu_next_event
-  - entity: sensor.tribu_open_tasks
-  - entity: sensor.tribu_open_shopping_items
-  - entity: sensor.tribu_upcoming_birthdays
-```
+See [Home Assistant: Dashboard example](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#dashboard-example).
 
 ## Privacy boundaries
 
-- Tribu data shown in Home Assistant becomes visible to people and integrations that can access your Home Assistant instance.
-- The package reads only family summary, open task count, shopping list counts, and upcoming birthday count by default.
-- The quick-capture command is opt-in and requires `quick_capture:write`.
-- Do not put full Tribu tokens, webhook IDs, or real private URLs into package YAML committed to a repository.
-- Keep Home Assistant diagnostics and screenshots redacted when asking for help.
+See [Home Assistant: Privacy boundaries](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#privacy-boundaries).
 
 ## Troubleshooting
 
-### Sensors are unavailable
-
-- Check that `tribu_url` points to the externally reachable Tribu URL.
-- Check that the REST URLs include `/api/` when you access Tribu through the frontend/reverse proxy.
-- Check that the token has the required read scopes.
-- Confirm Home Assistant can reach Tribu from inside the HA container or host.
-
-### Sensors show zero or empty data
-
-- Confirm `tribu_family_id` matches your family id.
-- Open the matching Tribu API URL in a browser while authenticated, or test with curl using the redacted pattern above.
-- For shopping, make sure the package points to `/api/shopping/lists?family_id=...`.
-
-### Webhook events do not arrive
-
-- Confirm the Home Assistant automation uses the same `tribu_webhook_id` stored in `secrets.yaml`.
-- Confirm the Tribu webhook endpoint uses `/api/webhook/<id>` on the Home Assistant side.
-- Use the Tribu webhook test button first. The Tribu UI should show a delivery status without exposing the full URL or token.
-- Check Home Assistant automation traces for the webhook automation.
-
-### Quick capture fails
-
-- Make sure the token includes `quick_capture:write`.
-- Make sure the payload includes the current `tribu_family_id`.
-- Start with destination `inbox`, then try `task` or `shopping` after the basic command works.
+See [Home Assistant: Troubleshooting](https://github.com/itsDNNS/tribu/wiki/Home-Assistant#troubleshooting).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,548 +1,62 @@
 # Self-Hosting Guide
 
-Everything you need to run Tribu on your own server.
+The GitHub Wiki is the primary documentation entry point for self-hosting Tribu.
+
+Use the current guide here:
+
+[Open the Self-Hosting Guide in the Wiki →](https://github.com/itsDNNS/tribu/wiki/Self-Hosting)
+
+This repository page remains as a compatibility pointer for existing links. Keep detailed setup, operations, integration, backup, update, and troubleshooting guidance in the Wiki so self-hosters have one current place to read.
 
 ## Use this guide for
 
+Use the Wiki guide for:
+
 - installing Tribu on your own infrastructure
-- configuring environment variables, reverse proxy, and phone sync
+- configuring environment variables, reverse proxy, SSO, and phone sync
 - connecting Home Assistant through REST sensors and Tribu webhooks
 - backups, updates, and troubleshooting in production-like setups
 
-If you want the public overview, start with the [README](../README.md).
-If you want local development workflow, tests, and PR expectations, use [CONTRIBUTING.md](../CONTRIBUTING.md).
-
 ## Prerequisites
 
-- **Docker** with **Compose v2** (`docker compose`, not the legacy `docker-compose`)
-- **512 MB RAM** minimum, **1 GB disk** for the database volume
-- A **domain with TLS** if you plan to expose Tribu to the internet (see [Reverse Proxy](#reverse-proxy))
+See [Self-Hosting: Prerequisites](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#prerequisites).
 
 ## Quick Start
 
-The fastest path is the stack snippet in the [README](../README.md#quick-start). It works with Portainer, Dockge, Dockhand, or the CLI.
-
-```bash
-mkdir tribu && cd tribu
-curl -LO https://raw.githubusercontent.com/itsDNNS/tribu/main/docker/docker-compose.yml
-curl -LO https://raw.githubusercontent.com/itsDNNS/tribu/main/docker/.env.example
-cp .env.example .env
-# Fill in JWT_SECRET and POSTGRES_PASSWORD (see below)
-docker compose up -d
-```
-
-Open [localhost:3000](http://localhost:3000) and register. The first user becomes the family admin.
+See [Self-Hosting: Quick Start](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#quick-start).
 
 ## Home Assistant
 
-Tribu ships a Home Assistant package for REST sensors, a webhook automation example, a quick-capture REST command, and a small dashboard card. See [Home Assistant integration](home-assistant.md) for setup and privacy notes.
+See [Home Assistant integration](https://github.com/itsDNNS/tribu/wiki/Home-Assistant).
 
 ## Configuration Reference
 
-All configuration is done through environment variables in your `.env` file.
-
-### Required
-
-| Variable | Description | Generate with |
-|----------|-------------|---------------|
-| `JWT_SECRET` | Secret key for signing JWT auth tokens | `openssl rand -hex 32` |
-| `POSTGRES_PASSWORD` | PostgreSQL database password | `openssl rand -hex 16` |
-
-The backend refuses to start if these are missing.
-
-### Optional
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SECURE_COOKIES` | `false` | Set to `true` when running behind a TLS reverse proxy. Enables the `Secure` flag on auth cookies. |
-| `BASE_URL` | *(auto-detect)* | Public URL of your instance (e.g. `https://tribu.example.com`). Used for push notification payloads. Auto-detected from request headers if not set. |
-| `JWT_EXPIRE_HOURS` | `24` | Session lifetime in hours for Tribu's auth tokens and cookies. |
-| `ALLOW_OPEN_REGISTRATION` | `false` | Enables public registration after initial setup. Keep disabled for normal self-hosted instances and invite users instead. |
-| `SETUP_RESTORE_TOKEN` | empty | Required for initial setup restore. Leave empty to disable setup restore, or set a one-time secret and enter it in the restore screen. |
-| `SETUP_RESTORE_MAX_BYTES` | `104857600` | Maximum setup restore archive size in bytes. |
-| `VAPID_PUBLIC_KEY` | *(empty)* | VAPID public key for push notifications. See [Push Notifications](#push-notifications-optional). |
-| `VAPID_PRIVATE_KEY` | *(empty)* | VAPID private key for push notifications. |
-| `VAPID_CLAIMS_EMAIL` | *(empty)* | Contact email for VAPID claims (e.g. `mailto:admin@example.com`). |
-| `REDIS_URL` | `redis://valkey:6379/0` | Optional Valkey-compatible cache connection string override. |
-
-### Docker Compose Internals
-
-These variables are constructed in `docker-compose.yml` and normally don't need manual changes:
-
-| Variable | Value |
-|----------|-------|
-| `DATABASE_URL` | Built from `POSTGRES_PASSWORD`: `postgresql://tribu:<password>@postgres:5432/tribu` |
-| `REDIS_URL` | `redis://valkey:6379/0` (overridable, see above) |
+See [Self-Hosting: Configuration Reference](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#configuration-reference).
 
 ## Reverse Proxy
 
-Running behind a reverse proxy gives you TLS (HTTPS), a clean domain, and is **required** for secure cookies. Set `SECURE_COOKIES=true` in your `.env` when using any of these.
-
-> All examples assume Tribu runs on the same host with the default ports (backend: 8000, frontend: 3000). `/api` must be forwarded to the backend **without** the `/api` prefix, while `/dav` and `/.well-known/{caldav,carddav}` must reach the backend unchanged. The `/ws` examples below are required for shopping live sync.
->
-> Shopping live sync uses the current frontend origin and the proxied `/ws/shopping/...` path. Ensure your reverse proxy forwards `/ws/*` to the backend with WebSocket upgrade headers.
-
-### Caddy (recommended)
-
-Caddy handles TLS certificates automatically via Let's Encrypt.
-
-```
-tribu.example.com {
-	handle_path /api/* {
-		reverse_proxy localhost:8000
-	}
-	handle /ws/* {
-		reverse_proxy localhost:8000
-	}
-	handle /dav {
-		reverse_proxy localhost:8000
-	}
-	handle /dav/* {
-		reverse_proxy localhost:8000
-	}
-	handle /.well-known/caldav {
-		reverse_proxy localhost:8000
-	}
-	handle /.well-known/carddav {
-		reverse_proxy localhost:8000
-	}
-	handle {
-		reverse_proxy localhost:3000
-	}
-}
-```
-
-### Nginx
-
-If you want the simplest setup, proxy everything to the frontend on port `3000`. Tribu's frontend already rewrites `/api/*`, `/dav*`, and `/.well-known/{caldav,carddav}` to the backend.
-
-```nginx
-upstream tribu-app {
-    zone tribu-app 64k;
-    server 127.0.0.1:3000;
-    keepalive 2;
-}
-
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    ''      "";
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name tribu.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/tribu.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/tribu.example.com/privkey.pem;
-    client_max_body_size 10M;
-
-    location / {
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass http://tribu-app;
-        proxy_read_timeout 180s;
-    }
-}
-```
-
-If you prefer handling backend routes directly in nginx, this split setup also works. Keep the trailing slash on `proxy_pass http://127.0.0.1:8000/;` inside `location /api/` so nginx strips the `/api` prefix before forwarding to the backend.
-
-```nginx
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name tribu.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/tribu.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/tribu.example.com/privkey.pem;
-    client_max_body_size 10M;
-
-    location /api/ {
-        proxy_pass http://127.0.0.1:8000/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location /ws/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location = /dav {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location /dav/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location = /.well-known/caldav {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location = /.well-known/carddav {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location / {
-        proxy_pass http://127.0.0.1:3000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
-```
-
-### Traefik
-
-Add these labels to the `frontend` service in your `docker-compose.yml`:
-
-```yaml
-frontend:
-  labels:
-    - "traefik.enable=true"
-    - "traefik.http.routers.tribu.rule=Host(`tribu.example.com`)"
-    - "traefik.http.routers.tribu.entrypoints=websecure"
-    - "traefik.http.routers.tribu.tls.certresolver=letsencrypt"
-    - "traefik.http.services.tribu.loadbalancer.server.port=3000"
-```
-
-And for the `backend` service:
-
-```yaml
-backend:
-  labels:
-    - "traefik.enable=true"
-    - "traefik.http.middlewares.tribu-api-strip.stripprefix.prefixes=/api"
-    - "traefik.http.routers.tribu-api.rule=Host(`tribu.example.com`) && PathPrefix(`/api`)"
-    - "traefik.http.routers.tribu-api.entrypoints=websecure"
-    - "traefik.http.routers.tribu-api.tls.certresolver=letsencrypt"
-    - "traefik.http.routers.tribu-api.middlewares=tribu-api-strip"
-    - "traefik.http.routers.tribu-ws.rule=Host(`tribu.example.com`) && PathPrefix(`/ws`)"
-    - "traefik.http.routers.tribu-ws.entrypoints=websecure"
-    - "traefik.http.routers.tribu-ws.tls.certresolver=letsencrypt"
-    - "traefik.http.routers.tribu-ws.service=tribu-api"
-    - "traefik.http.routers.tribu-dav.rule=Host(`tribu.example.com`) && (PathPrefix(`/dav`) || Path(`/.well-known/caldav`) || Path(`/.well-known/carddav`))"
-    - "traefik.http.routers.tribu-dav.entrypoints=websecure"
-    - "traefik.http.routers.tribu-dav.tls.certresolver=letsencrypt"
-    - "traefik.http.routers.tribu-dav.service=tribu-api"
-    - "traefik.http.services.tribu-api.loadbalancer.server.port=8000"
-```
-
-When using Traefik, remove the `ports` sections from both services since Traefik handles routing. Shopping live sync uses the proxied `/ws` route, so the backend port does not need to be exposed publicly when Traefik handles `/ws`.
+See [Self-Hosting: Reverse Proxy](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#reverse-proxy).
 
 ## Single Sign-On (OIDC)
 
-Tribu speaks OpenID Connect, so you can delegate authentication to an existing identity provider (Authentik, Zitadel, Keycloak, or any other OIDC-compatible stack).
-
-### 1. Create a client at your provider
-
-Set these values when you register Tribu as an OIDC client:
-
-- **Redirect URI / Callback URL**: `https://<your-tribu-domain>/auth/oidc/callback`
-- **Client type**: Confidential (Tribu stores a client secret).
-- **Grant type**: Authorization Code with **PKCE (S256)**.
-- **Scopes**: `openid profile email` (Tribu needs the `email` + `email_verified` claims to match a login to an existing family member).
-
-Provider-specific hints:
-
-| Provider | Issuer URL shape | Notes |
-|----------|------------------|-------|
-| Authentik | `https://auth.example.com/application/o/tribu/` | Copy the value of "OpenID Configuration Issuer" from the provider page. The trailing slash matters. |
-| Zitadel | `https://<instance>.zitadel.cloud` | Register a "Web" application with PKCE. The issuer is your instance root URL. |
-| Keycloak | `https://keycloak.example.com/realms/<realm>` | Create a confidential OIDC client in the realm hosting your users. If the client's `token_endpoint_auth_method` is pinned to `client_secret_basic`, Tribu will fall back to HTTP Basic automatically. |
-| Generic | `https://idp.example.com` | Any OIDC-conformant provider with a `/.well-known/openid-configuration` document. |
-
-### 2. Enable SSO in Tribu
-
-Sign in as an admin, open **Admin settings > Single Sign-On**, and fill in:
-
-- **Provider preset**: Pick your provider for better placeholders and the default button label.
-- **Issuer URL**: From the table above.
-- **Client ID / Client secret**: From your provider.
-- **Scopes**: Leave at `openid profile email` unless your provider is unusual.
-- **Allow new accounts via SSO**: Required only if you also share SSO-backed invitation links (see below).
-- **Disable password login**: Optional. Only takes effect once SSO is fully configured so you cannot lock yourself out.
-
-Use **Test discovery** to verify the provider is reachable before saving.
-
-### 3. User onboarding paths
-
-- **Matching an existing account by email.** When an SSO login arrives for an email that already belongs to a Tribu user, Tribu links the new identity and logs them in. The provider must mark the email as verified (`email_verified=true` in the ID token), otherwise Tribu refuses to link.
-- **Invitation-bound signup.** If **Allow new accounts via SSO** is enabled, creating an invitation link via **Admin > Invitations** and sharing it with a new family member lets them finish onboarding entirely through the IdP. The link's preset role + adult flag apply on creation.
-- **Local admin recovery.** Password login is preserved as long as **Disable password login** is unchecked. Even if you flip it on, Tribu's `/auth/register-with-invite` and `/auth/login` endpoints only refuse password auth when SSO is *ready* (enabled + issuer + client configured), so mis-configurations never lock out the admin.
-
-### 4. Reverse proxy
-
-All Tribu reverse-proxy examples in this guide already forward `/auth/oidc/*` to the Tribu frontend, which proxies it to the backend. No extra rules are needed. If you use a custom split setup that routes `/api/*` directly to the backend, do **not** route `/auth/oidc/*` directly. Keep it going through the frontend so the callback URL (`/auth/oidc/callback`) matches what your IdP has registered.
-
-### 5. Secret storage
-
-The client secret is stored in Tribu's `system_settings` table as plaintext, the same trust model as `JWT_SECRET` in your `.env`. Put the database volume on encrypted storage if your threat model requires it, and rotate the secret by editing the admin form and clicking **Clear secret** before pasting a new one.
+See [Self-Hosting: Single Sign-On](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#single-sign-on-oidc) and [Single Sign-On (OIDC)](https://github.com/itsDNNS/tribu/wiki/Single-Sign-On-(OIDC)).
 
 ## Push Notifications (Optional)
 
-Tribu supports browser push notifications for event reminders, overdue tasks, and birthday alerts.
-
-### 1. Generate VAPID Keys
-
-```bash
-# Requires Node.js
-npx web-push generate-vapid-keys
-```
-
-This outputs a public key, private key, and a subject line.
-
-### 2. Add to `.env`
-
-```
-VAPID_PUBLIC_KEY=BPxr...your-public-key
-VAPID_PRIVATE_KEY=your-private-key
-VAPID_CLAIMS_EMAIL=admin@example.com
-```
-
-### 3. Restart
-
-```bash
-docker compose up -d
-```
-
-Users can then enable push notifications from their profile settings. Push notifications require HTTPS (a reverse proxy with TLS). On iPhone and iPad, Web Push only works for the installed Home Screen app on supported iOS/Safari versions, not from a normal browser tab. If Settings says server push is not configured, verify all three VAPID variables are set and restart the backend.
+See [Self-Hosting: Push Notifications](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#push-notifications-optional).
 
 ## Phone Sync (CalDAV / CardDAV)
 
-Tribu can sync calendars and contacts with phones and DAV-compatible clients via **CalDAV** and **CardDAV**.
-
-### Requirements
-
-- A running Tribu instance with a reachable public or local URL
-- HTTPS if you want to connect phones outside a trusted local-only setup
-- A user account that already belongs to the relevant family
-- A **Personal Access Token (PAT)** for DAV login
-
-### Where to find the sync URLs
-
-After signing in to Tribu:
-
-1. Open **Settings**
-2. Go to **Phone sync**
-3. Copy the **CalDAV** and **CardDAV** URLs for the family you want to sync
-
-Tribu shows one calendar URL and one address book URL per family.
-
-### Authentication
-
-DAV clients use **HTTP Basic Auth** with:
-
-- **Username:** your Tribu email address
-- **Password:** a Tribu Personal Access Token (PAT)
-
-Recommended PAT scopes:
-
-- `calendar:read` / `calendar:write`
-- `contacts:read` / `contacts:write`
-
-Use read-only scopes if you only want a subscription-style setup. Use write scopes if events and contacts should sync back into Tribu.
-
-### iPhone / iPad setup
-
-For calendars:
-
-1. Open **Settings → Apps → Calendar → Calendar Accounts → Add Account → Other → Add CalDAV Account**
-2. Paste the CalDAV URL from **Settings → Phone sync** in Tribu
-3. Enter your Tribu email address and PAT
-4. Save and allow the device to sync
-
-For contacts:
-
-1. Open **Settings → Apps → Contacts → Contacts Accounts → Add Account → Other → Add CardDAV Account**
-2. Paste the CardDAV URL from Tribu
-3. Enter your Tribu email address and PAT
-4. Save and allow the device to sync
-
-### Android setup
-
-The most common setup is **DAVx5**:
-
-1. Install **DAVx5**
-2. Add a new account
-3. Choose login with URL and credentials
-4. Paste the CalDAV/CardDAV URL from Tribu
-5. Sign in with your Tribu email address and PAT
-6. Select the collections you want to sync
-
-### What to expect
-
-Once connected, you can:
-
-- create and edit events on your phone and see them in Tribu
-- create and edit contacts on your phone and keep them in sync
-- use Tribu as the shared source of truth for family calendars and contacts
-
-### Troubleshooting
-
-- Make sure the PAT has the scopes required for the DAV collection you want to use
-- If login works in the browser but not in the DAV client, double-check that you are using the **PAT**, not your normal account password
-- If you are exposing Tribu through a reverse proxy, confirm HTTPS is working correctly and the public URL is stable
-- If the client appears stale after reconnecting, force a refresh/resync in the DAV app once before troubleshooting deeper
+See [Self-Hosting: Phone Sync](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#phone-sync-caldav--carddav).
 
 ## Backup & Restore
 
-Tribu has a built-in backup system accessible from the Admin panel.
-
-### Automatic Backups
-
-Configure automatic backups in **Settings > Admin > Backup**:
-
-- **Schedule**: daily, weekly, or monthly
-- **Retention**: how many backups to keep (oldest are deleted automatically)
-
-### Backup Format
-
-Each backup is a `tribu-backup-YYYY-MM-DD-HHMMSS.tar.gz` archive containing:
-
-- `database.dump`: PostgreSQL dump (`pg_dump -Fc` custom format)
-- `metadata.json`: backup version, Alembic revision, PostgreSQL version, timestamp
-
-The export is a database backup. It includes Tribu household data such as calendars, tasks, contacts, shopping lists, meal plans, recipes, rewards, gifts, families, members, and app settings stored in the database.
-
-It does not include deployment-level secrets or host files such as `JWT_SECRET`, OIDC client secrets, reverse proxy configuration, TLS certificates, or files outside the database and configured backup volume. Keep your `.env`, Compose file, and reverse proxy configuration in your normal server backup.
-
-### Manual Backup
-
-Trigger a backup from the Admin panel or via API:
-
-```bash
-curl -X POST http://localhost:8000/admin/backup/trigger \
-  -H "Cookie: tribu_token=<your-jwt>"
-```
-
-### Restore
-
-Backups can be restored during the **Setup Wizard** on a fresh installation. Upload a backup archive and Tribu restores the database and runs any pending migrations automatically.
-
-### External Backup Storage
-
-By default, backups are stored in a Docker volume. To store them on a NAS or external drive, replace the volume with a bind mount in your `docker-compose.yml`:
-
-```yaml
-backend:
-  volumes:
-    - /mnt/nas/backups/tribu:/backups
-```
-
-### API Endpoints
-
-All backup endpoints require admin privileges.
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/admin/backup/config` | Get backup configuration |
-| `PUT` | `/admin/backup/config` | Update schedule and retention |
-| `POST` | `/admin/backup/trigger` | Trigger manual backup |
-| `GET` | `/admin/backup/list` | List all backups |
-| `GET` | `/admin/backup/{filename}/download` | Download backup file |
-| `DELETE` | `/admin/backup/{filename}` | Delete backup file |
+See [Backup & Restore](https://github.com/itsDNNS/tribu/wiki/Backup-&-Restore).
 
 ## Updating
 
-```bash
-docker compose pull
-docker compose up -d
-```
-
-Database migrations run automatically on startup via Alembic. No manual migration steps needed.
-
-> **Tip:** Check the [Changelog](https://github.com/itsDNNS/tribu/wiki/Changelog) before updating for any breaking changes.
+See [Self-Hosting: Updating](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#updating).
 
 ## Troubleshooting
 
-### Container won't start
-
-Check logs for the failing service:
-
-```bash
-docker compose logs backend
-docker compose logs frontend
-docker compose logs postgres
-```
-
-Common causes:
-- Missing `JWT_SECRET` or `POSTGRES_PASSWORD`: the backend exits immediately with an error message
-- Port 8000 or 3000 already in use: change the host port in `docker-compose.yml` (e.g. `"8080:8000"`)
-
-### Database connection errors
-
-```bash
-# Check if PostgreSQL is running
-docker compose ps postgres
-
-# Test connection from the backend container
-docker compose exec backend python -c "from app.database import engine; engine.connect()"
-```
-
-The backend waits for PostgreSQL on startup, but if the database takes too long to initialize (first run), restart the backend:
-
-```bash
-docker compose restart backend
-```
-
-### Cookies not working behind a reverse proxy
-
-If you can log in but get redirected back to the login page:
-
-1. Make sure `SECURE_COOKIES=true` is set in `.env`
-2. Verify your reverse proxy forwards the `X-Forwarded-Proto` header
-3. Confirm your browser receives the cookie with the `Secure` flag (DevTools > Application > Cookies)
-
-If running locally without TLS, keep `SECURE_COOKIES=false`.
-
-### Push notifications not working
-
-- VAPID keys must be set in `.env` **and** the backend must be restarted
-- Push notifications require HTTPS, so they will not work over plain HTTP
-- The user must explicitly enable notifications in their profile settings
-- Check browser permissions (Settings > Site permissions > Notifications)
-
-### Rate limiting
-
-The backend applies rate limits to auth endpoints:
-
-| Endpoint | Limit |
-|----------|-------|
-| `POST /auth/register` | 10 requests/minute |
-| `POST /auth/login` | 20 requests/minute |
-| `POST /auth/register-with-invite` | 10 requests/minute |
-
-If you hit rate limits during testing, wait 60 seconds or restart the backend container (resets the in-memory rate limiter).
+See [Self-Hosting: Troubleshooting](https://github.com/itsDNNS/tribu/wiki/Self-Hosting#troubleshooting).


### PR DESCRIPTION
## Summary
- makes the Wiki the primary documentation entry point from the README
- moves self-hosting and Home Assistant guides into the Wiki, with repo stubs that preserve old links
- adds a repo-local documentation ownership policy and inventory

## Validation
- `git diff --check`
- local Markdown link validation script
- Wiki Markdown link validation script

Closes #270
