### PR TITLE
feat(calendar): add event icons

### DIFF
--- a/backend/alembic/versions/0048_add_calendar_event_icon.py
+++ b/backend/alembic/versions/0048_add_calendar_event_icon.py
@@ -1,0 +1,25 @@
+"""add calendar event icon
+
+Revision ID: 0048_add_calendar_event_icon
+Revises: 0047_add_push_categories
+Create Date: 2026-04-30 10:50:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0048_add_calendar_event_icon"
+down_revision: Union[str, None] = "0047_add_push_categories"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("calendar_events", sa.Column("icon", sa.String(length=50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("calendar_events", "icon")

--- a/backend/app/core/calendar_icons.py
+++ b/backend/app/core/calendar_icons.py
@@ -1,0 +1,36 @@
+"""Allowlisted icons for local calendar events."""
+
+CALENDAR_EVENT_ICONS = {
+    "handball",
+    "gymnastics",
+    "soccer",
+    "dentist",
+    "doctor",
+    "school",
+    "daycare",
+    "swimming",
+    "music",
+    "birthday",
+    "shopping",
+    "meal",
+    "playdate",
+    "pickup",
+    "vacation",
+    "household",
+    "homework",
+    "pet",
+    "family_visit",
+    "appointment",
+}
+
+
+def normalize_calendar_event_icon(value: str | None) -> str | None:
+    """Return a safe event icon key or ``None`` for empty values."""
+    if value is None:
+        return None
+    icon = value.strip()
+    if not icon:
+        return None
+    if icon not in CALENDAR_EVENT_ICONS:
+        raise ValueError("Calendar event icon is not supported")
+    return icon

--- a/backend/app/core/recurrence.py
+++ b/backend/app/core/recurrence.py
@@ -86,6 +86,7 @@ def _event_to_dict(event) -> dict:
         "assigned_to": event.assigned_to,
         "color": event.color,
         "category": event.category,
+        "icon": event.icon,
         "created_by_user_id": event.created_by_user_id,
         "created_at": event.created_at,
     }

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -84,6 +84,7 @@ class CalendarEvent(Base):
     assigned_to = Column(JSON, nullable=True)
     color = Column(String, nullable=True)
     category = Column(String, nullable=True)
+    icon = Column(String(50), nullable=True)
     created_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime, nullable=False, default=utcnow)
     updated_at = Column(

--- a/backend/app/modules/calendar_router.py
+++ b/backend/app/modules/calendar_router.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from app.core import cache
 from app.core.activity import record_activity
 from app.core.clock import utcnow
+from app.core.calendar_icons import normalize_calendar_event_icon
 from app.core.calendar_subscriptions import (
     IcsSubscriptionError,
     fetch_ics_text,
@@ -150,6 +151,7 @@ MEANINGFUL_EVENT_ACTIVITY_FIELDS = {
     "recurrence",
     "recurrence_end",
     "assigned_to",
+    "icon",
 }
 
 
@@ -776,6 +778,7 @@ def create_calendar_event(
         assigned_to=payload.assigned_to,
         color=payload.color,
         category=payload.category,
+        icon=payload.icon,
         created_by_user_id=user.id,
     )
     db.add(event)
@@ -851,6 +854,8 @@ def update_calendar_event(
         event.color = payload.color or None
     if payload.category is not None:
         event.category = payload.category or None
+    if "icon" in payload.model_fields_set:
+        event.icon = normalize_calendar_event_icon(payload.icon)
 
     if event.ends_at and event.ends_at < event.starts_at:
         raise HTTPException(status_code=400, detail=error_detail(END_BEFORE_START))

--- a/backend/app/modules/display_router.py
+++ b/backend/app/modules/display_router.py
@@ -327,6 +327,7 @@ def display_dashboard(
             occurrence_date=o.get("occurrence_date"),
             color=o.get("color"),
             category=o.get("category"),
+            icon=o.get("icon"),
         )
         for o in occurrences[:8]
     ]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -9,6 +9,7 @@ from enum import Enum
 
 from pydantic import BaseModel, EmailStr, ConfigDict, Field, field_validator
 
+from app.core.calendar_icons import normalize_calendar_event_icon
 from app.core.notification_preferences import normalize_push_categories
 
 
@@ -363,10 +364,16 @@ class CalendarEventCreate(BaseModel):
     assigned_to: Optional[Union[list[int], str]] = Field(None, description="Assigned members: null (nobody), 'all' (whole family), or list of user IDs")
     color: Optional[str] = Field(None, description="Event color as hex string (e.g. '#7c3aed')")
     category: Optional[str] = Field(None, description="Event category label")
+    icon: Optional[str] = Field(None, description="Allowlisted calendar event icon key")
 
     model_config = ConfigDict(json_schema_extra={
         "examples": [{"family_id": 1, "title": "Family Dinner", "starts_at": "2026-03-01T18:00:00", "ends_at": "2026-03-01T20:00:00", "all_day": False, "recurrence": "weekly", "recurrence_end": "2026-06-01T00:00:00", "assigned_to": [1, 3]}]
     })
+
+    @field_validator("icon")
+    @classmethod
+    def validate_icon(cls, v: Optional[str]) -> Optional[str]:
+        return normalize_calendar_event_icon(v)
 
 
 class CalendarEventUpdate(BaseModel):
@@ -382,6 +389,12 @@ class CalendarEventUpdate(BaseModel):
     assigned_to: Optional[Union[list[int], str]] = Field(None, description="Assigned members: null (nobody), 'all' (whole family), or list of user IDs")
     color: Optional[str] = Field(None, description="Event color as hex string")
     category: Optional[str] = Field(None, description="Event category label")
+    icon: Optional[str] = Field(None, description="Allowlisted calendar event icon key")
+
+    @field_validator("icon")
+    @classmethod
+    def validate_icon(cls, v: Optional[str]) -> Optional[str]:
+        return normalize_calendar_event_icon(v)
 
 
 class CalendarEventResponse(BaseModel):
@@ -403,6 +416,7 @@ class CalendarEventResponse(BaseModel):
     assigned_to: Optional[Union[list[int], str]] = Field(None, description="Assigned members: null, 'all', or list of user IDs")
     color: Optional[str] = Field(None, description="Event color as hex string")
     category: Optional[str] = Field(None, description="Event category label")
+    icon: Optional[str] = Field(None, description="Allowlisted calendar event icon key")
     created_by_user_id: Optional[int] = Field(None, description="User who created the event")
     created_at: datetime = Field(..., description="Creation timestamp")
     source_type: str = Field("local", description="Where the event came from: 'local', 'import', or 'subscription'")
@@ -1788,6 +1802,7 @@ class DisplayDashboardEvent(BaseModel):
     occurrence_date: Optional[str] = Field(None, description="Date of this specific occurrence (YYYY-MM-DD) for recurring events")
     color: Optional[str] = Field(None, description="Event color as hex string, if set")
     category: Optional[str] = Field(None, description="Event category label")
+    icon: Optional[str] = Field(None, description="Allowlisted calendar event icon key")
 
 
 class DisplayDashboardBirthday(BaseModel):

--- a/backend/tests/test_calendar_locations.py
+++ b/backend/tests/test_calendar_locations.py
@@ -115,3 +115,61 @@ def test_create_list_update_and_clear_calendar_event_location():
         assert event.location is None
     finally:
         db.close()
+
+
+def test_create_update_clear_and_reject_calendar_event_icons():
+    token, family_id = _seed_adult()
+    client = TestClient(app)
+
+    created = client.post(
+        "/calendar/events",
+        json={
+            "family_id": family_id,
+            "title": "Football practice",
+            "starts_at": "2026-05-12T16:00:00",
+            "icon": "soccer",
+        },
+        headers=_auth_headers(token),
+    )
+    assert created.status_code == 200, created.text
+    body = created.json()
+    assert body["icon"] == "soccer"
+
+    listed = client.get(f"/calendar/events?family_id={family_id}", headers=_auth_headers(token))
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["items"][0]["icon"] == "soccer"
+
+    updated = client.patch(
+        f"/calendar/events/{body['id']}",
+        json={"icon": "dentist"},
+        headers=_auth_headers(token),
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["icon"] == "dentist"
+
+    cleared = client.patch(
+        f"/calendar/events/{body['id']}",
+        json={"icon": None},
+        headers=_auth_headers(token),
+    )
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["icon"] is None
+
+    invalid = client.post(
+        "/calendar/events",
+        json={
+            "family_id": family_id,
+            "title": "Unsafe icon",
+            "starts_at": "2026-05-13T16:00:00",
+            "icon": "<svg/onload=alert(1)>",
+        },
+        headers=_auth_headers(token),
+    )
+    assert invalid.status_code == 422, invalid.text
+
+    db = TestSession()
+    try:
+        event = db.query(CalendarEvent).filter(CalendarEvent.id == body["id"]).one()
+        assert event.icon is None
+    finally:
+        db.close()

--- a/backend/tests/test_display_devices.py
+++ b/backend/tests/test_display_devices.py
@@ -300,6 +300,7 @@ class TestDisplayRuntime:
             assigned_to=[admin_user_id],
             color="#7c3aed",
             category="sports",
+            icon="soccer",
             created_by_user_id=admin_user_id,
             source_type="subscription",
             source_name="Coach Feed",
@@ -324,8 +325,9 @@ class TestDisplayRuntime:
         # Whitelist exactly the keys we expect.
         assert set(evt.keys()) == {
             "title", "starts_at", "ends_at", "all_day",
-            "occurrence_date", "color", "category",
+            "occurrence_date", "color", "category", "icon",
         }, evt
+        assert evt["icon"] == "soccer"
         # Defensive: forbidden fields must not appear in the event JSON.
         events_json = json_module.dumps(body["next_events"])
         for forbidden in (

--- a/frontend/__tests__/components/CalendarViewBirthdayIndicators.test.js
+++ b/frontend/__tests__/components/CalendarViewBirthdayIndicators.test.js
@@ -117,4 +117,17 @@ describe('CalendarView birthday month indicators', () => {
     expect(eventDay.querySelector('.calendar-day-birthday-indicator')).not.toBeInTheDocument();
     expect(eventDay.querySelectorAll('.calendar-day-dot')).toHaveLength(1);
   });
+
+  it('shows allowlisted event icons instead of regular dots in month cells', () => {
+    mockUseCalendar.mockReturnValue(baseCalendar([
+      emptyCell(),
+      monthCell(4, [{ id: 77, title: 'Soccer practice', color: '#16a34a', icon: 'soccer' }]),
+    ]));
+
+    render(<CalendarView />);
+
+    const eventDay = screen.getByRole('button', { name: /May 4, 1 event: Soccer training/i });
+    expect(eventDay.querySelector('.calendar-day-icon-indicator')).toHaveTextContent('⚽');
+    expect(eventDay.querySelector('.calendar-day-dot')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/__tests__/hooks/useCalendar.test.js
+++ b/frontend/__tests__/hooks/useCalendar.test.js
@@ -107,6 +107,7 @@ describe('useCalendar edit flow', () => {
       assigned_to: [7],
       color: '#7c3aed',
       category: 'work',
+      icon: 'music',
       is_recurring: true,
     }));
 
@@ -120,6 +121,7 @@ describe('useCalendar edit flow', () => {
     expect(result.current.editAssignedTo).toEqual([7]);
     expect(result.current.editColor).toBe('#7c3aed');
     expect(result.current.editCategory).toBe('work');
+    expect(result.current.editIcon).toBe('music');
   });
 
   it('startEdit preserves an "all" assignment instead of coercing it to an array', () => {
@@ -147,7 +149,7 @@ describe('useCalendar edit flow', () => {
     expect(result.current.editingEvent).toBeNull();
   });
 
-  it('saveEdit payload includes recurrence, assigned_to, color, category, and location', async () => {
+  it('saveEdit payload includes recurrence, assigned_to, color, category, icon, and location', async () => {
     const ctx = setupAppContext({ demoMode: false });
     const { useCalendar } = require('../../hooks/useCalendar');
     const api = require('../../lib/api');
@@ -163,6 +165,7 @@ describe('useCalendar edit flow', () => {
       result.current.setEditAssignedTo(['7']);
       result.current.setEditColor('#22d3ee');
       result.current.setEditCategory('health');
+      result.current.setEditIcon('dentist');
       result.current.setEditLocation('Main Street Clinic');
     });
 
@@ -174,6 +177,7 @@ describe('useCalendar edit flow', () => {
       recurrence: 'monthly',
       assigned_to: [7],
       color: '#22d3ee',
+      icon: 'dentist',
       location: 'Main Street Clinic',
     }));
     // all_day and category are intentionally omitted from the PATCH
@@ -195,6 +199,7 @@ describe('useCalendar edit flow', () => {
       result.current.setTitle('Football practice');
       result.current.setStartsAt('2026-05-12T16:00');
       result.current.setLocation('Sports Park, Field 2');
+      result.current.setIcon('soccer');
     });
 
     await act(async () => {
@@ -204,8 +209,10 @@ describe('useCalendar edit flow', () => {
     expect(api.apiCreateEvent).toHaveBeenCalledWith(expect.objectContaining({
       title: 'Football practice',
       location: 'Sports Park, Field 2',
+      icon: 'soccer',
     }));
     expect(result.current.location).toBe('');
+    expect(result.current.icon).toBe('');
   });
 
   it('saveEdit does not wipe the dialog if the user switched events mid-save', async () => {

--- a/frontend/components/calendar/CalendarHelpers.js
+++ b/frontend/components/calendar/CalendarHelpers.js
@@ -3,6 +3,7 @@ import { Cake, Download, MapPin, Pencil, Repeat, Rss, Trash2 } from 'lucide-reac
 import { prettyDate } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import { getMemberColor } from '../../lib/member-colors';
+import { getCalendarEventIcon } from '../../lib/calendar-icons';
 import AssignedBadges from '../AssignedBadges';
 
 export const RECURRENCE_OPTIONS = [
@@ -111,12 +112,14 @@ export function EventCard({ ev, index, messages, lang, timeFormat, onDelete, onE
   const editable = !!onEdit && !ev._isBirthday && !isImported;
   const cardClickable = editable;
   const mapsLinks = mapsLinksForLocation(ev.location);
+  const eventIcon = !ev._isBirthday ? getCalendarEventIcon(ev.icon) : null;
 
   return (
     <div className="day-event-card" style={{ borderColor: ev.color || getMemberColor(null, index), cursor: cardClickable ? 'pointer' : undefined }} onClick={() => cardClickable && onEdit(ev)}>
       <div style={{ flex: 1 }}>
         <div className="event-card-title">
           {ev._isBirthday && <Cake size={14} style={{ color: '#f43f5e', flexShrink: 0 }} aria-hidden="true" />}
+          {eventIcon && <span className="event-card-icon" aria-label={eventIcon.label}>{eventIcon.emoji}</span>}
           {ev.title}
           {ev.is_recurring && <Repeat size={13} style={{ color: 'var(--text-muted)', flexShrink: 0 }} aria-hidden="true" />}
           {isImported && (

--- a/frontend/components/calendar/DayDetailPanel.js
+++ b/frontend/components/calendar/DayDetailPanel.js
@@ -2,6 +2,7 @@ import { Plus } from 'lucide-react';
 import { t } from '../../lib/i18n';
 import { RECURRENCE_OPTIONS, AssignChips, EventCard } from './CalendarHelpers';
 import { COLOR_PALETTE } from '../../lib/member-colors';
+import { CALENDAR_EVENT_ICON_OPTIONS } from '../../lib/calendar-icons';
 
 export default function DayDetailPanel({ cal, locale, messages, lang, timeFormat, events, members, isChild, demoMode, setActiveView, isMobile }) {
   if (!cal.selectedDate) return null;
@@ -85,6 +86,15 @@ export default function DayDetailPanel({ cal, locale, messages, lang, timeFormat
               ))}
             </div>
           </div>
+          <div>
+            <label className="cal-form-label" htmlFor="calendar-edit-icon">{t(messages, 'module.calendar.icon')}</label>
+            <select id="calendar-edit-icon" className="form-input" value={cal.editIcon} onChange={e => cal.setEditIcon(e.target.value)}>
+              <option value="">{t(messages, 'module.calendar.icon_none')}</option>
+              {CALENDAR_EVENT_ICON_OPTIONS.map(option => (
+                <option key={option.key} value={option.key}>{option.emoji} {option.label}</option>
+              ))}
+            </select>
+          </div>
           <input className="form-input" value={cal.editDescription} onChange={e => cal.setEditDescription(e.target.value)} placeholder={t(messages, 'module.calendar.description')} />
           <div className="cal-form-actions">
             <button className="btn-sm" type="submit">{t(messages, 'save')}</button>
@@ -131,6 +141,15 @@ export default function DayDetailPanel({ cal, locale, messages, lang, timeFormat
                     aria-label={c} />
                 ))}
               </div>
+            </div>
+            <div>
+              <label className="cal-form-label" htmlFor="calendar-create-icon">{t(messages, 'module.calendar.icon')}</label>
+              <select id="calendar-create-icon" className="form-input" value={cal.icon} onChange={e => cal.setIcon(e.target.value)}>
+                <option value="">{t(messages, 'module.calendar.icon_none')}</option>
+                {CALENDAR_EVENT_ICON_OPTIONS.map(option => (
+                  <option key={option.key} value={option.key}>{option.emoji} {option.label}</option>
+                ))}
+              </select>
             </div>
             <button className="btn-sm" type="submit"><Plus size={14} /> {t(messages, 'create_event')}</button>
           </form>

--- a/frontend/components/calendar/index.js
+++ b/frontend/components/calendar/index.js
@@ -4,6 +4,7 @@ import { useCalendar } from '../../hooks/useCalendar';
 import { t } from '../../lib/i18n';
 import { DeleteRecurringDialog, EventCard } from './CalendarHelpers';
 import { getMemberColor } from '../../lib/member-colors';
+import { getCalendarEventIcon } from '../../lib/calendar-icons';
 import DayDetailPanel from './DayDetailPanel';
 
 export default function CalendarView() {
@@ -14,10 +15,17 @@ export default function CalendarView() {
 
   const today = new Date();
   const formatCountLabel = (count, singular, plural) => `${count} ${count === 1 ? singular : plural}`;
-  const buildDayContentLabel = (birthdayCount, eventCount) => {
+  const buildDayContentLabel = (birthdayCount, regularEvents) => {
+    const eventCount = regularEvents.length;
+    const iconLabels = regularEvents
+      .map((ev) => getCalendarEventIcon(ev.icon)?.label)
+      .filter(Boolean);
     const parts = [];
     if (birthdayCount > 0) parts.push(formatCountLabel(birthdayCount, 'birthday', 'birthdays'));
-    if (eventCount > 0) parts.push(formatCountLabel(eventCount, 'event', 'events'));
+    if (eventCount > 0) {
+      const eventLabel = formatCountLabel(eventCount, 'event', 'events');
+      parts.push(iconLabels.length > 0 ? `${eventLabel}: ${iconLabels.join(', ')}` : eventLabel);
+    }
     return parts.join(', ');
   };
   const isToday = (day) => {
@@ -133,7 +141,7 @@ export default function CalendarView() {
                 const regularEvents = (c.events || []).filter((ev) => !ev._isBirthday);
                 const birthdayCount = birthdayEvents.length;
                 const regularEventCount = regularEvents.length;
-                const dayContentLabel = buildDayContentLabel(birthdayCount, regularEventCount);
+                const dayContentLabel = buildDayContentLabel(birthdayCount, regularEvents);
                 const dayLabel = dayDate
                   ? dayDate.toLocaleDateString(locale, { day: 'numeric', month: 'long' }) + (dayContentLabel ? `, ${dayContentLabel}` : '')
                   : undefined;
@@ -167,9 +175,20 @@ export default function CalendarView() {
                                 <Cake size={11} strokeWidth={2.4} aria-hidden="true" />
                               </div>
                             )}
-                            {regularEvents.slice(0, birthdayCount > 0 ? 2 : 3).map((ev, di) => (
-                              <div key={ev.id || di} className="calendar-day-dot" style={{ background: ev.color || getMemberColor(null, di) }} />
-                            ))}
+                            {regularEvents.slice(0, birthdayCount > 0 ? 2 : 3).map((ev, di) => {
+                              const eventIcon = getCalendarEventIcon(ev.icon);
+                              return eventIcon ? (
+                                <div
+                                  key={ev.id || di}
+                                  className="calendar-day-icon-indicator"
+                                  title={eventIcon.label}
+                                >
+                                  {eventIcon.emoji}
+                                </div>
+                              ) : (
+                                <div key={ev.id || di} className="calendar-day-dot" style={{ background: ev.color || getMemberColor(null, di) }} />
+                              );
+                            })}
                           </div>
                         )}
                       </>

--- a/frontend/e2e/tests/calendar.spec.js
+++ b/frontend/e2e/tests/calendar.spec.js
@@ -13,7 +13,7 @@ test.describe('Calendar', () => {
     await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
 
     // Click on day 15
-    await page.locator('.calendar-day:not(.other-month)', { hasText: /^15$/ }).first().click();
+    await page.getByRole('button', { name: /^[A-Za-z]+ 15(?:,|$)/ }).click();
 
     // Fill event title and location in the form that appears
     const form = page.locator('.day-detail-panel .quick-add-form');
@@ -21,12 +21,15 @@ test.describe('Calendar', () => {
     await titleInput.waitFor({ timeout: 5000 });
     await titleInput.fill('E2E Test Event');
     await form.locator('input[placeholder="Location or address"]').fill('Sports Park, Field 2');
+    await form.locator('#calendar-create-icon').selectOption('soccer');
 
     // Submit
     await form.locator('button[type="submit"]').click();
 
     // Event should appear with location and provider-neutral map links
     await expect(page.getByText('E2E Test Event')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.calendar-day-icon-indicator', { hasText: '⚽' })).toBeVisible();
+    await expect(page.locator('.event-card-icon').filter({ hasText: '⚽' })).toBeVisible();
     await expect(page.getByText('Sports Park, Field 2')).toBeVisible();
     await expect(page.getByRole('link', { name: 'Open in Google Maps' })).toHaveAttribute(
       'href',
@@ -43,7 +46,7 @@ test.describe('Calendar', () => {
     await navigateTo(page, 'Calendar');
     await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
 
-    await page.locator('.calendar-day:not(.other-month)', { hasText: /^15$/ }).first().click();
+    await page.getByRole('button', { name: /^[A-Za-z]+ 15(?:,|$)/ }).click();
 
     const form = page.locator('.day-detail-panel .quick-add-form');
     await expect(form).toBeVisible({ timeout: 5000 });
@@ -81,7 +84,7 @@ test.describe('Calendar', () => {
     await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
 
     // Click on day 20
-    await page.locator('.calendar-day:not(.other-month)', { hasText: /^20$/ }).first().click();
+    await page.getByRole('button', { name: /^[A-Za-z]+ 20(?:,|$)/ }).click();
 
     // Wait for event to appear
     await expect(page.getByText('Delete Me')).toBeVisible({ timeout: 10000 });

--- a/frontend/hooks/useCalendar.js
+++ b/frontend/hooks/useCalendar.js
@@ -42,6 +42,7 @@ export function useCalendar() {
   // Color and category
   const [color, setColor] = useState('');
   const [category, setCategory] = useState('');
+  const [icon, setIcon] = useState('');
 
   // Edit state
   const [editingEvent, setEditingEvent] = useState(null);
@@ -56,6 +57,7 @@ export function useCalendar() {
   const [editAssignedTo, setEditAssignedTo] = useState([]);
   const [editColor, setEditColor] = useState('');
   const [editCategory, setEditCategory] = useState('');
+  const [editIcon, setEditIcon] = useState('');
 
   // Delete confirmation for recurring events
   const [deleteConfirm, setDeleteConfirm] = useState(null);
@@ -230,6 +232,7 @@ export function useCalendar() {
       assigned_to: assignedPayload,
       color: color || null,
       category: category || null,
+      icon: icon || null,
     };
     if (demoMode) {
       const newEvent = { id: Date.now(), ...payload, is_recurring: !!recurrence, occurrence_date: null };
@@ -247,7 +250,7 @@ export function useCalendar() {
       await Promise.all([loadEventsForRange(), loadDashboard()]);
     }
     setTitle(''); setDescription(''); setLocation(''); setStartsAt(''); setEndsAt(''); setAllDay(false);
-    setRecurrence(''); setRecurrenceEnd(''); setAssignedTo([]); setColor(''); setCategory('');
+    setRecurrence(''); setRecurrenceEnd(''); setAssignedTo([]); setColor(''); setCategory(''); setIcon('');
     const msg = t(messages, 'toast.event_created');
     toastSuccess(msg);
     announce(msg);
@@ -274,6 +277,7 @@ export function useCalendar() {
     else setEditAssignedTo([]);
     setEditColor(ev.color || '');
     setEditCategory(ev.category || '');
+    setEditIcon(ev.icon || '');
   }
 
   function cancelEdit() {
@@ -302,6 +306,7 @@ export function useCalendar() {
       recurrence_end: editRecurrence ? toIsoOrNull(editRecurrenceEnd) : null,
       assigned_to: assignedPayload,
       color: editColor || null,
+      icon: editIcon || null,
     };
     if (demoMode) {
       setEvents(prev => prev.map(ev => ev.id === eventId ? { ...ev, ...payload } : ev));
@@ -395,6 +400,7 @@ export function useCalendar() {
     assignedTo, setAssignedTo,
     color, setColor,
     category, setCategory,
+    icon, setIcon,
     deleteConfirm, setDeleteConfirm,
     birthdayName, setBirthdayName,
     birthdayMonth, setBirthdayMonth,
@@ -412,6 +418,7 @@ export function useCalendar() {
     editAssignedTo, setEditAssignedTo,
     editColor, setEditColor,
     editCategory, setEditCategory,
+    editIcon, setEditIcon,
   };
 }
 

--- a/frontend/i18n/modules/calendar/de.json
+++ b/frontend/i18n/modules/calendar/de.json
@@ -51,6 +51,8 @@
   "module.calendar.color": "Terminfarbe",
   "module.calendar.color_none": "Keine Farbe",
   "module.calendar.category": "Kategorie",
+  "module.calendar.icon": "Terminsymbol",
+  "module.calendar.icon_none": "Kein Symbol",
   "module.calendar.edit_event": "Termin bearbeiten",
   "module.calendar.description": "Beschreibung",
   "module.calendar.location": "Ort oder Adresse",

--- a/frontend/i18n/modules/calendar/en.json
+++ b/frontend/i18n/modules/calendar/en.json
@@ -51,6 +51,8 @@
   "module.calendar.color": "Event color",
   "module.calendar.color_none": "No color",
   "module.calendar.category": "Category",
+  "module.calendar.icon": "Event icon",
+  "module.calendar.icon_none": "No icon",
   "module.calendar.edit_event": "Edit event",
   "module.calendar.description": "Description",
   "module.calendar.location": "Location or address",

--- a/frontend/lib/calendar-icons.js
+++ b/frontend/lib/calendar-icons.js
@@ -1,0 +1,29 @@
+export const CALENDAR_EVENT_ICON_OPTIONS = [
+  { key: 'handball', label: 'Handball training', emoji: '🤾' },
+  { key: 'gymnastics', label: 'Gymnastics', emoji: '🤸' },
+  { key: 'soccer', label: 'Soccer training', emoji: '⚽' },
+  { key: 'dentist', label: 'Dentist', emoji: '🦷' },
+  { key: 'doctor', label: 'Doctor', emoji: '🩺' },
+  { key: 'school', label: 'School', emoji: '🎒' },
+  { key: 'daycare', label: 'Kindergarten / daycare', emoji: '🧸' },
+  { key: 'swimming', label: 'Swimming', emoji: '🏊' },
+  { key: 'music', label: 'Music lesson', emoji: '🎵' },
+  { key: 'birthday', label: 'Birthday', emoji: '🎂' },
+  { key: 'shopping', label: 'Shopping / errands', emoji: '🛒' },
+  { key: 'meal', label: 'Meal / restaurant', emoji: '🍽️' },
+  { key: 'playdate', label: 'Playdate', emoji: '🧩' },
+  { key: 'pickup', label: 'Pickup / drop-off', emoji: '🚗' },
+  { key: 'vacation', label: 'Vacation / holiday', emoji: '🏖️' },
+  { key: 'household', label: 'Household / chores', emoji: '🏠' },
+  { key: 'homework', label: 'Homework / learning', emoji: '📚' },
+  { key: 'pet', label: 'Pet / vet', emoji: '🐾' },
+  { key: 'family_visit', label: 'Family visit', emoji: '👨‍👩‍👧‍👦' },
+  { key: 'appointment', label: 'Appointment', emoji: '📌' },
+];
+
+const ICON_BY_KEY = new Map(CALENDAR_EVENT_ICON_OPTIONS.map((option) => [option.key, option]));
+
+export function getCalendarEventIcon(key) {
+  if (!key) return null;
+  return ICON_BY_KEY.get(key) || null;
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1029,6 +1029,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .calendar-day-num { font-size: 0.88rem; font-weight: 500; font-family: 'JetBrains Mono', monospace; }
 .calendar-day-dots { display: flex; align-items: center; gap: 3px; min-height: 11px; }
 .calendar-day-dot { width: 5px; height: 5px; border-radius: 50%; }
+.calendar-day-icon-indicator { width: 14px; height: 14px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; font-size: 10px; line-height: 1; background: var(--bg-muted); flex: 0 0 auto; }
 .calendar-day-birthday-indicator { width: 13px; height: 13px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; color: #f43f5e; background: color-mix(in srgb, #f43f5e 12%, transparent); flex: 0 0 auto; }
 .day-detail-panel { padding: var(--space-lg); background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); align-self: start; }
 .day-detail-date { font-size: 1.1rem; font-weight: 600; margin-bottom: var(--space-xs); }
@@ -1072,6 +1073,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .assigned-badge { width: 20px; height: 20px; border-radius: 50%; font-size: 0.6rem; font-weight: 600; display: inline-flex; align-items: center; justify-content: center; color: #fff; }
 
 .event-card-title { font-weight: 500; font-size: 0.9rem; display: flex; align-items: center; gap: 6px; }
+.event-card-icon { flex-shrink: 0; line-height: 1; }
 .event-card-meta { font-size: 0.78rem; color: var(--text-muted); margin-top: 2px; }
 .event-card-location { font-size: 0.78rem; color: var(--text-secondary); margin-top: 4px; display: flex; align-items: center; gap: 5px; flex-wrap: wrap; }
 .event-card-map-links { display: inline-flex; gap: 8px; margin-left: 2px; }


### PR DESCRIPTION
## Summary
- Add an allowlisted calendar event icon field to the backend, API schemas, migrations, and display-safe payloads.
- Add the calendar icon picker for create/edit flows and render selected icons in month cells and event cards while preserving birthday indicators and dot fallback.
- Cover create/update/clear/invalid icon handling, frontend payloads, calendar rendering, and the calendar browser flow.

## Test plan
- `DATABASE_URL=sqlite:///./test-calendar-locations.db JWT_SECRET=test-secret PYTHONPATH=. pytest tests/test_calendar_locations.py -q`
- `npm test -- --runTestsByPath __tests__/hooks/useCalendar.test.js __tests__/components/CalendarViewBirthdayIndicators.test.js --runInBand`
- `npm run build`
- `npx playwright test e2e/tests/calendar.spec.js --list`
- `npx playwright test e2e/tests/calendar.spec.js --reporter=list`

Closes #285
