### PR TITLE
Add customizable dashboard module layout

### DIFF
--- a/backend/alembic/versions/0046_add_dashboard_layout_preference.py
+++ b/backend/alembic/versions/0046_add_dashboard_layout_preference.py
@@ -1,0 +1,25 @@
+"""add dashboard layout preference
+
+Revision ID: 0046
+Revises: 0045
+Create Date: 2026-04-30 03:35:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0046"
+down_revision: Union[str, None] = "0045"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("user_nav_order", sa.Column("dashboard_layout", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_nav_order", "dashboard_layout")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -518,6 +518,7 @@ class UserNavOrder(Base):
 
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
     nav_order = Column(JSON, nullable=False, default=["dashboard", "calendar", "shopping", "tasks", "templates", "contacts", "notifications", "settings"])
+    dashboard_layout = Column(JSON, nullable=True)
 
 
 class AuditLog(Base):

--- a/backend/app/modules/nav_router.py
+++ b/backend/app/modules/nav_router.py
@@ -6,13 +6,15 @@ from app.core.deps import current_user
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import User, UserNavOrder
-from app.schemas import AUTH_RESPONSES, NavOrderResponse, NavOrderUpdate
+from app.schemas import AUTH_RESPONSES, DashboardLayoutResponse, DashboardLayoutUpdate, NavOrderResponse, NavOrderUpdate
 from app.core.errors import error_detail, UNKNOWN_NAV_KEYS
 
 router = APIRouter(prefix="/nav", tags=["nav"], responses={**AUTH_RESPONSES})
 
 DEFAULT_NAV_ORDER = ["dashboard", "calendar", "shopping", "tasks", "templates", "meal_plans", "recipes", "contacts", "notifications", "settings", "admin"]
 KNOWN_KEYS = {"dashboard", "calendar", "shopping", "tasks", "templates", "rewards", "gifts", "meal_plans", "recipes", "contacts", "notifications", "settings", "admin"}
+DEFAULT_DASHBOARD_LAYOUT = ["quick_capture", "daily_loop", "events", "tasks", "birthdays", "activity", "rewards"]
+KNOWN_DASHBOARD_MODULES = set(DEFAULT_DASHBOARD_LAYOUT)
 
 
 @router.get(
@@ -53,3 +55,70 @@ def update_nav_order(payload: NavOrderUpdate, user: User = Depends(current_user)
     db.commit()
     cache.invalidate(f"tribu:nav_order:{user.id}")
     return NavOrderResponse(nav_order=row.nav_order)
+
+
+@router.get(
+    "/dashboard-layout",
+    response_model=DashboardLayoutResponse,
+    summary="Get dashboard module layout",
+    description="Return the current user's custom dashboard module order, or the default if not set.",
+    response_description="Dashboard module layout",
+)
+def get_dashboard_layout(user: User = Depends(current_user), db: Session = Depends(get_db), _scope=require_scope("profile:read")):
+    def _load():
+        row = db.query(UserNavOrder).filter(UserNavOrder.user_id == user.id).first()
+        modules = row.dashboard_layout if row and row.dashboard_layout else DEFAULT_DASHBOARD_LAYOUT
+        return {"modules": _normalize_dashboard_modules(modules)}
+    data = cache.get_or_set(f"tribu:dashboard_layout:{user.id}", 600, _load)
+    return DashboardLayoutResponse(**data)
+
+
+@router.put(
+    "/dashboard-layout",
+    response_model=DashboardLayoutResponse,
+    summary="Update dashboard module layout",
+    description="Save a custom dashboard module order for the current user.",
+    response_description="Updated dashboard module layout",
+)
+def update_dashboard_layout(payload: DashboardLayoutUpdate, user: User = Depends(current_user), db: Session = Depends(get_db), _scope=require_scope("profile:write")):
+    modules = _validate_dashboard_modules(payload.modules)
+    row = db.query(UserNavOrder).filter(UserNavOrder.user_id == user.id).first()
+    if row:
+        row.dashboard_layout = modules
+    else:
+        row = UserNavOrder(user_id=user.id, nav_order=DEFAULT_NAV_ORDER, dashboard_layout=modules)
+        db.add(row)
+    db.commit()
+    cache.invalidate(f"tribu:dashboard_layout:{user.id}")
+    return DashboardLayoutResponse(modules=row.dashboard_layout)
+
+
+@router.delete(
+    "/dashboard-layout",
+    response_model=DashboardLayoutResponse,
+    summary="Reset dashboard module layout",
+    description="Reset the current user's dashboard module order back to the default.",
+    response_description="Default dashboard module layout",
+)
+def reset_dashboard_layout(user: User = Depends(current_user), db: Session = Depends(get_db), _scope=require_scope("profile:write")):
+    row = db.query(UserNavOrder).filter(UserNavOrder.user_id == user.id).first()
+    if row:
+        row.dashboard_layout = None
+        db.commit()
+    cache.invalidate(f"tribu:dashboard_layout:{user.id}")
+    return DashboardLayoutResponse(modules=DEFAULT_DASHBOARD_LAYOUT)
+
+
+def _normalize_dashboard_modules(modules: list[str]) -> list[str]:
+    seen = []
+    for module in modules:
+        if module in KNOWN_DASHBOARD_MODULES and module not in seen:
+            seen.append(module)
+    return seen + [module for module in DEFAULT_DASHBOARD_LAYOUT if module not in seen]
+
+
+def _validate_dashboard_modules(modules: list[str]) -> list[str]:
+    invalid = [module for module in modules if module not in KNOWN_DASHBOARD_MODULES]
+    if invalid:
+        raise HTTPException(status_code=422, detail=error_detail(UNKNOWN_NAV_KEYS, keys=', '.join(invalid)))
+    return _normalize_dashboard_modules(modules)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1152,6 +1152,16 @@ class NavOrderUpdate(BaseModel):
     nav_order: list[str] = Field(min_length=1, max_length=10, description="Ordered list of view keys")
 
 
+class DashboardLayoutResponse(BaseModel):
+    """User's dashboard module layout."""
+    modules: list[str] = Field(..., description="Ordered dashboard module keys")
+
+
+class DashboardLayoutUpdate(BaseModel):
+    """Update dashboard module layout."""
+    modules: list[str] = Field(min_length=1, max_length=12, description="Ordered dashboard module keys")
+
+
 # ---------------------------------------------------------------------------
 # Invitations
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_dashboard_layout.py
+++ b/backend/tests/test_dashboard_layout.py
@@ -1,0 +1,136 @@
+"""Integration tests for per-user dashboard module layout preferences."""
+
+import hashlib
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import PersonalAccessToken, User, UserNavOrder
+from app.security import PAT_PREFIX, hash_password
+
+
+engine = create_engine("sqlite:///./test-dashboard-layout.db", connect_args={"check_same_thread": False})
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_user(scopes: str = "*") -> tuple[str, int]:
+    db = TestSession()
+    user = User(
+        email=f"dashboard-layout-{scopes.replace(':', '-').replace('*', 'star')}@example.com",
+        password_hash=hash_password("Password1"),
+        display_name="Dashboard User",
+    )
+    db.add(user)
+    db.flush()
+    plain = f"{PAT_PREFIX}dashboard-layout-{scopes.replace(',', '-').replace(':', '_').replace('*', 'star')}"
+    fingerprint = hashlib.sha256(plain.encode()).hexdigest()
+    db.add(PersonalAccessToken(user_id=user.id, name="dashboard-layout-pat", token_hash=fingerprint, token_lookup=fingerprint, scopes=scopes))
+    db.commit()
+    user_id = user.id
+    db.close()
+    return plain, user_id
+
+
+def test_dashboard_layout_persists_normalizes_and_resets_per_user():
+    token, user_id = _seed_user()
+
+    default_response = client.get("/nav/dashboard-layout", headers=_auth(token))
+    assert default_response.status_code == 200, default_response.json()
+    assert default_response.json()["modules"] == [
+        "quick_capture",
+        "daily_loop",
+        "events",
+        "tasks",
+        "birthdays",
+        "activity",
+        "rewards",
+    ]
+
+    update_response = client.put(
+        "/nav/dashboard-layout",
+        json={"modules": ["tasks", "events", "tasks", "quick_capture"]},
+        headers=_auth(token),
+    )
+    assert update_response.status_code == 200, update_response.json()
+    assert update_response.json()["modules"] == [
+        "tasks",
+        "events",
+        "quick_capture",
+        "daily_loop",
+        "birthdays",
+        "activity",
+        "rewards",
+    ]
+
+    db = TestSession()
+    row = db.query(UserNavOrder).filter(UserNavOrder.user_id == user_id).first()
+    assert row is not None
+    assert row.dashboard_layout[0:3] == ["tasks", "events", "quick_capture"]
+    db.close()
+
+    saved_response = client.get("/nav/dashboard-layout", headers=_auth(token))
+    assert saved_response.status_code == 200, saved_response.json()
+    assert saved_response.json()["modules"][0:3] == ["tasks", "events", "quick_capture"]
+
+    reset_response = client.delete("/nav/dashboard-layout", headers=_auth(token))
+    assert reset_response.status_code == 200, reset_response.json()
+    assert reset_response.json()["modules"][0:2] == ["quick_capture", "daily_loop"]
+
+
+def test_dashboard_layout_rejects_unknown_modules_and_enforces_scopes():
+    read_token, _ = _seed_user(scopes="profile:read")
+    write_token, _ = _seed_user(scopes="profile:write")
+
+    forbidden_read = client.get("/nav/dashboard-layout", headers=_auth(write_token))
+    assert forbidden_read.status_code == 403
+
+    forbidden_write = client.put(
+        "/nav/dashboard-layout",
+        json={"modules": ["tasks", "events"]},
+        headers=_auth(read_token),
+    )
+    assert forbidden_write.status_code == 403
+
+    invalid = client.put(
+        "/nav/dashboard-layout",
+        json={"modules": ["tasks", "unknown"]},
+        headers=_auth(write_token),
+    )
+    assert invalid.status_code == 422
+    assert "unknown" in str(invalid.json())

--- a/frontend/__tests__/components/DashboardActivationPanel.test.js
+++ b/frontend/__tests__/components/DashboardActivationPanel.test.js
@@ -16,8 +16,11 @@ jest.mock('../../lib/i18n', () => ({
 jest.mock('../../lib/api', () => ({
   apiCompleteSetupChecklistStep: jest.fn(() => Promise.resolve({ ok: true, data: { dismissed: false, show_on_dashboard: false, completed_count: 1, total_count: 1, steps: [] } })),
   apiDismissSetupChecklist: jest.fn(() => Promise.resolve({ ok: true })),
+  apiGetDashboardLayout: jest.fn(() => new Promise(() => {})),
   apiGetSetupChecklist: jest.fn(() => Promise.resolve({ ok: false })),
   apiListMealPlans: jest.fn(() => Promise.resolve({ ok: true, data: [] })),
+  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
+  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
 }));
 
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {

--- a/frontend/__tests__/components/DashboardDailyLoop.test.js
+++ b/frontend/__tests__/components/DashboardDailyLoop.test.js
@@ -10,8 +10,11 @@ jest.mock('../../contexts/AppContext', () => ({
 }));
 
 jest.mock('../../lib/api', () => ({
+  apiGetDashboardLayout: jest.fn(() => new Promise(() => {})),
   apiGetSetupChecklist: jest.fn(),
   apiListMealPlans: jest.fn(),
+  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
+  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
 }));
 
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {

--- a/frontend/__tests__/components/DashboardDesktopLayout.test.js
+++ b/frontend/__tests__/components/DashboardDesktopLayout.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DashboardView from '../../components/DashboardView';
 
@@ -14,9 +14,16 @@ jest.mock('../../lib/i18n', () => ({
   t: (messages, key) => messages?.[key] || key,
 }));
 
+const mockApiGetDashboardLayout = jest.fn();
+const mockApiUpdateDashboardLayout = jest.fn();
+const mockApiResetDashboardLayout = jest.fn();
+
 jest.mock('../../lib/api', () => ({
+  apiGetDashboardLayout: (...args) => mockApiGetDashboardLayout(...args),
   apiGetSetupChecklist: jest.fn().mockResolvedValue({ ok: true, data: null }),
   apiListMealPlans: jest.fn().mockResolvedValue({ ok: true, data: [] }),
+  apiResetDashboardLayout: (...args) => mockApiResetDashboardLayout(...args),
+  apiUpdateDashboardLayout: (...args) => mockApiUpdateDashboardLayout(...args),
 }));
 
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
@@ -56,6 +63,19 @@ const messages = {
   'module.dashboard.daily_loop_open_shopping': 'Open shopping',
   'module.dashboard.daily_loop_open_routines': 'Open routines',
   'module.dashboard.daily_loop_empty': 'Plan a meal, add groceries or set a recurring task to start the daily loop.',
+  'module.dashboard.customize_layout': 'Customize layout',
+  'module.dashboard.customize_layout_hint': 'Move dashboard modules into the order that fits your day.',
+  'module.dashboard.reset_layout': 'Reset layout',
+  'module.dashboard.move_module_up': 'Move {module} up',
+  'module.dashboard.move_module_down': 'Move {module} down',
+  'module.dashboard.module_quick_capture': 'Quick capture',
+  'module.dashboard.module_daily_loop': 'Today in motion',
+  'module.dashboard.module_events': 'Next events',
+  'module.dashboard.module_tasks': 'Open tasks',
+  'module.dashboard.module_birthdays': 'Birthdays',
+  'module.dashboard.module_activity': 'Recent activity',
+  'module.dashboard.module_rewards': 'Rewards',
+  'module.dashboard.quick_capture_title': 'Quick capture',
   next_events: 'Next events',
   upcoming_birthdays_4w: 'Birthdays',
 };
@@ -85,23 +105,68 @@ function baseApp(overrides = {}) {
 describe('DashboardView desktop bento layout', () => {
   beforeEach(() => {
     mockAppState = baseApp();
+    mockApiGetDashboardLayout.mockReset();
+    mockApiUpdateDashboardLayout.mockReset();
+    mockApiResetDashboardLayout.mockReset();
+    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } });
+    mockApiUpdateDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['daily_loop', 'quick_capture', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } });
+    mockApiResetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } });
+    sessionStorage.clear();
   });
 
-  it('keeps the current desktop module order', () => {
+  it('keeps the current desktop module order', async () => {
     const { container } = render(<DashboardView />);
 
-    const modules = Array.from(container.querySelectorAll('.bento-grid > .bento-card'));
-    expect(modules[0]).toHaveClass('bento-quick-capture');
-    expect(modules[1]).toHaveClass('bento-daily-loop');
-    expect(modules[1]).toHaveAccessibleName('Today in motion');
-    expect(modules[2]).toHaveClass('bento-events');
-    expect(modules[2]).toHaveAccessibleName('Next events');
-    expect(modules[3]).toHaveClass('bento-tasks');
-    expect(modules[3]).toHaveAccessibleName('Open tasks');
-    expect(modules[4]).toHaveClass('bento-birthdays');
-    expect(modules[4]).toHaveAccessibleName('Birthdays');
-    expect(modules[5]).toHaveClass('bento-activity');
-    expect(modules[6]).toHaveClass('bento-rewards');
+    await waitFor(() => expect(mockApiGetDashboardLayout).toHaveBeenCalledTimes(1));
+    const modules = Array.from(container.querySelectorAll('.bento-grid > [data-dashboard-module]'));
+    expect(modules.map((module) => module.getAttribute('data-dashboard-module'))).toEqual([
+      'quick_capture',
+      'daily_loop',
+      'events',
+      'tasks',
+      'birthdays',
+      'activity',
+      'rewards',
+    ]);
+    expect(modules[1].querySelector('.bento-card')).toHaveAccessibleName('Today in motion');
+    expect(modules[2].querySelector('.bento-card')).toHaveAccessibleName('Next events');
+    expect(modules[3].querySelector('.bento-card')).toHaveAccessibleName('Open tasks');
+    expect(modules[4].querySelector('.bento-card')).toHaveAccessibleName('Birthdays');
+  });
+
+  it('loads a saved dashboard layout and persists keyboard-accessible module moves', async () => {
+    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['tasks', 'events', 'quick_capture', 'daily_loop', 'birthdays', 'activity', 'rewards'] } });
+
+    const { container } = render(<DashboardView />);
+
+    await waitFor(() => expect(container.querySelector('[data-dashboard-module="tasks"]')).toHaveStyle({ order: '0' }));
+    expect(container.querySelector('[data-dashboard-module="events"]')).toHaveStyle({ order: '1' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Customize layout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Move Open tasks down' }));
+
+    await waitFor(() => expect(mockApiUpdateDashboardLayout).toHaveBeenCalledWith([
+      'events',
+      'tasks',
+      'quick_capture',
+      'daily_loop',
+      'birthdays',
+      'activity',
+      'rewards',
+    ]));
+  });
+
+  it('resets the dashboard layout to the default order', async () => {
+    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['tasks', 'events', 'quick_capture', 'daily_loop', 'birthdays', 'activity', 'rewards'] } });
+
+    const { container } = render(<DashboardView />);
+
+    await waitFor(() => expect(container.querySelector('[data-dashboard-module="tasks"]')).toHaveStyle({ order: '0' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Customize layout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reset layout' }));
+
+    await waitFor(() => expect(mockApiResetDashboardLayout).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(container.querySelector('[data-dashboard-module="quick_capture"]')).toHaveStyle({ order: '0' }));
   });
 
   it('keeps the loading skeleton in the same card order', () => {
@@ -125,8 +190,8 @@ describe('DashboardView desktop bento layout', () => {
     expect(css).toMatch(/\.bento-tasks\s*\{\s*grid-column:\s*span 6;\s*\}/);
     expect(css).toMatch(/\.bento-birthdays\s*\{\s*grid-column:\s*span 6;\s*\}/);
     expect(css).toMatch(/\.bento-rewards\s*\{\s*grid-column:\s*span 6;\s*\}/);
-    expect(css).toMatch(/@media \(max-width: 1100px\) \{[\s\S]*\.bento-daily-loop, \.bento-quick-capture \{ grid-column: span 12; \}/);
-    expect(css).toMatch(/@media \(max-width: 1100px\) \{[\s\S]*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-activity, \.bento-rewards \{ grid-column: span 6; \}/);
-    expect(css).toMatch(/@media \(max-width: 768px\)[\s\S]*\.bento-events, \.bento-tasks, \.bento-birthdays, \.bento-activity, \.bento-rewards, \.bento-daily-loop, \.bento-quick-capture \{ grid-column: span 1; \}/);
+    expect(css).toMatch(/@media \(max-width: 1100px\) \{[\s\S]*\.dashboard-module-shell\[data-dashboard-module="daily_loop"\],[\s\S]*\.dashboard-module-shell\[data-dashboard-module="quick_capture"\] \{ grid-column: span 12; \}/);
+    expect(css).toMatch(/@media \(max-width: 1100px\) \{[\s\S]*\.dashboard-module-shell\[data-dashboard-module="events"\],[\s\S]*\.dashboard-module-shell\[data-dashboard-module="rewards"\] \{ grid-column: span 6; \}/);
+    expect(css).toMatch(/@media \(max-width: 768px\)[\s\S]*\.dashboard-module-shell\[data-dashboard-module="events"\],[\s\S]*\.dashboard-module-shell\[data-dashboard-module="quick_capture"\] \{ grid-column: span 1; \}/);
   });
 });

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,15 +1,26 @@
 import { useEffect, useMemo, useState } from 'react';
-import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer } from 'lucide-react';
+import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer, Settings2, ArrowUp, ArrowDown, RotateCcw } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { getMemberColor } from '../lib/member-colors';
-import { apiCompleteSetupChecklistStep, apiDismissSetupChecklist, apiGetSetupChecklist, apiListMealPlans } from '../lib/api';
+import { apiCompleteSetupChecklistStep, apiDismissSetupChecklist, apiGetDashboardLayout, apiGetSetupChecklist, apiListMealPlans, apiResetDashboardLayout, apiUpdateDashboardLayout } from '../lib/api';
 import AssignedBadges from './AssignedBadges';
 import MemberAvatar from './MemberAvatar';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
 import HouseholdActivityFeed from './HouseholdActivityFeed';
 import QuickCaptureCard from './QuickCaptureCard';
+
+const DEFAULT_DASHBOARD_LAYOUT = ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'];
+
+function normalizeDashboardLayout(modules, availableModules = DEFAULT_DASHBOARD_LAYOUT) {
+  const available = new Set(availableModules);
+  const ordered = [];
+  (Array.isArray(modules) ? modules : []).forEach((module) => {
+    if (available.has(module) && !ordered.includes(module)) ordered.push(module);
+  });
+  return ordered.concat(availableModules.filter((module) => !ordered.includes(module)));
+}
 
 function todayIsoDate() {
   const now = new Date();
@@ -166,6 +177,8 @@ export default function DashboardView() {
   const todayIso = useMemo(() => todayIsoDate(), []);
   const [mealsTodayCount, setMealsTodayCount] = useState(0);
   const [setupChecklist, setSetupChecklist] = useState(null);
+  const [layoutEditing, setLayoutEditing] = useState(false);
+  const [dashboardLayout, setDashboardLayout] = useState(DEFAULT_DASHBOARD_LAYOUT);
 
   const openTasks = tasks.filter((task) => task.status === 'open');
   const shoppingOpenCount = useMemo(() => countOpenShoppingItems(shoppingLists), [shoppingLists]);
@@ -204,6 +217,20 @@ export default function DashboardView() {
     });
     return () => { cancelled = true; };
   }, [familyId, demoMode, isChild]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (demoMode) {
+      setDashboardLayout(DEFAULT_DASHBOARD_LAYOUT);
+      return () => { cancelled = true; };
+    }
+    apiGetDashboardLayout().then((res) => {
+      if (!cancelled && res?.ok) setDashboardLayout(normalizeDashboardLayout(res.data?.modules));
+    }).catch(() => {
+      if (!cancelled) setDashboardLayout(DEFAULT_DASHBOARD_LAYOUT);
+    });
+    return () => { cancelled = true; };
+  }, [demoMode]);
 
   const todayEventCount = (summary.next_events || []).filter((ev) => {
     const d = parseDate(ev.starts_at);
@@ -349,6 +376,28 @@ export default function DashboardView() {
     if (response?.ok) setSetupChecklist(response.data);
   };
 
+  const moveDashboardModule = async (moduleKey, direction) => {
+    const current = normalizeDashboardLayout(dashboardLayout, availableDashboardModules);
+    const index = current.indexOf(moduleKey);
+    const nextIndex = index + direction;
+    if (index < 0 || nextIndex < 0 || nextIndex >= current.length) return;
+    const next = [...current];
+    [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+    setDashboardLayout(next);
+    if (!demoMode) {
+      const response = await apiUpdateDashboardLayout(next).catch(() => null);
+      if (response?.ok) setDashboardLayout(normalizeDashboardLayout(response.data?.modules, availableDashboardModules));
+    }
+  };
+
+  const resetDashboardModules = async () => {
+    setDashboardLayout(DEFAULT_DASHBOARD_LAYOUT);
+    if (!demoMode) {
+      const response = await apiResetDashboardLayout().catch(() => null);
+      if (response?.ok) setDashboardLayout(normalizeDashboardLayout(response.data?.modules, availableDashboardModules));
+    }
+  };
+
   const summaryText = (() => {
     let s = todayEventCount > 0
       ? t(messages, 'module.dashboard.summary_events').replace('{count}', todayEventCount)
@@ -360,6 +409,11 @@ export default function DashboardView() {
     }
     return s;
   })();
+  const availableDashboardModules = isChild
+    ? DEFAULT_DASHBOARD_LAYOUT.filter((module) => module !== 'quick_capture')
+    : DEFAULT_DASHBOARD_LAYOUT;
+  const orderedDashboardLayout = normalizeDashboardLayout(dashboardLayout, availableDashboardModules);
+  const moduleOrder = (moduleKey) => orderedDashboardLayout.indexOf(moduleKey);
 
   return (
     <div>
@@ -370,8 +424,42 @@ export default function DashboardView() {
         </div>
         <div className="dashboard-header-actions">
           <div className="view-date">{todayStr}</div>
+          <button type="button" className="dashboard-layout-toggle" onClick={() => setLayoutEditing((current) => !current)}>
+            <Settings2 size={15} aria-hidden="true" />
+            <span>{t(messages, 'module.dashboard.customize_layout')}</span>
+          </button>
         </div>
       </div>
+
+      {layoutEditing && (
+        <section className="dashboard-layout-panel" aria-label={t(messages, 'module.dashboard.customize_layout')}>
+          <div className="dashboard-layout-panel-header">
+            <div>
+              <h2>{t(messages, 'module.dashboard.customize_layout')}</h2>
+              <p>{t(messages, 'module.dashboard.customize_layout_hint')}</p>
+            </div>
+            <button type="button" className="dashboard-layout-reset" onClick={resetDashboardModules}>
+              <RotateCcw size={14} aria-hidden="true" />
+              {t(messages, 'module.dashboard.reset_layout')}
+            </button>
+          </div>
+          <ol className="dashboard-layout-list">
+            {orderedDashboardLayout.map((moduleKey, index) => (
+              <li key={moduleKey} className="dashboard-layout-item">
+                <span>{t(messages, `module.dashboard.module_${moduleKey}`)}</span>
+                <span className="dashboard-layout-controls">
+                  <button type="button" onClick={() => moveDashboardModule(moduleKey, -1)} disabled={index === 0} aria-label={t(messages, 'module.dashboard.move_module_up').replace('{module}', t(messages, `module.dashboard.module_${moduleKey}`))}>
+                    <ArrowUp size={14} aria-hidden="true" />
+                  </button>
+                  <button type="button" onClick={() => moveDashboardModule(moduleKey, 1)} disabled={index === orderedDashboardLayout.length - 1} aria-label={t(messages, 'module.dashboard.move_module_down').replace('{module}', t(messages, `module.dashboard.module_${moduleKey}`))}>
+                    <ArrowDown size={14} aria-hidden="true" />
+                  </button>
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
 
       <div
         className="hero-context-chips"
@@ -430,26 +518,31 @@ export default function DashboardView() {
 
       <div className="bento-grid">
         {!isChild && (
-          <QuickCaptureCard
-            familyId={familyId}
-            inbox={quickCaptureInbox}
-            messages={messages}
-            loadQuickCaptureInbox={loadQuickCaptureInbox}
-            loadTasks={loadTasks}
-            loadShoppingLists={loadShoppingLists}
-            loadActivity={loadActivity}
-          />
+          <div className="dashboard-module-shell" style={{ order: moduleOrder('quick_capture') }} data-dashboard-module="quick_capture">
+            <QuickCaptureCard
+              familyId={familyId}
+              inbox={quickCaptureInbox}
+              messages={messages}
+              loadQuickCaptureInbox={loadQuickCaptureInbox}
+              loadTasks={loadTasks}
+              loadShoppingLists={loadShoppingLists}
+              loadActivity={loadActivity}
+            />
+          </div>
         )}
 
-        <DailyLoopCard
-          mealsTodayCount={mealsTodayCount}
-          shoppingOpenCount={shoppingOpenCount}
-          routineDueCount={routineDueCount}
-          messages={messages}
-          setActiveView={setActiveView}
-        />
+        <div className="dashboard-module-shell" style={{ order: moduleOrder('daily_loop') }} data-dashboard-module="daily_loop">
+          <DailyLoopCard
+            mealsTodayCount={mealsTodayCount}
+            shoppingOpenCount={shoppingOpenCount}
+            routineDueCount={routineDueCount}
+            messages={messages}
+            setActiveView={setActiveView}
+          />
+        </div>
 
         {/* Events Card */}
+        <div className="dashboard-module-shell" style={{ order: moduleOrder('events') }} data-dashboard-module="events">
         <div className="bento-card bento-events" role="region" aria-label={t(messages, 'next_events')}>
           <div className="bento-card-header">
             <h2 className="bento-card-title"><CalendarClock size={16} aria-hidden="true" /> {t(messages, 'next_events')}</h2>
@@ -484,8 +577,10 @@ export default function DashboardView() {
             })}
           </div>
         </div>
+        </div>
 
         {/* Tasks Card */}
+        <div className="dashboard-module-shell" style={{ order: moduleOrder('tasks') }} data-dashboard-module="tasks">
         <div className="bento-card bento-tasks" role="region" aria-label={t(messages, 'module.dashboard.open_tasks')}>
           <div className="bento-card-header">
             <h2 className="bento-card-title"><ListChecks size={16} aria-hidden="true" /> {t(messages, 'module.dashboard.open_tasks')}</h2>
@@ -513,8 +608,10 @@ export default function DashboardView() {
             })}
           </div>
         </div>
+        </div>
 
         {/* Birthdays Card */}
+        <div className="dashboard-module-shell" style={{ order: moduleOrder('birthdays') }} data-dashboard-module="birthdays">
         <div className="bento-card bento-birthdays" role="region" aria-label={t(messages, 'upcoming_birthdays_4w')}>
           <div className="bento-card-header">
             <h2 className="bento-card-title"><Cake size={16} aria-hidden="true" /> {t(messages, 'upcoming_birthdays_4w')}</h2>
@@ -544,11 +641,16 @@ export default function DashboardView() {
             })}
           </div>
         </div>
+        </div>
 
-        <HouseholdActivityFeed activity={activity} messages={messages} lang={lang} />
+        <div className="dashboard-module-shell" style={{ order: moduleOrder('activity') }} data-dashboard-module="activity">
+          <HouseholdActivityFeed activity={activity} messages={messages} lang={lang} />
+        </div>
 
         {/* Rewards Widget */}
-        <RewardsDashboardWidget />
+        <div className="dashboard-module-shell" style={{ order: moduleOrder('rewards') }} data-dashboard-module="rewards">
+          <RewardsDashboardWidget />
+        </div>
       </div>
     </div>
   );

--- a/frontend/e2e/helpers/navigation.js
+++ b/frontend/e2e/helpers/navigation.js
@@ -50,8 +50,13 @@ async function navigateTo(page, viewName) {
   if (!ALWAYS_OVERFLOW.has(viewName)) {
     const bottomNavItem = page.locator('.bottom-nav-item', { hasText: mobileName });
     if (await bottomNavItem.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await bottomNavItem.click();
-      return;
+      try {
+        await bottomNavItem.click({ timeout: 2000 });
+        return;
+      } catch {
+        await navigateByHash(page, desktopName);
+        return;
+      }
     }
   }
 

--- a/frontend/e2e/tests/calendar-birthday-identity.spec.js
+++ b/frontend/e2e/tests/calendar-birthday-identity.spec.js
@@ -20,7 +20,8 @@ async function seedContact(request, familyId, fullName, month, day) {
 async function openCalendarDay(page, day) {
   const calendarDay = page.locator('.calendar-day:not(.other-month)', { hasText: new RegExp(`^${day}$`) }).first();
   await calendarDay.evaluate((element) => element.scrollIntoView({ block: 'center', inline: 'center' }));
-  await calendarDay.click();
+  await calendarDay.focus();
+  await page.keyboard.press('Enter');
 }
 
 test.describe('Birthday identity regression', () => {

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -81,4 +81,28 @@ test.describe('Dashboard', () => {
     await quickCapture.locator('.quick-capture-item-actions').getByRole('button', { name: 'Shopping' }).click();
     await expect(quickCapture).not.toContainText('Buy apples from market', { timeout: 10000 });
   });
+
+  test('customizes dashboard module order and keeps it after reload', async ({ authedPage: page }) => {
+    const tasksModule = page.locator('[data-dashboard-module="tasks"]');
+    const eventsModule = page.locator('[data-dashboard-module="events"]');
+    await expect(tasksModule).toBeVisible({ timeout: 10000 });
+    await expect(eventsModule).toHaveCSS('order', '2');
+    await expect(tasksModule).toHaveCSS('order', '3');
+
+    await page.getByRole('button', { name: 'Customize layout' }).click();
+    await page.getByRole('button', { name: 'Move Open tasks up' }).click();
+
+    await expect(tasksModule).toHaveCSS('order', '2');
+    await expect(eventsModule).toHaveCSS('order', '3');
+
+    await page.reload();
+    await page.locator('#main-content').waitFor({ timeout: 15000 });
+    await expect(page.locator('[data-dashboard-module="tasks"]')).toHaveCSS('order', '2');
+    await expect(page.locator('[data-dashboard-module="events"]')).toHaveCSS('order', '3');
+
+    await page.getByRole('button', { name: 'Customize layout' }).click();
+    await page.getByRole('button', { name: 'Reset layout' }).click();
+    await expect(page.locator('[data-dashboard-module="events"]')).toHaveCSS('order', '2');
+    await expect(page.locator('[data-dashboard-module="tasks"]')).toHaveCSS('order', '3');
+  });
 });

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -99,5 +99,17 @@
   "module.dashboard.setup_step_phone_sync_title": "Phone Sync prüfen",
   "module.dashboard.setup_step_phone_sync_desc": "Richte Kalender- oder Kontakt-Sync für die passenden Geräte ein.",
   "module.dashboard.setup_step_backup_guidance_title": "Backup-Hinweise prüfen",
-  "module.dashboard.setup_step_backup_guidance_desc": "Prüfe Backup und Wiederherstellung, bevor Tribu täglich genutzt wird."
+  "module.dashboard.setup_step_backup_guidance_desc": "Prüfe Backup und Wiederherstellung, bevor Tribu täglich genutzt wird.",
+  "module.dashboard.customize_layout": "Layout anpassen",
+  "module.dashboard.customize_layout_hint": "Sortiere die Dashboard-Module so, wie sie zu eurem Alltag passen.",
+  "module.dashboard.reset_layout": "Layout zurücksetzen",
+  "module.dashboard.move_module_up": "{module} nach oben verschieben",
+  "module.dashboard.move_module_down": "{module} nach unten verschieben",
+  "module.dashboard.module_quick_capture": "Schnell erfassen",
+  "module.dashboard.module_daily_loop": "Heute im Griff",
+  "module.dashboard.module_events": "Nächste Termine",
+  "module.dashboard.module_tasks": "Offene Aufgaben",
+  "module.dashboard.module_birthdays": "Geburtstage",
+  "module.dashboard.module_activity": "Letzte Aktivitäten",
+  "module.dashboard.module_rewards": "Rewards"
 }

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -99,5 +99,17 @@
   "module.dashboard.setup_step_phone_sync_title": "Review phone sync",
   "module.dashboard.setup_step_phone_sync_desc": "Connect calendar or contacts sync for the devices that need it.",
   "module.dashboard.setup_step_backup_guidance_title": "Review backup guidance",
-  "module.dashboard.setup_step_backup_guidance_desc": "Check backup and restore guidance before the household depends on Tribu daily."
+  "module.dashboard.setup_step_backup_guidance_desc": "Check backup and restore guidance before the household depends on Tribu daily.",
+  "module.dashboard.customize_layout": "Customize layout",
+  "module.dashboard.customize_layout_hint": "Move dashboard modules into the order that fits your day.",
+  "module.dashboard.reset_layout": "Reset layout",
+  "module.dashboard.move_module_up": "Move {module} up",
+  "module.dashboard.move_module_down": "Move {module} down",
+  "module.dashboard.module_quick_capture": "Quick capture",
+  "module.dashboard.module_daily_loop": "Today in motion",
+  "module.dashboard.module_events": "Next events",
+  "module.dashboard.module_tasks": "Open tasks",
+  "module.dashboard.module_birthdays": "Birthdays",
+  "module.dashboard.module_activity": "Recent activity",
+  "module.dashboard.module_rewards": "Rewards"
 }

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -117,6 +117,22 @@ export function apiGetDashboard(familyId) {
   return request(`/dashboard/summary?family_id=${familyId}`);
 }
 
+export function apiGetDashboardLayout() {
+  return request('/nav/dashboard-layout');
+}
+
+export function apiUpdateDashboardLayout(modules) {
+  return request('/nav/dashboard-layout', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ modules }),
+  });
+}
+
+export function apiResetDashboardLayout() {
+  return request('/nav/dashboard-layout', { method: 'DELETE' });
+}
+
 export function apiGetActivity(familyId, limit = 10, offset = 0) {
   return request(`/activity?family_id=${familyId}&limit=${limit}&offset=${offset}`);
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -705,6 +705,17 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .view-subtitle { color: var(--text-secondary); font-size: 0.88rem; margin-top: 2px; }
 .view-date { font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; color: var(--text-secondary); background: rgba(255,255,255,0.03); padding: 8px 14px; border-radius: var(--radius-sm); border: 1px solid var(--glass-border); }
 .dashboard-header-actions { display: flex; align-items: center; gap: var(--space-sm); }
+.dashboard-layout-toggle, .dashboard-layout-reset { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: 38px; border: 1px solid var(--glass-border); border-radius: var(--radius-pill); padding: 8px 13px; background: rgba(255,255,255,0.03); color: var(--text-primary); font: inherit; font-size: 0.82rem; font-weight: 600; cursor: pointer; transition: background 0.2s, border-color 0.2s; }
+.dashboard-layout-toggle:hover, .dashboard-layout-reset:hover { background: rgba(255,255,255,0.06); border-color: rgba(120, 130, 180, 0.28); }
+.dashboard-layout-panel { margin: calc(-1 * var(--space-sm)) 0 var(--space-md); padding: var(--space-md); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); background: rgba(255,255,255,0.025); }
+.dashboard-layout-panel-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-md); margin-bottom: var(--space-md); }
+.dashboard-layout-panel h2 { margin: 0; font-size: 1rem; }
+.dashboard-layout-panel p { margin: 5px 0 0; color: var(--text-muted); font-size: 0.86rem; }
+.dashboard-layout-list { list-style: none; display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: var(--space-sm); margin: 0; padding: 0; }
+.dashboard-layout-item { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); padding: 10px 12px; border: 1px solid rgba(120, 130, 180, 0.12); border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); color: var(--text-primary); font-size: 0.88rem; }
+.dashboard-layout-controls { display: inline-flex; align-items: center; gap: 5px; }
+.dashboard-layout-controls button { display: inline-flex; align-items: center; justify-content: center; width: 34px; min-width: 34px; height: 34px; border: 0; border-radius: var(--radius-pill); background: var(--void-surface); color: var(--text-primary); cursor: pointer; }
+.dashboard-layout-controls button:disabled { opacity: 0.4; cursor: not-allowed; }
 .dashboard-quick-actions { display: flex; flex-wrap: wrap; gap: var(--space-sm); margin-bottom: var(--space-md); }
 .quick-action-pill { display: inline-flex; align-items: center; gap: 8px; padding: 10px 16px; min-height: 44px; border-radius: var(--radius-pill); border: 1px solid var(--glass-border); background: rgba(255,255,255,0.03); color: var(--text-primary); font-family: inherit; font-size: 0.85rem; font-weight: 500; cursor: pointer; transition: background 0.2s, border-color 0.2s, transform 0.1s; }
 .quick-action-pill:hover { background: rgba(255,255,255,0.06); border-color: rgba(120, 130, 180, 0.35); }
@@ -727,6 +738,15 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    BENTO GRID (Dashboard)
    ═══════════════════════════════════════════ */
 .bento-grid { display: grid; grid-template-columns: repeat(12, 1fr); column-gap: var(--space-md); row-gap: var(--space-lg); }
+.dashboard-module-shell { display: flex; min-width: 0; }
+.dashboard-module-shell > .bento-card { width: 100%; }
+.dashboard-module-shell[data-dashboard-module="daily_loop"],
+.dashboard-module-shell[data-dashboard-module="quick_capture"],
+.dashboard-module-shell[data-dashboard-module="events"],
+.dashboard-module-shell[data-dashboard-module="tasks"],
+.dashboard-module-shell[data-dashboard-module="birthdays"],
+.dashboard-module-shell[data-dashboard-module="activity"],
+.dashboard-module-shell[data-dashboard-module="rewards"] { grid-column: span 6; }
 .bento-card { padding: var(--space-lg); background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); transition: all 0.2s; }
 .bento-card:hover { border-color: rgba(120, 130, 180, 0.2); }
 .bento-daily-loop { grid-column: span 6; }
@@ -1696,8 +1716,15 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    RESPONSIVE
    ═══════════════════════════════════════════ */
 @media (max-width: 1100px) {
-  .bento-daily-loop, .bento-quick-capture { grid-column: span 12; }
-  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards { grid-column: span 6; }
+  .bento-daily-loop, .bento-quick-capture,
+  .dashboard-module-shell[data-dashboard-module="daily_loop"],
+  .dashboard-module-shell[data-dashboard-module="quick_capture"] { grid-column: span 12; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards,
+  .dashboard-module-shell[data-dashboard-module="events"],
+  .dashboard-module-shell[data-dashboard-module="tasks"],
+  .dashboard-module-shell[data-dashboard-module="birthdays"],
+  .dashboard-module-shell[data-dashboard-module="activity"],
+  .dashboard-module-shell[data-dashboard-module="rewards"] { grid-column: span 6; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .calendar-layout { grid-template-columns: 1fr; }
 }
@@ -1709,7 +1736,14 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .mobile-header { display: flex; }
   .bottom-nav { display: block; }
   .bento-grid { grid-template-columns: 1fr; row-gap: var(--space-md); }
-  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards, .bento-daily-loop, .bento-quick-capture { grid-column: span 1; }
+  .bento-events, .bento-tasks, .bento-birthdays, .bento-activity, .bento-rewards, .bento-daily-loop, .bento-quick-capture,
+  .dashboard-module-shell[data-dashboard-module="events"],
+  .dashboard-module-shell[data-dashboard-module="tasks"],
+  .dashboard-module-shell[data-dashboard-module="birthdays"],
+  .dashboard-module-shell[data-dashboard-module="activity"],
+  .dashboard-module-shell[data-dashboard-module="rewards"],
+  .dashboard-module-shell[data-dashboard-module="daily_loop"],
+  .dashboard-module-shell[data-dashboard-module="quick_capture"] { grid-column: span 1; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .daily-loop-item { grid-template-columns: auto 1fr; }
   .daily-loop-action { grid-column: 1 / -1; justify-self: stretch; text-align: center; }


### PR DESCRIPTION
## Summary
- Adds per-user dashboard module layout preferences with API support and migration
- Adds a keyboard-accessible dashboard customization panel with move up/down and reset controls
- Persists the layout across reloads and keeps desktop/mobile module placement coherent
- Stabilizes affected mobile E2E navigation around fixed bottom navigation

## Test plan
- `DATABASE_URL=sqlite:///./test-dashboard-layout.db JWT_SECRET=test-secret python -m pytest tests/test_dashboard_layout.py -q`
- `python -m ruff check backend/app/models.py backend/app/modules/nav_router.py backend/app/schemas.py backend/tests/test_dashboard_layout.py backend/alembic/versions/0046_add_dashboard_layout_preference.py`
- `DATABASE_URL=sqlite:////tmp/tribu-issue-266-0046.db JWT_SECRET=test-secret alembic upgrade head` from a stamped 0045 SQLite smoke DB
- `npm test -- --runTestsByPath __tests__/components/DashboardDesktopLayout.test.js __tests__/components/DashboardActivationPanel.test.js __tests__/components/DashboardDailyLoop.test.js --runInBand`
- `npm run build`
- `npx playwright test --list` reported 90 tests
- `npx playwright test --reporter=list` passed 90 tests

Closes #266
