### PR TITLE
Remove duplicate dashboard header summaries

### DIFF
--- a/frontend/__tests__/components/DashboardDesktopLayout.test.js
+++ b/frontend/__tests__/components/DashboardDesktopLayout.test.js
@@ -134,6 +134,27 @@ describe('DashboardView desktop bento layout', () => {
     expect(modules[4].querySelector('.bento-card')).toHaveAccessibleName('Birthdays');
   });
 
+  it('keeps duplicated count summaries out of the dashboard header', async () => {
+    mockAppState = baseApp({
+      members: [
+        { user_id: 1, display_name: 'Dennis' },
+        { user_id: 2, display_name: 'Family member' },
+      ],
+      tasks: [{ id: 1, title: 'Take bins out', status: 'open' }],
+      summary: { next_events: [{ id: 1, title: 'Training', starts_at: '2030-01-01T10:00:00Z' }], upcoming_birthdays: [] },
+    });
+
+    const { container } = render(<DashboardView />);
+
+    await waitFor(() => expect(mockApiGetDashboardLayout).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('group', { name: 'Dashboard summary' })).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="hero-chip-members"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="hero-chip-events"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="hero-chip-tasks"]')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Today you have 1 events/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/1 open tasks/i)).not.toBeInTheDocument();
+  });
+
   it('loads a saved dashboard layout and persists keyboard-accessible module moves', async () => {
     mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['tasks', 'events', 'quick_capture', 'daily_loop', 'birthdays', 'activity', 'rewards'] } });
 

--- a/frontend/__tests__/components/DashboardHero.test.js
+++ b/frontend/__tests__/components/DashboardHero.test.js
@@ -145,7 +145,7 @@ describe('DashboardView hero', () => {
     expect(container.querySelectorAll('.dashboard-header-actions .btn-icon')).toHaveLength(0);
   });
 
-  it('renders child-safe quick action pills and hides admin members chip for child members', () => {
+  it('renders child-safe quick action pills without duplicated header summary chips', () => {
     mockAppState = baseApp({ isChild: true, isAdmin: false });
     render(<DashboardView />);
     const region = screen.getByRole('group', { name: 'Quick actions' });
@@ -153,16 +153,15 @@ describe('DashboardView hero', () => {
     expect(within(region).getByRole('button', { name: 'Rewards' })).toBeVisible();
     expect(screen.queryByRole('button', { name: 'Event' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
-
-    const chipGroup = screen.getByRole('group', { name: 'Family at a glance' });
-    expect(within(chipGroup).queryByTestId('hero-chip-members')).not.toBeInTheDocument();
-    expect(within(chipGroup).getByTestId('hero-chip-events')).toBeVisible();
-    expect(within(chipGroup).getByTestId('hero-chip-tasks')).toBeVisible();
+    expect(screen.queryByRole('group', { name: 'Family at a glance' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-chip-members')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-chip-events')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-chip-tasks')).not.toBeInTheDocument();
   });
 
 
 
-  it('does not expose invite actions or the members chip to non-admin adults', () => {
+  it('does not expose invite actions to non-admin adults', () => {
     mockAppState = baseApp({ isAdmin: false });
     render(<DashboardView />);
     const region = screen.getByRole('group', { name: 'Quick actions' });
@@ -170,10 +169,11 @@ describe('DashboardView hero', () => {
     expect(within(region).getByRole('button', { name: 'Task' })).toBeVisible();
     expect(within(region).getByRole('button', { name: 'Shopping' })).toBeVisible();
     expect(within(region).queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('group', { name: 'Family at a glance' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('hero-chip-members')).not.toBeInTheDocument();
   });
 
-  it('renders hero context chips for admin members, today events and open tasks using existing data', () => {
+  it('keeps family, event and task counts in the richer dashboard modules instead of header chips', () => {
     mockAppState = baseApp({
       members: [
         { user_id: 1, display_name: 'Dennis' },
@@ -196,18 +196,12 @@ describe('DashboardView hero', () => {
     });
     render(<DashboardView />);
 
-    const chipGroup = screen.getByRole('group', { name: 'Family at a glance' });
-    const membersChip = within(chipGroup).getByTestId('hero-chip-members');
-    expect(membersChip).toHaveTextContent('3');
-    expect(membersChip).toHaveTextContent('Members');
-
-    const eventsChip = within(chipGroup).getByTestId('hero-chip-events');
-    expect(eventsChip).toHaveTextContent('2');
-    expect(eventsChip).toHaveTextContent('Today');
-
-    const tasksChip = within(chipGroup).getByTestId('hero-chip-tasks');
-    expect(tasksChip).toHaveTextContent('2');
-    expect(tasksChip).toHaveTextContent('Open tasks');
+    expect(screen.queryByRole('group', { name: 'Family at a glance' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-chip-members')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-chip-events')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-chip-tasks')).not.toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Next events' })).toHaveTextContent('School run');
+    expect(screen.getByRole('region', { name: 'Open tasks' })).toHaveTextContent('Pack bags');
   });
 
   it('removes the standalone Family Stats bento card from the grid', () => {

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { CalendarClock, ListChecks, Cake, Users, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer, Settings2, ArrowUp, ArrowDown, RotateCcw } from 'lucide-react';
+import { CalendarClock, ListChecks, Cake, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer, Settings2, ArrowUp, ArrowDown, RotateCcw } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
@@ -232,13 +232,6 @@ export default function DashboardView() {
     return () => { cancelled = true; };
   }, [demoMode]);
 
-  const todayEventCount = (summary.next_events || []).filter((ev) => {
-    const d = parseDate(ev.starts_at);
-    if (!d) return false;
-    const now = new Date();
-    return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
-  }).length;
-
   const adultQuickActions = [
     { key: 'event', label: t(messages, 'module.dashboard.quick_event'), icon: Calendar, onClick: () => setActiveView('calendar') },
     { key: 'task', label: t(messages, 'module.dashboard.quick_task'), icon: CheckSquare, onClick: () => setActiveView('tasks') },
@@ -253,12 +246,6 @@ export default function DashboardView() {
         { key: 'rewards', label: t(messages, 'module.dashboard.quick_rewards'), icon: CheckCircle, onClick: () => setActiveView('rewards') },
       ]
     : adultQuickActions;
-
-  const heroChips = [
-    ...(isAdmin ? [{ key: 'members', testId: 'hero-chip-members', value: members.length, label: t(messages, 'module.dashboard.chip_members'), icon: Users, onClick: () => setActiveView('admin') }] : []),
-    { key: 'events', testId: 'hero-chip-events', value: todayEventCount, label: t(messages, 'module.dashboard.chip_today_events'), icon: CalendarClock, onClick: () => setActiveView('calendar') },
-    { key: 'tasks', testId: 'hero-chip-tasks', value: openTasks.length, label: t(messages, 'module.dashboard.chip_open_tasks'), icon: ListChecks, onClick: () => setActiveView('tasks') },
-  ];
 
   const safeShoppingLists = Array.isArray(shoppingLists) ? shoppingLists : [];
   const hasShoppingContent = safeShoppingLists.some((list) => {
@@ -398,17 +385,6 @@ export default function DashboardView() {
     }
   };
 
-  const summaryText = (() => {
-    let s = todayEventCount > 0
-      ? t(messages, 'module.dashboard.summary_events').replace('{count}', todayEventCount)
-      : t(messages, 'module.dashboard.summary_no_events');
-    if (openTasks.length > 0) {
-      s += t(messages, 'module.dashboard.summary_tasks').replace('{count}', openTasks.length);
-    } else {
-      s += '.';
-    }
-    return s;
-  })();
   const availableDashboardModules = isChild
     ? DEFAULT_DASHBOARD_LAYOUT.filter((module) => module !== 'quick_capture')
     : DEFAULT_DASHBOARD_LAYOUT;
@@ -420,7 +396,6 @@ export default function DashboardView() {
       <div className="view-header">
         <div>
           <h1 className="view-title">{getGreeting(messages)}, {me?.display_name || 'User'}</h1>
-          <div className="view-subtitle">{summaryText}</div>
         </div>
         <div className="dashboard-header-actions">
           <div className="view-date">{todayStr}</div>
@@ -460,29 +435,6 @@ export default function DashboardView() {
           </ol>
         </section>
       )}
-
-      <div
-        className="hero-context-chips"
-        role="group"
-        aria-label={t(messages, 'module.dashboard.context_chips_label')}
-      >
-        {heroChips.map((chip) => {
-          const Icon = chip.icon;
-          return (
-            <button
-              key={chip.key}
-              type="button"
-              className="hero-chip"
-              data-testid={chip.testId}
-              onClick={chip.onClick}
-            >
-              <span className="hero-chip-icon" aria-hidden="true"><Icon size={14} /></span>
-              <span className="hero-chip-value">{chip.value}</span>
-              <span className="hero-chip-label">{chip.label}</span>
-            </button>
-          );
-        })}
-      </div>
 
       <div
         className="dashboard-quick-actions"

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -9,6 +9,16 @@ test.describe('Dashboard', () => {
     await expect(greeting).toContainText(testUser.displayName);
   });
 
+  test('keeps duplicate summary counts out of the dashboard header', async ({ authedPage: page }) => {
+    await expect(page.getByRole('group', { name: 'Quick actions' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('group', { name: 'Family at a glance' })).toHaveCount(0);
+    await expect(page.getByTestId('hero-chip-members')).toHaveCount(0);
+    await expect(page.getByTestId('hero-chip-events')).toHaveCount(0);
+    await expect(page.getByTestId('hero-chip-tasks')).toHaveCount(0);
+    await expect(page.getByRole('region', { name: 'Next events' })).toBeVisible();
+    await expect(page.getByRole('region', { name: 'Open tasks' })).toBeVisible();
+  });
+
   test('quick-action pills navigate to correct views', async ({ authedPage: page }) => {
     const quickActions = page.getByRole('group', { name: 'Quick actions' });
     await quickActions.waitFor({ timeout: 10000 });


### PR DESCRIPTION
## Summary
- Removes the duplicated dashboard header summary chips for members, today's events, and open tasks.
- Keeps the greeting, date, quick actions, and richer dashboard modules as the primary places for family context, tasks, and upcoming events.
- Updates component and browser coverage so the calmer header structure stays in place.

Closes #265

## Test plan
- `npm test -- --runInBand`
- `npm run build`
- `timeout 300s nice -n 19 ionice -c3 npx playwright test e2e/tests/dashboard.spec.js --reporter=list`
- `git diff --check`
