### PR TITLE
feat: improve PWA mobile app shell

### DIFF
--- a/frontend/__tests__/components/AppShellMobileNav.test.js
+++ b/frontend/__tests__/components/AppShellMobileNav.test.js
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AppShell from '../../components/AppShell';
+import { DEFAULT_NAV_ORDER } from '../../contexts/UIContext';
+
+let mockAppState = {};
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+jest.mock('../../lib/announce', () => ({ announce: jest.fn() }));
+
+jest.mock('../../components/DashboardView', () => function MockDashboard() { return <div>Dashboard view</div>; });
+jest.mock('../../components/ActivityView', () => function MockActivity() { return <div>Activity view</div>; });
+jest.mock('../../components/calendar', () => function MockCalendar() { return <div>Calendar view</div>; });
+jest.mock('../../components/ContactsView', () => function MockContacts() { return <div>Contacts view</div>; });
+jest.mock('../../components/TasksView', () => function MockTasks() { return <div>Tasks view</div>; });
+jest.mock('../../components/TemplatesView', () => function MockTemplates() { return <div>Templates view</div>; });
+jest.mock('../../components/RewardsView', () => function MockRewards() { return <div>Rewards view</div>; });
+jest.mock('../../components/GiftsView', () => function MockGifts() { return <div>Gifts view</div>; });
+jest.mock('../../components/MealPlansView', () => function MockMealPlans() { return <div>Meal plans view</div>; });
+jest.mock('../../components/RecipesView', () => function MockRecipes() { return <div>Recipes view</div>; });
+jest.mock('../../components/ShoppingView', () => function MockShopping() { return <div>Shopping view</div>; });
+jest.mock('../../components/settings', () => function MockSettings() { return <div>Settings view</div>; });
+jest.mock('../../components/admin', () => function MockAdmin() { return <div>Admin view</div>; });
+jest.mock('../../components/WeeklyPlanView', () => function MockWeeklyPlan() { return <div>Weekly plan view</div>; });
+jest.mock('../../components/NotificationCenter', () => function MockNotifications() { return <div>Notifications view</div>; });
+jest.mock('../../components/ForcePasswordChange', () => function MockForcePasswordChange() { return <div>Force password change</div>; });
+jest.mock('../../components/OnboardingWizard', () => function MockOnboarding() { return <div>Onboarding</div>; });
+jest.mock('../../components/MemberAvatar', () => function MockMemberAvatar() { return <div data-testid="member-avatar" />; });
+jest.mock('../../components/SearchOverlay', () => function MockSearchOverlay() { return null; });
+
+const messages = {
+  dashboard: 'Dashboard',
+  calendar: 'Calendar',
+  activity: 'Activity',
+  contacts: 'Contacts',
+  notifications: 'Notifications',
+  settings: 'Settings',
+  admin: 'Admin',
+  nav_more: 'More',
+  member: 'Member',
+  child: 'Child',
+  'aria.open_menu': 'Open menu',
+  'aria.logout': 'Logout',
+  'aria.bottom_navigation': 'Bottom navigation',
+  'aria.main_navigation': 'Main navigation',
+  'aria.expand_sidebar': 'Expand sidebar',
+  'aria.collapse_sidebar': 'Collapse sidebar',
+  'module.shopping.name': 'Shopping',
+  'module.tasks.name': 'Tasks',
+  'module.templates.name': 'Templates',
+  'module.meal_plans.name': 'Meals',
+  'module.recipes.name': 'Recipes',
+  'module.rewards.name': 'Rewards',
+  'module.gifts.name': 'Gifts',
+  'module.weekly_plan.name': 'Weekly',
+  'search.title': 'Search',
+  'search.placeholder': 'Search Tribu',
+};
+
+function baseState(overrides = {}) {
+  return {
+    activeView: 'dashboard',
+    setActiveView: jest.fn(),
+    isMobile: true,
+    isAdmin: true,
+    isChild: false,
+    messages,
+    me: { user_id: 1, display_name: 'Dennis', has_completed_onboarding: true },
+    members: [{ user_id: 1, display_name: 'Dennis' }],
+    families: [{ family_id: 1, family_name: 'Family' }],
+    familyId: 1,
+    tasks: [{ status: 'open' }, { status: 'done' }],
+    shoppingLists: [{ item_count: 3, checked_count: 1 }],
+    unreadCount: 7,
+    logout: jest.fn(),
+    demoMode: false,
+    loading: false,
+    navOrder: DEFAULT_NAV_ORDER,
+    profileImage: null,
+    ...overrides,
+  };
+}
+
+describe('AppShell mobile bottom navigation', () => {
+  it('keeps high-priority mobile items visible and pins settings/admin in overflow', async () => {
+    mockAppState = baseState();
+    render(<AppShell />);
+
+    const bottomNav = screen.getByRole('navigation', { name: 'Bottom navigation' });
+    expect(bottomNav).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /dashboard/i })).toHaveAttribute('aria-current', 'page');
+    const tasksItem = bottomNav.querySelector('.bottom-nav-item:nth-child(4)');
+    const shoppingItem = bottomNav.querySelector('.bottom-nav-item:nth-child(3)');
+    expect(tasksItem).toHaveTextContent('Tasks');
+    expect(tasksItem).toHaveTextContent('1');
+    expect(shoppingItem).toHaveTextContent('Shopping');
+    expect(shoppingItem).toHaveTextContent('2');
+
+    const visibleBottomItems = bottomNav.querySelectorAll('.bottom-nav-inner > .bottom-nav-item');
+    expect(visibleBottomItems).toHaveLength(5);
+
+    fireEvent.click(screen.getByRole('button', { name: /more/i }));
+    expect(screen.getAllByRole('button', { name: /^settings$/i })
+      .some((button) => button.classList.contains('bottom-nav-overflow-item'))).toBe(true);
+    expect(screen.getAllByRole('button', { name: /^admin$/i })
+      .some((button) => button.classList.contains('bottom-nav-overflow-item'))).toBe(true);
+  });
+
+  it('exposes active overflow destinations as the current page and closes after navigation', async () => {
+    const setActiveView = jest.fn();
+    mockAppState = baseState({ activeView: 'settings', setActiveView });
+    render(<AppShell />);
+
+    fireEvent.click(screen.getByRole('button', { name: /more/i }));
+    const settingsItem = screen.getAllByRole('button', { name: /^settings$/i })
+      .find((button) => button.classList.contains('bottom-nav-overflow-item'));
+    expect(settingsItem).toHaveAttribute('aria-current', 'page');
+
+    const adminItem = screen.getAllByRole('button', { name: /^admin$/i })
+      .find((button) => button.classList.contains('bottom-nav-overflow-item'));
+    fireEvent.click(adminItem);
+    expect(setActiveView).toHaveBeenCalledWith('admin');
+    expect(document.querySelector('.bottom-nav-overflow')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/PWABanners.test.js
+++ b/frontend/__tests__/components/PWABanners.test.js
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PWABanners } from '../../components/PWABanners';
+
+let pwaState = {};
+
+jest.mock('../../hooks/usePWA', () => ({
+  usePWA: () => pwaState,
+}));
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => ({
+    messages: {
+      'pwa.offline': 'You are offline',
+      'pwa.back_online': 'Back online',
+      'pwa.update_available': 'New version available',
+      'pwa.update_action': 'Update now',
+      'pwa.install_prompt': 'Install Tribu on this device',
+      'pwa.install_action': 'Install',
+      'pwa.install_dismiss': 'Dismiss install prompt',
+    },
+  }),
+}));
+
+function renderWithPwa(overrides) {
+  pwaState = {
+    isOffline: false,
+    showBackOnline: false,
+    updateAvailable: false,
+    installPrompt: null,
+    isInstalled: false,
+    triggerInstall: jest.fn(),
+    dismissInstall: jest.fn(),
+    applyUpdate: jest.fn(),
+    ...overrides,
+  };
+  render(<PWABanners />);
+  return pwaState;
+}
+
+describe('PWABanners', () => {
+  it('announces offline and back-online state without install/update actions', () => {
+    renderWithPwa({ isOffline: true });
+    expect(screen.getByRole('alert')).toHaveTextContent('You are offline');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    renderWithPwa({ showBackOnline: true });
+    expect(screen.getByRole('status')).toHaveTextContent('Back online');
+  });
+
+  it('lets users apply a waiting service-worker update', async () => {
+    const state = renderWithPwa({ updateAvailable: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Update now' }));
+    expect(state.applyUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the captured install prompt only when the app is not installed', async () => {
+    const state = renderWithPwa({ installPrompt: { prompt: jest.fn() } });
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }));
+    expect(state.triggerInstall).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss install prompt' }));
+    expect(state.dismissInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/__tests__/lib/navigationState.test.js
+++ b/frontend/__tests__/lib/navigationState.test.js
@@ -1,0 +1,40 @@
+import { resolveInitialView } from '../../lib/navigationState';
+import { DEFAULT_NAV_ORDER } from '../../contexts/UIContext';
+
+describe('resolveInitialView', () => {
+  it('prioritizes bookmarkable hash routes over PWA shortcut query strings and stored view', () => {
+    expect(resolveInitialView({
+      hash: '#calendar',
+      search: '?view=tasks',
+      storedView: 'shopping',
+      validViews: DEFAULT_NAV_ORDER,
+    })).toBe('calendar');
+  });
+
+  it('supports manifest shortcut query URLs before falling back to session state', () => {
+    expect(resolveInitialView({
+      hash: '',
+      search: '?view=shopping',
+      storedView: 'dashboard',
+      validViews: DEFAULT_NAV_ORDER,
+    })).toBe('shopping');
+  });
+
+  it('ignores non-shortcut query views while still allowing stored navigation state', () => {
+    expect(resolveInitialView({
+      hash: '',
+      search: '?view=admin',
+      storedView: 'settings',
+      validViews: DEFAULT_NAV_ORDER,
+    })).toBe('settings');
+  });
+
+  it('ignores unknown views from URLs and storage', () => {
+    expect(resolveInitialView({
+      hash: '#unknown',
+      search: '?view=admin<script>',
+      storedView: 'bad-view',
+      validViews: DEFAULT_NAV_ORDER,
+    })).toBeNull();
+  });
+});

--- a/frontend/__tests__/public-manifest.test.js
+++ b/frontend/__tests__/public-manifest.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadManifest() {
+  const manifestPath = path.join(__dirname, '../public/manifest.json');
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+}
+
+describe('PWA manifest', () => {
+  it('declares a stable install identity and standalone app shell', () => {
+    const manifest = loadManifest();
+
+    expect(manifest).toEqual(expect.objectContaining({
+      name: expect.any(String),
+      short_name: expect.any(String),
+      description: expect.any(String),
+      start_url: '/',
+      id: '/',
+      scope: '/',
+      display: 'standalone',
+      theme_color: expect.stringMatching(/^#[0-9a-f]{6}$/i),
+      background_color: expect.stringMatching(/^#[0-9a-f]{6}$/i),
+    }));
+  });
+
+  it('offers app shortcuts for the daily mobile workflows', () => {
+    const manifest = loadManifest();
+
+    expect(manifest.shortcuts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'Dashboard', url: '/?view=dashboard' }),
+      expect.objectContaining({ name: 'Calendar', url: '/?view=calendar' }),
+      expect.objectContaining({ name: 'Tasks', url: '/?view=tasks' }),
+      expect.objectContaining({ name: 'Shopping', url: '/?view=shopping' }),
+    ]));
+
+    for (const shortcut of manifest.shortcuts) {
+      expect(shortcut.short_name).toEqual(expect.any(String));
+      expect(shortcut.description).toEqual(expect.any(String));
+      expect(shortcut.icons).toEqual(expect.arrayContaining([
+        expect.objectContaining({ src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' }),
+      ]));
+    }
+  });
+
+  it('ships regular and maskable install icons with files present', () => {
+    const manifest = loadManifest();
+    expect(manifest.icons.some((icon) => icon.sizes === '192x192' && icon.purpose === 'any')).toBe(true);
+    expect(manifest.icons.some((icon) => icon.sizes === '512x512' && icon.purpose === 'any')).toBe(true);
+    expect(manifest.icons.some((icon) => icon.sizes === '192x192' && icon.purpose === 'maskable')).toBe(true);
+    expect(manifest.icons.some((icon) => icon.sizes === '512x512' && icon.purpose === 'maskable')).toBe(true);
+
+    for (const icon of manifest.icons) {
+      expect(icon.type).toBe('image/png');
+      expect(fs.existsSync(path.join(__dirname, '../public', icon.src))).toBe(true);
+    }
+  });
+});

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -345,6 +345,7 @@ export default function AppShell() {
                   key={item.key}
                   className={`bottom-nav-overflow-item${activeView === item.key ? ' active' : ''}`}
                   onClick={() => navigate(item.key)}
+                  aria-current={activeView === item.key ? 'page' : undefined}
                 >
                   <item.icon size={20} aria-hidden="true" />
                   <span>{item.mobileLabel || item.label}</span>

--- a/frontend/components/PWABanners.js
+++ b/frontend/components/PWABanners.js
@@ -40,7 +40,7 @@ export function PWABanners() {
           <button className="pwa-banner__action" onClick={pwa.triggerInstall}>
             {t(messages, 'pwa.install_action')}
           </button>
-          <button className="pwa-banner__dismiss" onClick={pwa.dismissInstall} aria-label="Dismiss">
+          <button className="pwa-banner__dismiss" onClick={pwa.dismissInstall} aria-label={t(messages, 'pwa.install_dismiss')}>
             &times;
           </button>
         </div>

--- a/frontend/contexts/AppContext.js
+++ b/frontend/contexts/AppContext.js
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect } from 'react';
 import * as api from '../lib/api';
 import { buildDemoData } from '../lib/demo-data';
+import { resolveInitialView } from '../lib/navigationState';
 import { AuthProvider, useAuth } from './AuthContext';
 import { FamilyProvider, useFamily } from './FamilyContext';
 import { DataProvider, useData } from './DataContext';
@@ -162,12 +163,14 @@ function AppOrchestrator({ children }) {
       setLang(match || 'en');
     }
     setProfileImage('');
-    // Hash takes priority (bookmarkable URLs), then sessionStorage
+    // Hash takes priority (bookmarkable URLs), then PWA shortcut query URLs, then sessionStorage.
     const VALID_VIEWS = new Set(DEFAULT_NAV_ORDER);
-    const rawHash = window.location.hash?.slice(1);
-    const hashView = rawHash && VALID_VIEWS.has(rawHash) ? rawHash : null;
-    const storedView = sessionStorage.getItem('tribu_view');
-    const savedView = hashView ?? (storedView && VALID_VIEWS.has(storedView) ? storedView : null);
+    const savedView = resolveInitialView({
+      hash: window.location.hash,
+      search: window.location.search,
+      storedView: sessionStorage.getItem('tribu_view'),
+      validViews: VALID_VIEWS,
+    });
     if (savedView) restoreView(savedView);
 
     // Listen for browser back/forward

--- a/frontend/e2e/tests/pwa-mobile.spec.js
+++ b/frontend/e2e/tests/pwa-mobile.spec.js
@@ -1,0 +1,81 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({
+  serviceWorkers: 'block',
+  viewport: { width: 390, height: 844 },
+});
+
+function json(route, data) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(data),
+  });
+}
+
+async function mockAuthenticatedFamily(page) {
+  await page.route(/\/api\//, async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname.replace(/^\/api/, '');
+
+    if (path === '/auth/me') {
+      return json(route, {
+        id: 1,
+        email: 'tester@example.com',
+        display_name: 'Tester',
+        profile_image: '',
+        has_completed_onboarding: true,
+        must_change_password: false,
+      });
+    }
+    if (path === '/families/me') {
+      return json(route, [{ family_id: 7, family_name: 'Test Family', role: 'admin', is_adult: true }]);
+    }
+    if (path === '/dashboard/summary') return json(route, { next_events: [], upcoming_birthdays: [] });
+    if (path === '/calendar/events') return json(route, { items: [] });
+    if (path === '/families/7/members') return json(route, []);
+    if (path === '/contacts') return json(route, []);
+    if (path === '/birthdays') return json(route, []);
+    if (path === '/tasks') return json(route, { items: [] });
+    if (path === '/shopping/lists') return json(route, []);
+    if (path === '/shopping/templates') return json(route, []);
+    if (path === '/activity') return json(route, { items: [] });
+    if (path === '/quick-capture') return json(route, { items: [] });
+    if (path === '/nav/order') return json(route, { nav_order: ['dashboard', 'calendar', 'shopping', 'tasks', 'activity', 'settings', 'admin'] });
+    if (path === '/admin/settings/time-format') return json(route, { time_format: '24h' });
+    if (path === '/notifications/unread-count') return json(route, { count: 0 });
+    if (path === '/notifications') return json(route, []);
+    if (path === '/notifications/stream') {
+      return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' });
+    }
+    return json(route, {});
+  });
+}
+
+test.describe('PWA mobile app shell', () => {
+  test('manifest shortcut query opens the requested mobile destination', async ({ page }) => {
+    await mockAuthenticatedFamily(page);
+
+    await page.goto('/?view=shopping', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByRole('heading', { name: 'Shopping' })).toBeVisible({ timeout: 10000 });
+    const bottomNav = page.getByRole('navigation', { name: 'Bottom navigation' });
+    await expect(bottomNav).toBeVisible();
+    await expect(bottomNav.getByRole('button', { name: /Shopping/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('manifest exposes install identity and daily shortcuts', async ({ request }) => {
+    const response = await request.get('/manifest.json');
+    expect(response.ok()).toBe(true);
+
+    const manifest = await response.json();
+    expect(manifest.id).toBe('/');
+    expect(manifest.scope).toBe('/');
+    expect(manifest.shortcuts.map((shortcut) => shortcut.url)).toEqual([
+      '/?view=dashboard',
+      '/?view=calendar',
+      '/?view=tasks',
+      '/?view=shopping',
+    ]);
+  });
+});

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -564,6 +564,7 @@
   "pwa.update_action": "Aktualisieren",
   "pwa.install_prompt": "Tribu installieren für schnellen Zugriff",
   "pwa.install_action": "Installieren",
+  "pwa.install_dismiss": "Installationshinweis ausblenden",
   "display_title": "Displays",
   "display_intro": "Verknüpfe gemeinsame Bildschirme (Küchen-Tablet, Flur-Bilderrahmen) mit einer schreibgeschützten Familienübersicht.",
   "display_not_a_person": "Ein Display ist ein Gerät, keine Person — es hat keine E-Mail, kein Passwort und taucht nicht in der Mitgliederliste auf.",

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -564,6 +564,7 @@
   "pwa.update_action": "Update",
   "pwa.install_prompt": "Install Tribu for quick access",
   "pwa.install_action": "Install",
+  "pwa.install_dismiss": "Dismiss install prompt",
   "display_title": "Displays",
   "display_intro": "Pair shared screens (kitchen tablet, hallway frame) with a read-only family dashboard.",
   "display_not_a_person": "A display is a device, not a person — it has no email, no password, and does not appear in your member list.",

--- a/frontend/lib/navigationState.js
+++ b/frontend/lib/navigationState.js
@@ -1,0 +1,26 @@
+const DEFAULT_SHORTCUT_VIEWS = ['dashboard', 'calendar', 'tasks', 'shopping'];
+
+export function resolveInitialView({
+  hash = '',
+  search = '',
+  storedView = null,
+  validViews = [],
+  shortcutViews = DEFAULT_SHORTCUT_VIEWS,
+} = {}) {
+  const valid = validViews instanceof Set ? validViews : new Set(validViews);
+  const shortcuts = shortcutViews instanceof Set ? shortcutViews : new Set(shortcutViews);
+  const normalize = (value) => (value && valid.has(value) ? value : null);
+
+  const hashView = normalize(hash?.startsWith('#') ? hash.slice(1) : hash);
+  if (hashView) return hashView;
+
+  try {
+    const params = new URLSearchParams(search || '');
+    const queryView = normalize(params.get('view'));
+    if (queryView && shortcuts.has(queryView)) return queryView;
+  } catch {
+    // Ignore malformed search strings and fall back to stored state.
+  }
+
+  return normalize(storedView);
+}

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,7 +2,9 @@
   "name": "Tribu",
   "short_name": "Tribu",
   "description": "Family Organizer",
+  "id": "/",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#06080f",
   "theme_color": "#7c3aed",
@@ -11,5 +13,35 @@
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
     { "src": "/icons/icon-maskable-192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
     { "src": "/icons/icon-maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ],
+  "shortcuts": [
+    {
+      "name": "Dashboard",
+      "short_name": "Today",
+      "description": "Open the family dashboard",
+      "url": "/?view=dashboard",
+      "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    },
+    {
+      "name": "Calendar",
+      "short_name": "Calendar",
+      "description": "Open events and birthdays",
+      "url": "/?view=calendar",
+      "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    },
+    {
+      "name": "Tasks",
+      "short_name": "Tasks",
+      "description": "Open household tasks",
+      "url": "/?view=tasks",
+      "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    },
+    {
+      "name": "Shopping",
+      "short_name": "Shopping",
+      "description": "Open shopping lists",
+      "url": "/?view=shopping",
+      "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #294.

This improves Tribu's existing PWA/mobile app-like experience as the first focused slice instead of starting a separate native Android app.

- Adds a stable PWA manifest identity with `id`, `scope`, and daily workflow shortcuts for Dashboard, Calendar, Tasks, and Shopping.
- Supports manifest shortcut URLs like `/?view=shopping` while keeping hash navigation as the strongest bookmarkable route and limiting query shortcuts to safe daily destinations.
- Improves mobile bottom-navigation accessibility by marking active overflow destinations with `aria-current="page"`.
- Localizes the PWA install-banner dismiss label for screen readers.
- Adds unit/component coverage for manifest fields, shortcut routing, mobile nav overflow, and PWA banners.
- Adds a Mobile Chrome Playwright spec for PWA shortcut entry and manifest shortcut exposure.

Wiki documentation was published separately in the GitHub Wiki:

- `a3812bf docs: add PWA installation guide`
- Adds `Install-Tribu-as-a-PWA.md`
- Links it from the Wiki home page.

## Test plan

- [x] `npm test -- --runInBand` in `frontend` — 51 suites, 312 tests passed
- [x] `npm run build` in `frontend`
- [x] `npx playwright test e2e/tests/pwa-mobile.spec.js --project='Mobile Chrome' --workers=1` — 2 passed
- [x] `npx playwright test --list` — 98 tests listed across Desktop and Mobile Chrome
- [x] JSON validation for manifest and i18n files
- [x] `git diff --cached --check`
- [x] static added-line scan for secret/injection patterns
- [x] independent code review of staged diff
- [x] Wiki internal-link check — 27 pages ok
- [x] Wiki red-flag scan

## Notes

The full Playwright matrix is expected to run in GitHub Actions before merge. The local browser gate covered the new PWA/mobile spec directly on Mobile Chrome.
