### PR TITLE
ci: update actions for Node 24 runtime

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -52,11 +52,11 @@ jobs:
           echo "value=${version}" >> "$GITHUB_OUTPUT"
           echo "date=${build_date}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Extract version from tag
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.BACKEND_IMAGE }}
           tags: |
@@ -74,7 +74,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.release_tag.outputs.stable == 'true' || github.ref_name == github.event.repository.default_branch }}
             type=ref,event=branch
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./backend
           platforms: linux/amd64,linux/arm64
@@ -96,7 +96,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -127,11 +127,11 @@ jobs:
           echo "value=${version}" >> "$GITHUB_OUTPUT"
           echo "date=${build_date}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -139,7 +139,7 @@ jobs:
 
       - name: Extract version from tag
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.FRONTEND_IMAGE }}
           tags: |
@@ -149,7 +149,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.release_tag.outputs.stable == 'true' || github.ref_name == github.event.repository.default_branch }}
             type=ref,event=branch
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./frontend
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Start services
         working-directory: docker
@@ -56,7 +56,7 @@ jobs:
             sleep 2
           done
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -77,7 +77,7 @@ jobs:
           BASE_URL: http://localhost:3000
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report
@@ -85,7 +85,7 @@ jobs:
           retention-days: 7
 
       - name: Upload traces on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-traces


### PR DESCRIPTION
## Summary

- Updates GitHub-hosted Actions in Docker and E2E workflows to current Node 24-compatible major versions.
- Keeps Docker image names, tag rules, multi-arch platforms, cache scopes, build args, and release/latest behavior unchanged.
- Keeps E2E behavior unchanged while updating checkout, setup-node, and artifact upload actions.

## Action version changes

- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`
- `actions/upload-artifact@v4` -> `actions/upload-artifact@v7`
- `docker/setup-qemu-action@v3` -> `docker/setup-qemu-action@v4`
- `docker/setup-buildx-action@v3` -> `docker/setup-buildx-action@v4`
- `docker/login-action@v3` -> `docker/login-action@v4`
- `docker/metadata-action@v5` -> `docker/metadata-action@v6`
- `docker/build-push-action@v6` -> `docker/build-push-action@v7`

## Upstream references checked

- Latest releases were checked through the GitHub API before updating.
- Docker action v4/v6/v7 release notes identify the Node 24 runtime migration for the affected Docker actions.
- GitHub Actions releases show current major versions available for checkout, setup-node, and artifact upload.

## Verification

- `actionlint v1.7.12 .github/workflows/docker.yml .github/workflows/e2e.yml`
- Structural assertions confirm old Node 20-era action majors are no longer present in the touched workflows.
- `git diff --check`
- Independent config review found no security concerns or logic errors.

Closes #291
