### PR TITLE
Make daily check-in tiles clickable

### DIFF
--- a/frontend/__tests__/components/DashboardDailyLoop.test.js
+++ b/frontend/__tests__/components/DashboardDailyLoop.test.js
@@ -152,16 +152,27 @@ describe('DashboardView daily loop', () => {
     expect(within(card).getByTestId('daily-loop-routines')).toHaveTextContent('2');
   });
 
-  it('navigates from daily loop actions to meals, shopping and routines', async () => {
+  it('navigates from full daily loop tiles without nested pill buttons', async () => {
     const setActiveView = jest.fn();
     mockAppState = baseApp({ setActiveView });
 
     render(<DashboardView />);
 
     const card = screen.getByRole('region', { name: 'Today in motion' });
-    fireEvent.click(within(card).getByRole('button', { name: 'Plan meals' }));
-    fireEvent.click(within(card).getByRole('button', { name: 'Open shopping' }));
-    fireEvent.click(within(card).getByRole('button', { name: 'Open routines' }));
+    expect(card.querySelectorAll('.daily-loop-action')).toHaveLength(0);
+
+    const mealsTile = within(card).getByRole('button', { name: 'Plan meals' });
+    const shoppingTile = within(card).getByRole('button', { name: 'Open shopping' });
+    const routinesTile = within(card).getByRole('button', { name: 'Open routines' });
+    expect(mealsTile).toHaveClass('daily-loop-item');
+    expect(shoppingTile).toHaveClass('daily-loop-item');
+    expect(routinesTile).toHaveClass('daily-loop-item');
+
+    mealsTile.focus();
+    expect(mealsTile).toHaveFocus();
+    fireEvent.click(mealsTile);
+    fireEvent.click(shoppingTile);
+    fireEvent.click(routinesTile);
 
     expect(setActiveView).toHaveBeenCalledWith('meal_plans');
     expect(setActiveView).toHaveBeenCalledWith('shopping');

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -99,14 +99,19 @@ function DailyLoopCard({ mealsTodayCount, shoppingOpenCount, routineDueCount, me
         {items.map((item) => {
           const Icon = item.icon;
           return (
-            <div key={item.key} className="daily-loop-item">
+            <button
+              key={item.key}
+              type="button"
+              className="daily-loop-item"
+              aria-label={item.actionLabel}
+              onClick={item.onClick}
+            >
               <span className="daily-loop-icon" aria-hidden="true"><Icon size={16} /></span>
-              <div className="daily-loop-copy">
+              <span className="daily-loop-copy">
                 <span className="daily-loop-value" data-testid={`daily-loop-${item.key}`}>{item.value}</span>
                 <span className="daily-loop-label">{item.label}</span>
-              </div>
-              <button type="button" className="daily-loop-action" onClick={item.onClick}>{item.actionLabel}</button>
-            </div>
+              </span>
+            </button>
           );
         })}
       </div>

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -55,6 +55,25 @@ test.describe('Dashboard', () => {
     await expect(page.getByRole('heading', { name: 'Admin' })).toBeVisible({ timeout: 10000 });
   });
 
+  test('daily check-in tiles navigate without separate pill buttons', async ({ authedPage: page }) => {
+    const dailyLoop = page.getByRole('region', { name: 'Today in motion' });
+    await expect(dailyLoop).toBeVisible({ timeout: 10000 });
+    await expect(dailyLoop.locator('.daily-loop-action')).toHaveCount(0);
+
+    await dailyLoop.getByRole('button', { name: 'Plan meals' }).click();
+    await expect(page.getByRole('heading', { name: 'Meal plan' })).toBeVisible({ timeout: 10000 });
+
+    await navigateTo(page, 'Home');
+    await page.getByRole('region', { name: 'Today in motion' }).waitFor({ timeout: 10000 });
+    await page.getByRole('region', { name: 'Today in motion' }).getByRole('button', { name: 'Open shopping' }).click();
+    await expect(page.locator('.shopping-lists-panel')).toBeVisible({ timeout: 10000 });
+
+    await navigateTo(page, 'Home');
+    await page.getByRole('region', { name: 'Today in motion' }).waitFor({ timeout: 10000 });
+    await page.getByRole('region', { name: 'Today in motion' }).getByRole('button', { name: 'Open routines' }).click();
+    await expect(page.locator('.tasks-filter-tabs')).toBeVisible({ timeout: 10000 });
+  });
+
   test('shows and dismisses the first-week setup checklist', async ({ authedPage: page }) => {
     const checklist = page.getByRole('region', { name: 'Set up your first week' });
     await expect(checklist).toBeVisible({ timeout: 10000 });

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -763,13 +763,14 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .daily-loop-header { align-items: flex-start; margin-bottom: var(--space-sm); }
 .daily-loop-subtitle { margin: 6px 0 0; color: var(--text-muted); font-size: 0.9rem; }
 .daily-loop-list { display: grid; grid-template-columns: 1fr; gap: var(--space-sm); }
-.daily-loop-item { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: var(--space-sm); padding: var(--space-sm) var(--space-md); border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); border: 1px solid rgba(120, 130, 180, 0.08); }
+.daily-loop-item { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: var(--space-sm); width: 100%; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); border: 1px solid rgba(120, 130, 180, 0.08); color: inherit; font: inherit; text-align: left; cursor: pointer; transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease; }
+.daily-loop-item:hover { background: rgba(139, 92, 246, 0.1); border-color: rgba(139, 92, 246, 0.28); transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.daily-loop-item:focus-visible { outline: 2px solid var(--amethyst); outline-offset: 3px; border-color: rgba(139, 92, 246, 0.45); }
+.daily-loop-item:active { transform: translateY(0); }
 .daily-loop-icon { display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px; border-radius: var(--radius-pill); background: rgba(139, 92, 246, 0.12); color: var(--amethyst); }
 .daily-loop-copy { display: flex; flex-direction: column; min-width: 0; }
 .daily-loop-value { font-family: 'JetBrains Mono', monospace; font-size: 1.35rem; font-weight: 700; color: var(--text-primary); line-height: 1; }
 .daily-loop-label { margin-top: 4px; color: var(--text-muted); font-size: 0.82rem; }
-.daily-loop-action { justify-self: end; min-height: 44px; border: none; border-radius: var(--radius-pill); padding: 7px 11px; background: var(--void-surface); color: var(--amethyst); font-family: inherit; font-size: 0.78rem; font-weight: 600; cursor: pointer; box-shadow: var(--shadow-sm); }
-.daily-loop-action:hover { background: rgba(139, 92, 246, 0.1); }
 .daily-loop-empty { margin-top: var(--space-sm); padding: 10px 12px; border-radius: var(--radius-md); background: rgba(120, 130, 180, 0.06); color: var(--text-muted); font-size: 0.85rem; }
 .activity-feed-list { display: flex; flex-direction: column; gap: var(--space-sm); }
 .activity-feed-item { display: grid; grid-template-columns: auto 1fr; gap: var(--space-sm); align-items: flex-start; padding: 10px 0; border-bottom: 1px solid rgba(120, 130, 180, 0.08); }
@@ -1746,7 +1747,6 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .dashboard-module-shell[data-dashboard-module="quick_capture"] { grid-column: span 1; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .daily-loop-item { grid-template-columns: auto 1fr; }
-  .daily-loop-action { grid-column: 1 / -1; justify-self: stretch; text-align: center; }
   .dashboard-header-actions { flex-wrap: wrap; }
   .view-header { flex-direction: column; align-items: flex-start; }
   .tasks-toolbar { flex-direction: column; align-items: flex-start; }


### PR DESCRIPTION
## Summary
- Make the full Today in motion rows act as the meals, shopping, and routines navigation targets
- Remove the nested pill buttons from those rows
- Add hover, active, and focus styling so the clickable rows stay discoverable

Closes #264

## Test plan
- `npm test -- --runTestsByPath __tests__/components/DashboardDailyLoop.test.js __tests__/components/DashboardDesktopLayout.test.js --runInBand`
- `npm run build`
- `npx playwright test --list` (94 tests listed)
- `npx playwright test e2e/tests/dashboard.spec.js --project='Desktop Chrome' --reporter=list` (8 passed)
- `npx playwright test e2e/tests/dashboard.spec.js --project='Mobile Chrome' --reporter=list` (8 passed)
