### PR TITLE
Move activity history out of the dashboard

### DIFF
--- a/backend/app/modules/nav_router.py
+++ b/backend/app/modules/nav_router.py
@@ -11,9 +11,9 @@ from app.core.errors import error_detail, UNKNOWN_NAV_KEYS
 
 router = APIRouter(prefix="/nav", tags=["nav"], responses={**AUTH_RESPONSES})
 
-DEFAULT_NAV_ORDER = ["dashboard", "calendar", "shopping", "tasks", "templates", "meal_plans", "recipes", "contacts", "notifications", "settings", "admin"]
-KNOWN_KEYS = {"dashboard", "calendar", "shopping", "tasks", "templates", "rewards", "gifts", "meal_plans", "recipes", "contacts", "notifications", "settings", "admin"}
-DEFAULT_DASHBOARD_LAYOUT = ["quick_capture", "daily_loop", "events", "tasks", "birthdays", "activity", "rewards"]
+DEFAULT_NAV_ORDER = ["dashboard", "calendar", "shopping", "tasks", "activity", "templates", "meal_plans", "recipes", "contacts", "notifications", "settings", "admin"]
+KNOWN_KEYS = {"dashboard", "calendar", "shopping", "tasks", "activity", "templates", "rewards", "gifts", "meal_plans", "recipes", "contacts", "notifications", "settings", "admin"}
+DEFAULT_DASHBOARD_LAYOUT = ["quick_capture", "daily_loop", "events", "tasks", "birthdays", "rewards"]
 KNOWN_DASHBOARD_MODULES = set(DEFAULT_DASHBOARD_LAYOUT)
 
 

--- a/backend/tests/test_dashboard_layout.py
+++ b/backend/tests/test_dashboard_layout.py
@@ -78,7 +78,6 @@ def test_dashboard_layout_persists_normalizes_and_resets_per_user():
         "events",
         "tasks",
         "birthdays",
-        "activity",
         "rewards",
     ]
 
@@ -94,7 +93,6 @@ def test_dashboard_layout_persists_normalizes_and_resets_per_user():
         "quick_capture",
         "daily_loop",
         "birthdays",
-        "activity",
         "rewards",
     ]
 
@@ -129,8 +127,8 @@ def test_dashboard_layout_rejects_unknown_modules_and_enforces_scopes():
 
     invalid = client.put(
         "/nav/dashboard-layout",
-        json={"modules": ["tasks", "unknown"]},
+        json={"modules": ["tasks", "activity"]},
         headers=_auth(write_token),
     )
     assert invalid.status_code == 422
-    assert "unknown" in str(invalid.json())
+    assert "activity" in str(invalid.json())

--- a/frontend/__tests__/components/ActivityView.test.js
+++ b/frontend/__tests__/components/ActivityView.test.js
@@ -1,0 +1,48 @@
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ActivityView from '../../components/ActivityView';
+
+let mockAppState = {};
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+const messages = {
+  'module.activity.title': 'Activity history',
+  'module.activity.subtitle': 'See the latest changes in your household.',
+  'module.dashboard.activity_title': 'Recent activity',
+  'module.dashboard.activity_empty': 'No household activity yet.',
+  'module.dashboard.activity_unknown_actor': 'Someone',
+};
+
+describe('ActivityView', () => {
+  beforeEach(() => {
+    mockAppState = {
+      activity: [],
+      messages,
+      lang: 'en',
+    };
+  });
+
+  it('shows household activity as a dedicated history view', () => {
+    mockAppState = {
+      ...mockAppState,
+      activity: [
+        {
+          id: 1,
+          actor_display_name: 'Dennis',
+          summary: 'Dennis completed task "Pay school lunch"',
+          created_at: '2026-04-29T10:00:00Z',
+        },
+      ],
+    };
+
+    render(<ActivityView />);
+
+    expect(screen.getByRole('heading', { name: 'Activity history' })).toBeVisible();
+    expect(screen.getByText('See the latest changes in your household.')).toBeVisible();
+    const feed = screen.getByRole('region', { name: 'Recent activity' });
+    expect(within(feed).getByText('Dennis completed task "Pay school lunch"')).toBeVisible();
+  });
+});

--- a/frontend/__tests__/components/DashboardActivationPanel.test.js
+++ b/frontend/__tests__/components/DashboardActivationPanel.test.js
@@ -19,8 +19,8 @@ jest.mock('../../lib/api', () => ({
   apiGetDashboardLayout: jest.fn(() => new Promise(() => {})),
   apiGetSetupChecklist: jest.fn(() => Promise.resolve({ ok: false })),
   apiListMealPlans: jest.fn(() => Promise.resolve({ ok: true, data: [] })),
-  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
-  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
+  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
+  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
 }));
 
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {

--- a/frontend/__tests__/components/DashboardDailyLoop.test.js
+++ b/frontend/__tests__/components/DashboardDailyLoop.test.js
@@ -13,8 +13,8 @@ jest.mock('../../lib/api', () => ({
   apiGetDashboardLayout: jest.fn(() => new Promise(() => {})),
   apiGetSetupChecklist: jest.fn(),
   apiListMealPlans: jest.fn(),
-  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
-  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } })),
+  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
+  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
 }));
 
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
@@ -186,7 +186,7 @@ describe('DashboardView daily loop', () => {
     expect(await within(card).findByText('Plan a meal, add groceries or set a recurring task to start the daily loop.')).toBeVisible();
   });
 
-  it('shows household activity on the dashboard', async () => {
+  it('keeps household activity out of the permanent dashboard layout', async () => {
     mockAppState = baseApp({
       activity: [{
         id: 1,
@@ -198,7 +198,7 @@ describe('DashboardView daily loop', () => {
 
     render(<DashboardView />);
 
-    const card = screen.getByRole('region', { name: 'Recent activity' });
-    expect(within(card).getByText('Dennis completed task "Pay school lunch"')).toBeVisible();
+    expect(screen.queryByRole('region', { name: 'Recent activity' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Dennis completed task "Pay school lunch"')).not.toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/components/DashboardDesktopLayout.test.js
+++ b/frontend/__tests__/components/DashboardDesktopLayout.test.js
@@ -108,9 +108,9 @@ describe('DashboardView desktop bento layout', () => {
     mockApiGetDashboardLayout.mockReset();
     mockApiUpdateDashboardLayout.mockReset();
     mockApiResetDashboardLayout.mockReset();
-    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } });
-    mockApiUpdateDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['daily_loop', 'quick_capture', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } });
-    mockApiResetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'] } });
+    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } });
+    mockApiUpdateDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['daily_loop', 'quick_capture', 'events', 'tasks', 'birthdays', 'rewards'] } });
+    mockApiResetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } });
     sessionStorage.clear();
   });
 
@@ -125,7 +125,6 @@ describe('DashboardView desktop bento layout', () => {
       'events',
       'tasks',
       'birthdays',
-      'activity',
       'rewards',
     ]);
     expect(modules[1].querySelector('.bento-card')).toHaveAccessibleName('Today in motion');
@@ -156,7 +155,7 @@ describe('DashboardView desktop bento layout', () => {
   });
 
   it('loads a saved dashboard layout and persists keyboard-accessible module moves', async () => {
-    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['tasks', 'events', 'quick_capture', 'daily_loop', 'birthdays', 'activity', 'rewards'] } });
+    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['tasks', 'events', 'quick_capture', 'daily_loop', 'birthdays', 'rewards'] } });
 
     const { container } = render(<DashboardView />);
 
@@ -172,13 +171,12 @@ describe('DashboardView desktop bento layout', () => {
       'quick_capture',
       'daily_loop',
       'birthdays',
-      'activity',
       'rewards',
     ]));
   });
 
   it('resets the dashboard layout to the default order', async () => {
-    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['tasks', 'events', 'quick_capture', 'daily_loop', 'birthdays', 'activity', 'rewards'] } });
+    mockApiGetDashboardLayout.mockResolvedValue({ ok: true, data: { modules: ['tasks', 'events', 'quick_capture', 'daily_loop', 'birthdays', 'rewards'] } });
 
     const { container } = render(<DashboardView />);
 

--- a/frontend/__tests__/components/NavigationTab.test.js
+++ b/frontend/__tests__/components/NavigationTab.test.js
@@ -23,6 +23,7 @@ const messages = {
   nav_reset: 'Zuruecksetzen',
   dashboard: 'Dashboard',
   calendar: 'Kalender',
+  activity: 'Aktivitäten',
   contacts: 'Kontakte',
   notifications: 'Benachrichtigungen',
   'module.shopping.name': 'Einkauf',
@@ -49,6 +50,7 @@ function baseState(overrides) {
 const LABEL_BY_KEY = {
   dashboard: 'Dashboard',
   calendar: 'Kalender',
+  activity: 'Aktivitäten',
   shopping: 'Einkauf',
   tasks: 'Aufgaben',
   templates: 'Vorlagen',

--- a/frontend/components/ActivityView.js
+++ b/frontend/components/ActivityView.js
@@ -1,0 +1,22 @@
+import HouseholdActivityFeed from './HouseholdActivityFeed';
+import { useApp } from '../contexts/AppContext';
+import { t } from '../lib/i18n';
+
+export default function ActivityView() {
+  const { activity, messages, lang } = useApp();
+
+  return (
+    <div>
+      <div className="view-header activity-view-header">
+        <div>
+          <h1 className="view-title">{t(messages, 'module.activity.title')}</h1>
+          <p className="view-subtitle">{t(messages, 'module.activity.subtitle')}</p>
+        </div>
+      </div>
+
+      <div className="activity-history-layout">
+        <HouseholdActivityFeed activity={activity} messages={messages} lang={lang} limit={0} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -7,6 +7,7 @@ import { announce } from '../lib/announce';
 import { isNavItemVisible, NAV_ITEM_META, PINNED_NAV_KEYS } from '../lib/navigation';
 import MemberAvatar from './MemberAvatar';
 import DashboardView from './DashboardView';
+import ActivityView from './ActivityView';
 import CalendarView from './calendar';
 import ContactsView from './ContactsView';
 import TasksView from './TasksView';
@@ -26,6 +27,7 @@ const MAX_BOTTOM_NAV = 5;
 
 const views = {
   dashboard: DashboardView,
+  activity: ActivityView,
   calendar: CalendarView,
   shopping: ShoppingView,
   contacts: ContactsView,

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -8,10 +8,9 @@ import { apiCompleteSetupChecklistStep, apiDismissSetupChecklist, apiGetDashboar
 import AssignedBadges from './AssignedBadges';
 import MemberAvatar from './MemberAvatar';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
-import HouseholdActivityFeed from './HouseholdActivityFeed';
 import QuickCaptureCard from './QuickCaptureCard';
 
-const DEFAULT_DASHBOARD_LAYOUT = ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'activity', 'rewards'];
+const DEFAULT_DASHBOARD_LAYOUT = ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'];
 
 function normalizeDashboardLayout(modules, availableModules = DEFAULT_DASHBOARD_LAYOUT) {
   const available = new Set(availableModules);
@@ -178,7 +177,7 @@ function ActivationPanel({ steps, completedCount, totalCount, messages, onDismis
 }
 
 export default function DashboardView() {
-  const { summary, me, members, tasks, events, shoppingLists, activity, quickCaptureInbox, familyId, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode, loadQuickCaptureInbox, loadTasks, loadShoppingLists, loadActivity } = useApp();
+  const { summary, me, members, tasks, events, shoppingLists, quickCaptureInbox, familyId, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode, loadQuickCaptureInbox, loadTasks, loadShoppingLists, loadActivity } = useApp();
   const todayIso = useMemo(() => todayIsoDate(), []);
   const [mealsTodayCount, setMealsTodayCount] = useState(0);
   const [setupChecklist, setSetupChecklist] = useState(null);
@@ -598,10 +597,6 @@ export default function DashboardView() {
             })}
           </div>
         </div>
-        </div>
-
-        <div className="dashboard-module-shell" style={{ order: moduleOrder('activity') }} data-dashboard-module="activity">
-          <HouseholdActivityFeed activity={activity} messages={messages} lang={lang} />
         </div>
 
         {/* Rewards Widget */}

--- a/frontend/components/HouseholdActivityFeed.js
+++ b/frontend/components/HouseholdActivityFeed.js
@@ -14,8 +14,9 @@ function formatActivityTime(value, lang = 'en') {
   });
 }
 
-export default function HouseholdActivityFeed({ activity = [], messages = {}, lang = 'en' }) {
-  const entries = Array.isArray(activity) ? activity.slice(0, 5) : [];
+export default function HouseholdActivityFeed({ activity = [], messages = {}, lang = 'en', limit = 5 }) {
+  const allEntries = Array.isArray(activity) ? activity : [];
+  const entries = limit ? allEntries.slice(0, limit) : allEntries;
   const title = t(messages, 'module.dashboard.activity_title');
   const unknownActor = t(messages, 'module.dashboard.activity_unknown_actor');
 

--- a/frontend/contexts/UIContext.js
+++ b/frontend/contexts/UIContext.js
@@ -3,7 +3,7 @@ import { buildMessages, listLanguages } from '../lib/i18n';
 import { getTheme, listThemes } from '../lib/themes';
 import { buildUi } from '../lib/styles';
 
-export const DEFAULT_NAV_ORDER = ['dashboard', 'calendar', 'shopping', 'tasks', 'templates', 'meal_plans', 'recipes', 'rewards', 'gifts', 'contacts', 'notifications', 'settings', 'admin'];
+export const DEFAULT_NAV_ORDER = ['dashboard', 'calendar', 'shopping', 'tasks', 'activity', 'templates', 'meal_plans', 'recipes', 'rewards', 'gifts', 'contacts', 'notifications', 'settings', 'admin'];
 
 const UIContext = createContext(null);
 export const useUI = () => useContext(UIContext);

--- a/frontend/e2e/helpers/navigation.js
+++ b/frontend/e2e/helpers/navigation.js
@@ -9,6 +9,7 @@ const VIEW_KEYS = {
   Calendar: 'calendar',
   Shopping: 'shopping',
   Tasks: 'tasks',
+  Activity: 'activity',
   Templates: 'templates',
   'Meal plan': 'meal_plans',
   Recipes: 'recipes',

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -83,20 +83,23 @@ test.describe('Dashboard', () => {
     await expect(checklist).not.toBeVisible({ timeout: 10000 });
   });
 
-  test('shows household activity from recent task changes', async ({ authedPage: page, apiCtx, testUser }) => {
+  test('moves household activity to a dedicated history view', async ({ authedPage: page, apiCtx, testUser }) => {
     const familyId = await getFamilyId(apiCtx);
     await seedTask(apiCtx, familyId, {
       title: 'E2E Activity Task',
-      description: 'private detail should stay out of the dashboard feed',
+      description: 'private detail should stay out of the activity feed',
     });
 
     await page.reload();
     await page.locator('#main-content').waitFor({ timeout: 15000 });
 
-    const activityCard = page.getByRole('region', { name: 'Recent activity' });
-    await expect(activityCard).toBeVisible({ timeout: 10000 });
-    await expect(activityCard).toContainText(`${testUser.displayName} created task "E2E Activity Task"`, { timeout: 10000 });
-    await expect(activityCard).not.toContainText('private detail');
+    await expect(page.getByRole('region', { name: 'Recent activity' })).toHaveCount(0);
+
+    await navigateTo(page, 'Activity');
+    await expect(page.getByRole('heading', { name: 'Activity history' })).toBeVisible({ timeout: 10000 });
+    const activityFeed = page.getByRole('region', { name: 'Recent activity' });
+    await expect(activityFeed).toContainText(`${testUser.displayName} created task "E2E Activity Task"`, { timeout: 10000 });
+    await expect(activityFeed).not.toContainText('private detail');
   });
 
   test('captures a quick note and triages it from the dashboard inbox', async ({ authedPage: page }) => {

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -12,6 +12,7 @@
   "switch_to_register": "Neu hier? Registrieren",
   "switch_to_login": "Schon registriert? Login",
   "dashboard": "Dashboard",
+  "activity": "Aktivitäten",
   "calendar": "Kalender",
   "settings": "Einstellungen",
   "settings_tab_account": "Konto",

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -12,6 +12,7 @@
   "switch_to_register": "New here? Sign up",
   "switch_to_login": "Already registered? Sign in",
   "dashboard": "Dashboard",
+  "activity": "Activity",
   "calendar": "Calendar",
   "settings": "Settings",
   "settings_tab_account": "Account",

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -63,6 +63,8 @@
   "module.dashboard.activity_title": "Letzte Aktivitäten",
   "module.dashboard.activity_empty": "Noch keine Haushaltsaktivitäten.",
   "module.dashboard.activity_unknown_actor": "Jemand",
+  "module.activity.title": "Aktivitätsverlauf",
+  "module.activity.subtitle": "Sieh nach, was sich zuletzt im Haushalt geändert hat.",
   "module.dashboard.quick_capture_title": "Schnell erfassen",
   "module.dashboard.quick_capture_subtitle": "Gedanken festhalten und später einsortieren.",
   "module.dashboard.quick_capture_placeholder": "Termin, Aufgabe oder Einkaufsnotiz notieren…",

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -63,6 +63,8 @@
   "module.dashboard.activity_title": "Recent activity",
   "module.dashboard.activity_empty": "No household activity yet.",
   "module.dashboard.activity_unknown_actor": "Someone",
+  "module.activity.title": "Activity history",
+  "module.activity.subtitle": "See the latest changes in your household.",
   "module.dashboard.quick_capture_title": "Quick capture",
   "module.dashboard.quick_capture_subtitle": "Save thoughts now and sort them later.",
   "module.dashboard.quick_capture_placeholder": "Note an event, task, or shopping thought…",

--- a/frontend/lib/navigation.js
+++ b/frontend/lib/navigation.js
@@ -1,5 +1,6 @@
 import {
   Bell,
+  Activity,
   BookUser,
   BookOpen,
   CalendarDays,
@@ -18,6 +19,7 @@ export const PINNED_NAV_KEYS = new Set(['settings', 'admin']);
 
 export const NAV_ITEM_META = {
   dashboard: { icon: LayoutDashboard, labelKey: 'dashboard', mobileLabel: 'Home' },
+  activity: { icon: Activity, labelKey: 'activity' },
   calendar: { icon: CalendarDays, labelKey: 'calendar' },
   shopping: { icon: ShoppingCart, labelKey: 'module.shopping.name' },
   tasks: { icon: CheckSquare, labelKey: 'module.tasks.name' },

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -755,6 +755,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .bento-tasks { grid-column: span 6; }
 .bento-birthdays { grid-column: span 6; }
 .bento-activity { grid-column: span 6; }
+.activity-history-layout .bento-activity { grid-column: 1 / -1; }
+.activity-history-layout .activity-feed-list { max-width: 860px; }
 .bento-rewards { grid-column: span 6; }
 .bento-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-md); }
 .bento-card-title { font-size: 0.78rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 8px; }


### PR DESCRIPTION
## Summary
- Move Recent activity out of the default dashboard modules
- Add a dedicated Activity navigation view that reuses the existing household activity feed
- Update dashboard layout defaults, translations, navigation metadata, and regression coverage

## Test plan
- `npm test -- --runTestsByPath __tests__/components/ActivityView.test.js __tests__/components/DashboardDesktopLayout.test.js __tests__/components/NavigationTab.test.js __tests__/components/DashboardDailyLoop.test.js --runInBand`
- `DATABASE_URL=sqlite:////tmp/tribu-issue-263/backend/test_dashboard_layout.db JWT_SECRET=*** uv run --with-requirements backend/requirements.txt --with pytest pytest backend/tests/test_dashboard_layout.py -q`
- `npm run build`
- `npx playwright test --list`
- `timeout 300s nice -n 19 ionice -c3 npx playwright test e2e/tests/dashboard.spec.js --reporter=list`
- `timeout 180s nice -n 19 ionice -c3 npx playwright test e2e/tests/dashboard.spec.js:86 --reporter=list`

Closes #263
