### PR TITLE
Show birthday indicators in calendar month view

### DIFF
--- a/frontend/__tests__/components/CalendarViewBirthdayIndicators.test.js
+++ b/frontend/__tests__/components/CalendarViewBirthdayIndicators.test.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import CalendarView from '../../components/calendar';
+
+const mockUseApp = jest.fn();
+const mockUseCalendar = jest.fn();
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockUseApp(),
+}));
+
+jest.mock('../../hooks/useCalendar', () => ({
+  useCalendar: () => mockUseCalendar(),
+}));
+
+function baseApp() {
+  return {
+    familyId: 1,
+    families: [{ family_id: 1, family_name: 'Family' }],
+    messages: {
+      calendar: 'Calendar',
+      'module.calendar.weekdays': 'Sun,Mon,Tue,Wed,Thu,Fri,Sat',
+      'module.calendar.today': 'Today',
+      'module.calendar.month': 'Month',
+      'module.calendar.week': 'Week',
+      'aria.previous_month': 'Previous month',
+      'aria.next_month': 'Next month',
+      'aria.events': '{count} events',
+    },
+    isMobile: false,
+    lang: 'en',
+    demoMode: false,
+    events: [],
+    setActiveView: jest.fn(),
+    isChild: false,
+    members: [],
+    timeFormat: '24h',
+  };
+}
+
+function monthCell(day, events = []) {
+  return { empty: false, day, count: events.length, events };
+}
+
+function emptyCell() {
+  return { empty: true };
+}
+
+function baseCalendar(cells) {
+  return {
+    calendarView: 'month',
+    calendarMonth: new Date(2026, 4, 1),
+    selectedDate: null,
+    monthCells: cells,
+    setCalendarMonth: jest.fn(),
+    setSelectedDate: jest.fn(),
+    startsAt: '',
+    setStartsAt: jest.fn(),
+    weekInfo: { weekNumber: 18, weekStart: new Date(2026, 4, 1), weekEnd: new Date(2026, 4, 8), days: [] },
+    setCalendarView: jest.fn(),
+    prevWeek: jest.fn(),
+    nextWeek: jest.fn(),
+    goToCurrentWeek: jest.fn(),
+    deleteConfirm: null,
+    setDeleteConfirm: jest.fn(),
+    performDelete: jest.fn(),
+    deleteEvent: jest.fn(),
+    startEdit: jest.fn(),
+  };
+}
+
+describe('CalendarView birthday month indicators', () => {
+  beforeEach(() => {
+    mockUseApp.mockReturnValue(baseApp());
+  });
+
+  it('shows a cake indicator instead of a regular dot for a birthday-only day', () => {
+    mockUseCalendar.mockReturnValue(baseCalendar([
+      emptyCell(),
+      monthCell(1, [{ id: 'birthday-1', title: 'Mia Birthday', _isBirthday: true, color: '#f43f5e' }]),
+    ]));
+
+    render(<CalendarView />);
+
+    const birthdayDay = screen.getByRole('button', { name: /May 1, 1 birthday/i });
+    expect(birthdayDay.querySelector('.calendar-day-birthday-indicator')).toBeInTheDocument();
+    expect(birthdayDay.querySelector('.calendar-day-dot')).not.toBeInTheDocument();
+  });
+
+  it('shows both birthday and regular event cues on a mixed day', () => {
+    mockUseCalendar.mockReturnValue(baseCalendar([
+      emptyCell(),
+      monthCell(2, [
+        { id: 'birthday-2', title: 'Noah Birthday', _isBirthday: true, color: '#f43f5e' },
+        { id: 42, title: 'Football', color: '#2563eb' },
+      ]),
+    ]));
+
+    render(<CalendarView />);
+
+    const mixedDay = screen.getByRole('button', { name: /May 2, 1 birthday, 1 event/i });
+    expect(mixedDay.querySelector('.calendar-day-birthday-indicator')).toBeInTheDocument();
+    expect(mixedDay.querySelectorAll('.calendar-day-dot')).toHaveLength(1);
+  });
+
+  it('keeps regular event-only days on dot indicators', () => {
+    mockUseCalendar.mockReturnValue(baseCalendar([
+      emptyCell(),
+      monthCell(3, [{ id: 99, title: 'Dentist', color: '#16a34a' }]),
+    ]));
+
+    render(<CalendarView />);
+
+    const eventDay = screen.getByRole('button', { name: /May 3, 1 event/i });
+    expect(eventDay.querySelector('.calendar-day-birthday-indicator')).not.toBeInTheDocument();
+    expect(eventDay.querySelectorAll('.calendar-day-dot')).toHaveLength(1);
+  });
+});

--- a/frontend/components/calendar/index.js
+++ b/frontend/components/calendar/index.js
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Cake, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useCalendar } from '../../hooks/useCalendar';
 import { t } from '../../lib/i18n';
@@ -13,6 +13,13 @@ export default function CalendarView() {
   const weekdays = t(messages, 'module.calendar.weekdays').split(',');
 
   const today = new Date();
+  const formatCountLabel = (count, singular, plural) => `${count} ${count === 1 ? singular : plural}`;
+  const buildDayContentLabel = (birthdayCount, eventCount) => {
+    const parts = [];
+    if (birthdayCount > 0) parts.push(formatCountLabel(birthdayCount, 'birthday', 'birthdays'));
+    if (eventCount > 0) parts.push(formatCountLabel(eventCount, 'event', 'events'));
+    return parts.join(', ');
+  };
   const isToday = (day) => {
     return day === today.getDate()
       && cal.calendarMonth.getMonth() === today.getMonth()
@@ -122,8 +129,13 @@ export default function CalendarView() {
                 const dayDate = !c.empty
                   ? new Date(cal.calendarMonth.getFullYear(), cal.calendarMonth.getMonth(), c.day)
                   : null;
+                const birthdayEvents = (c.events || []).filter((ev) => ev._isBirthday);
+                const regularEvents = (c.events || []).filter((ev) => !ev._isBirthday);
+                const birthdayCount = birthdayEvents.length;
+                const regularEventCount = regularEvents.length;
+                const dayContentLabel = buildDayContentLabel(birthdayCount, regularEventCount);
                 const dayLabel = dayDate
-                  ? dayDate.toLocaleDateString(locale, { day: 'numeric', month: 'long' }) + (c.count > 0 ? `, ${t(messages, 'aria.events').replace('{count}', c.count)}` : '')
+                  ? dayDate.toLocaleDateString(locale, { day: 'numeric', month: 'long' }) + (dayContentLabel ? `, ${dayContentLabel}` : '')
                   : undefined;
 
                 return (
@@ -148,10 +160,15 @@ export default function CalendarView() {
                     {!c.empty && (
                       <>
                         <span className="calendar-day-num">{c.day}</span>
-                        {c.count > 0 && (
+                        {(birthdayCount > 0 || regularEventCount > 0) && (
                           <div className="calendar-day-dots" aria-hidden="true">
-                            {(c.events || []).slice(0, 3).map((ev, di) => (
-                              <div key={di} className="calendar-day-dot" style={{ background: ev.color || getMemberColor(null, di) }} />
+                            {birthdayCount > 0 && (
+                              <div className="calendar-day-birthday-indicator" title={formatCountLabel(birthdayCount, 'birthday', 'birthdays')}>
+                                <Cake size={11} strokeWidth={2.4} aria-hidden="true" />
+                              </div>
+                            )}
+                            {regularEvents.slice(0, birthdayCount > 0 ? 2 : 3).map((ev, di) => (
+                              <div key={ev.id || di} className="calendar-day-dot" style={{ background: ev.color || getMemberColor(null, di) }} />
                             ))}
                           </div>
                         )}

--- a/frontend/e2e/tests/calendar-birthday-identity.spec.js
+++ b/frontend/e2e/tests/calendar-birthday-identity.spec.js
@@ -24,6 +24,12 @@ async function openCalendarDay(page, day) {
   await page.keyboard.press('Enter');
 }
 
+async function expectBirthdayCakeIndicator(page, day) {
+  const birthdayDay = page.getByRole('button', { name: new RegExp(`${day}.*birthday`, 'i') }).first();
+  await expect(birthdayDay.locator('.calendar-day-birthday-indicator')).toBeVisible();
+  await expect(birthdayDay.locator('.calendar-day-dot')).toHaveCount(0);
+}
+
 test.describe('Birthday identity regression', () => {
   test('calendar keeps duplicate-name contact birthdays separate and tracks rename/delete correctly', async ({ authedPage: page, apiCtx }) => {
     const familyId = await getFamilyId(apiCtx);
@@ -37,6 +43,7 @@ test.describe('Birthday identity regression', () => {
     await page.reload();
     await navigateTo(page, 'Calendar');
     await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+    await expectBirthdayCakeIndicator(page, day);
     await openCalendarDay(page, day);
 
     await expect(page.locator('.day-detail-events .event-card-title', { hasText: name })).toHaveCount(2);

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1027,8 +1027,9 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .calendar-day.empty { opacity: 0.25; cursor: default; }
 .calendar-day.other-month { opacity: 0.3; }
 .calendar-day-num { font-size: 0.88rem; font-weight: 500; font-family: 'JetBrains Mono', monospace; }
-.calendar-day-dots { display: flex; gap: 3px; min-height: 6px; }
+.calendar-day-dots { display: flex; align-items: center; gap: 3px; min-height: 11px; }
 .calendar-day-dot { width: 5px; height: 5px; border-radius: 50%; }
+.calendar-day-birthday-indicator { width: 13px; height: 13px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; color: #f43f5e; background: color-mix(in srgb, #f43f5e 12%, transparent); flex: 0 0 auto; }
 .day-detail-panel { padding: var(--space-lg); background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); align-self: start; }
 .day-detail-date { font-size: 1.1rem; font-weight: 600; margin-bottom: var(--space-xs); }
 .day-detail-weekday { color: var(--text-muted); font-size: 0.82rem; margin-bottom: var(--space-lg); }


### PR DESCRIPTION
## Summary
- Shows birthday cake indicators in the calendar month grid instead of treating birthdays as regular event dots
- Keeps regular event dots for non-birthday events and mixed birthday/event days
- Adds accessible month-cell labels that distinguish birthdays from events

## Validation
- npm test -- --runTestsByPath __tests__/components/CalendarHelpers.test.js __tests__/components/CalendarViewBirthdayIndicators.test.js __tests__/hooks/useCalendar.test.js --runInBand
- npm run build
- npx playwright test e2e/tests/calendar-birthday-identity.spec.js --reporter=list

Closes #280
