### PR TITLE
Record calendar changes in household activity

### DIFF
--- a/backend/app/modules/calendar_router.py
+++ b/backend/app/modules/calendar_router.py
@@ -6,6 +6,7 @@ from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from app.core import cache
+from app.core.activity import record_activity
 from app.core.clock import utcnow
 from app.core.calendar_subscriptions import (
     IcsSubscriptionError,
@@ -134,6 +135,45 @@ def calendar_feed_ics(
 
 def _subscription_label(source_name: str | None, source_url: str) -> str:
     return (source_name or "").strip() or hostname_from_url(source_url) or source_url
+
+
+MEANINGFUL_EVENT_ACTIVITY_FIELDS = {
+    "title",
+    "location",
+    "starts_at",
+    "ends_at",
+    "all_day",
+    "recurrence",
+    "recurrence_end",
+    "assigned_to",
+}
+
+
+def _calendar_event_snapshot(event: CalendarEvent) -> dict:
+    return {field: getattr(event, field) for field in MEANINGFUL_EVENT_ACTIVITY_FIELDS}
+
+
+def _record_calendar_activity(
+    db: Session,
+    *,
+    event: CalendarEvent,
+    user: User,
+    action: str,
+    object_label: str | None = None,
+    verb: str | None = None,
+) -> None:
+    record_activity(
+        db,
+        family_id=event.family_id,
+        actor_user_id=user.id,
+        actor_display_name=user.display_name,
+        action=action,
+        object_type="calendar_event",
+        object_id=event.id,
+        object_label=object_label or event.title,
+        verb=verb or action,
+        object_kind="calendar event",
+    )
 
 
 def _safe_subscription_error(exc: Exception) -> str:
@@ -738,6 +778,7 @@ def create_calendar_event(
     db.flush()
 
     _create_assignment_notifications(db, event, user.id)
+    _record_calendar_activity(db, event=event, user=user, action="created")
 
     db.commit()
     db.refresh(event)
@@ -771,6 +812,7 @@ def update_calendar_event(
         raise HTTPException(status_code=404, detail=error_detail(EVENT_NOT_FOUND))
 
     ensure_adult(db, user.id, event.family_id)
+    before = _calendar_event_snapshot(event)
 
     if payload.title is not None:
         event.title = payload.title
@@ -809,6 +851,9 @@ def update_calendar_event(
     if event.ends_at and event.ends_at < event.starts_at:
         raise HTTPException(status_code=400, detail=error_detail(END_BEFORE_START))
 
+    if _calendar_event_snapshot(event) != before:
+        _record_calendar_activity(db, event=event, user=user, action="updated")
+
     db.commit()
     db.refresh(event)
     cache.invalidate_pattern(f"tribu:dashboard:{event.family_id}:*")
@@ -842,10 +887,13 @@ def delete_calendar_event(
         if occurrence_date not in excluded:
             excluded.append(occurrence_date)
         event.excluded_dates = excluded
+        _record_calendar_activity(db, event=event, user=user, action="removed occurrence")
         db.commit()
         cache.invalidate_pattern(f"tribu:dashboard:{family_id}:*")
         return {"status": "occurrence_excluded", "event_id": event_id, "excluded_date": occurrence_date}
 
+    object_label = event.title
+    _record_calendar_activity(db, event=event, user=user, action="deleted", object_label=object_label)
     db.delete(event)
     db.commit()
     cache.invalidate_pattern(f"tribu:dashboard:{family_id}:*")

--- a/backend/tests/test_household_activity.py
+++ b/backend/tests/test_household_activity.py
@@ -186,6 +186,57 @@ def test_shopping_activity_and_family_boundaries():
     assert "private note" not in str(feed.json())
 
 
+def test_calendar_event_activity_is_recorded_public_safely():
+    token, family_id, _ = _seed_member("*", "calendar", display_name="Alex")
+    intruder_token, _, _ = _seed_member("*", "calendar-intruder", display_name="Other")
+
+    created = client.post(
+        "/calendar/events",
+        json={
+            "family_id": family_id,
+            "title": "  Piano lesson with a very very very long private-ish suffix that should be clipped  ",
+            "description": "teacher phone and door code should not leak",
+            "location": "Private home address should not leak",
+            "starts_at": "2026-05-01T15:00:00Z",
+            "ends_at": "2026-05-01T16:00:00Z",
+        },
+        headers=_auth(token),
+    )
+    assert created.status_code == 200, created.json()
+    event_id = created.json()["id"]
+
+    updated = client.patch(
+        f"/calendar/events/{event_id}",
+        json={"title": "Piano lesson", "description": "new private note"},
+        headers=_auth(token),
+    )
+    assert updated.status_code == 200, updated.json()
+
+    deleted = client.delete(f"/calendar/events/{event_id}", headers=_auth(token))
+    assert deleted.status_code == 200, deleted.json()
+
+    denied = client.get(f"/activity?family_id={family_id}", headers=_auth(intruder_token))
+    assert denied.status_code == 403
+
+    feed = client.get(f"/activity?family_id={family_id}&limit=10", headers=_auth(token))
+    assert feed.status_code == 200, feed.json()
+    data = feed.json()
+    assert data["total"] == 3
+    assert [(item["action"], item["object_type"]) for item in data["items"]] == [
+        ("deleted", "calendar_event"),
+        ("updated", "calendar_event"),
+        ("created", "calendar_event"),
+    ]
+    assert data["items"][0]["summary"] == 'Alex deleted calendar event "Piano lesson"'
+    assert data["items"][1]["summary"] == 'Alex updated calendar event "Piano lesson"'
+    assert data["items"][2]["summary"].startswith('Alex created calendar event "Piano lesson with a very very')
+    serialized = str(data)
+    assert "teacher phone" not in serialized
+    assert "door code" not in serialized
+    assert "Private home address" not in serialized
+    assert "new private note" not in serialized
+
+
 def test_activity_feed_orders_and_paginates():
     token, family_id, user_id = _seed_member("*", "pages")
     db = TestSession()

--- a/frontend/__tests__/components/HouseholdActivityFeed.test.js
+++ b/frontend/__tests__/components/HouseholdActivityFeed.test.js
@@ -34,6 +34,29 @@ describe('HouseholdActivityFeed', () => {
     expect(screen.queryByText('123')).not.toBeInTheDocument();
   });
 
+  it('renders calendar-related activity entries', () => {
+    render(
+      <HouseholdActivityFeed
+        messages={messages}
+        lang="en"
+        activity={[
+          {
+            id: 8,
+            actor_display_name: 'Alex',
+            summary: 'Alex created calendar event "Piano lesson"',
+            object_type: 'calendar_event',
+            object_id: 456,
+            created_at: '2026-05-01T15:00:00Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Alex created calendar event "Piano lesson"')).toBeInTheDocument();
+    expect(screen.queryByText('calendar_event')).not.toBeInTheDocument();
+    expect(screen.queryByText('456')).not.toBeInTheDocument();
+  });
+
   it('renders an empty state', () => {
     render(<HouseholdActivityFeed messages={messages} activity={[]} />);
     expect(screen.getByText('No household activity yet.')).toBeInTheDocument();

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('../helpers/fixtures');
-const { getFamilyId, seedTask } = require('../helpers/api-setup');
+const { getFamilyId, seedCalendarEvent, seedTask } = require('../helpers/api-setup');
 const { navigateTo } = require('../helpers/navigation');
 
 test.describe('Dashboard', () => {
@@ -89,6 +89,11 @@ test.describe('Dashboard', () => {
       title: 'E2E Activity Task',
       description: 'private detail should stay out of the activity feed',
     });
+    await seedCalendarEvent(apiCtx, familyId, {
+      title: 'E2E Calendar Activity',
+      description: 'calendar private detail should stay out',
+      location: 'calendar private location should stay out',
+    });
 
     await page.reload();
     await page.locator('#main-content').waitFor({ timeout: 15000 });
@@ -99,7 +104,9 @@ test.describe('Dashboard', () => {
     await expect(page.getByRole('heading', { name: 'Activity history' })).toBeVisible({ timeout: 10000 });
     const activityFeed = page.getByRole('region', { name: 'Recent activity' });
     await expect(activityFeed).toContainText(`${testUser.displayName} created task "E2E Activity Task"`, { timeout: 10000 });
+    await expect(activityFeed).toContainText(`${testUser.displayName} created calendar event "E2E Calendar Activity"`, { timeout: 10000 });
     await expect(activityFeed).not.toContainText('private detail');
+    await expect(activityFeed).not.toContainText('calendar private location');
   });
 
   test('captures a quick note and triages it from the dashboard inbox', async ({ authedPage: page }) => {


### PR DESCRIPTION
## Summary
- Record public-safe household activity when calendar events are created, updated, deleted, or a recurring occurrence is removed.
- Keep activity summaries family-scoped and sanitized so notes, locations, and internal identifiers are not shown.
- Extend component and browser coverage so calendar activity appears in the activity history view.

## Test plan
- `DATABASE_URL=sqlite:///./test-household-activity.db JWT_SECRET=test-secret PYTHONPATH=backend pytest backend/tests/test_household_activity.py -q`
- `DATABASE_URL=sqlite:///./test-household-activity.db JWT_SECRET=test-secret PYTHONPATH=backend pytest backend/tests/test_household_activity.py backend/tests/test_calendar_locations.py backend/tests/test_calendar_subscriptions.py -q`
- `ruff check backend/app/modules/calendar_router.py backend/tests/test_household_activity.py`
- `npm test -- --runTestsByPath __tests__/components/HouseholdActivityFeed.test.js --runInBand`
- `npm run build`
- `npx playwright test --list`
- `npx playwright test e2e/tests/dashboard.spec.js --project='Desktop Chrome' --project='Mobile Chrome' --reporter=list`

Closes #279
