### PR TITLE
Fix timezone display for server timestamps

### DIFF
--- a/frontend/__tests__/components/BackupSection.test.js
+++ b/frontend/__tests__/components/BackupSection.test.js
@@ -20,10 +20,14 @@ jest.mock('../../components/ConfirmDialog', () => ({ onConfirm }) => (
   </div>
 ));
 
-jest.mock('../../lib/helpers', () => ({
-  downloadBlob: jest.fn(),
-  errorText: (_detail, fallback) => fallback,
-}));
+jest.mock('../../lib/helpers', () => {
+  const actual = jest.requireActual('../../lib/helpers');
+  return {
+    ...actual,
+    downloadBlob: jest.fn(),
+    errorText: (_detail, fallback) => fallback,
+  };
+});
 
 jest.mock('../../lib/api', () => ({
   apiGetBackupConfig: jest.fn(),

--- a/frontend/__tests__/lib/helpers.test.js
+++ b/frontend/__tests__/lib/helpers.test.js
@@ -1,4 +1,4 @@
-import { toIsoOrNull, prettyDate, errorText, copyTextToClipboard } from '../../lib/helpers';
+import { toIsoOrNull, prettyDate, parseDate, parseServerInstant, serverTimeAgo, errorText, copyTextToClipboard } from '../../lib/helpers';
 
 describe('toIsoOrNull', () => {
   it('returns null for falsy values', () => {
@@ -10,6 +10,33 @@ describe('toIsoOrNull', () => {
   it('returns ISO string for valid date', () => {
     const result = toIsoOrNull('2026-03-15T10:00');
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+describe('server timestamp helpers', () => {
+  it('treats UTC-naive API datetimes as UTC instants', () => {
+    expect(parseServerInstant('2026-04-30T14:35:00').toISOString()).toBe('2026-04-30T14:35:00.000Z');
+  });
+
+  it('preserves explicit timezone offsets from API datetimes', () => {
+    expect(parseServerInstant('2026-04-30T16:35:00+02:00').toISOString()).toBe('2026-04-30T14:35:00.000Z');
+  });
+
+  it('leaves local wall-clock datetimes to parseDate', () => {
+    const local = parseDate('2026-04-30T14:35:00');
+    expect(local.getHours()).toBe(14);
+    expect(local.getMinutes()).toBe(35);
+  });
+
+  it('does not treat date-only values as UTC-naive date-times', () => {
+    expect(parseServerInstant('2026-04-30').toISOString()).toBe('2026-04-30T00:00:00.000Z');
+  });
+
+  it('uses UTC-aware parsing for relative server timestamps', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-30T14:40:00Z'));
+    expect(serverTimeAgo('2026-04-30T14:35:00', 'en')).toBe('5m ago');
+    expect(serverTimeAgo('2026-04-30T14:35:00', 'de')).toBe('vor 5 Min.');
+    jest.useRealTimers();
   });
 });
 

--- a/frontend/components/HouseholdActivityFeed.js
+++ b/frontend/components/HouseholdActivityFeed.js
@@ -1,9 +1,9 @@
 import { Activity } from 'lucide-react';
 import { t } from '../lib/i18n';
-import { parseDate } from '../lib/helpers';
+import { parseServerInstant } from '../lib/helpers';
 
 function formatActivityTime(value, lang = 'en') {
-  const parsed = parseDate(value);
+  const parsed = parseServerInstant(value);
   if (!parsed || Number.isNaN(parsed.getTime())) return '';
   const locale = lang === 'de' ? 'de-DE' : 'en-US';
   return parsed.toLocaleString(locale, {

--- a/frontend/components/NotificationCenter.js
+++ b/frontend/components/NotificationCenter.js
@@ -3,7 +3,7 @@ import { Bell, CalendarDays, CheckSquare, Cake, Trash2, CheckCheck, X } from 'lu
 import { useApp } from '../contexts/AppContext';
 import { t } from '../lib/i18n';
 import * as api from '../lib/api';
-import { timeAgo } from '../lib/helpers';
+import { parseServerInstant, serverTimeAgo } from '../lib/helpers';
 
 const TYPE_ICONS = {
   event_reminder: CalendarDays,
@@ -70,7 +70,7 @@ export default function NotificationCenter({ onClose } = {}) {
     const older = [];
 
     notifications.forEach(n => {
-      const d = new Date(n.created_at);
+      const d = parseServerInstant(n.created_at);
       if (d >= todayStart) today.push(n);
       else if (d >= yesterdayStart) yesterday.push(n);
       else older.push(n);
@@ -145,7 +145,7 @@ export default function NotificationCenter({ onClose } = {}) {
                         {notif.title}
                       </div>
                       <span className="notif-time">
-                        {timeAgo(notif.created_at, lang)}
+                        {serverTimeAgo(notif.created_at, lang)}
                       </span>
                     </div>
                     {notif.body && (

--- a/frontend/components/RewardsView.js
+++ b/frontend/components/RewardsView.js
@@ -4,7 +4,7 @@ import { useApp } from '../contexts/AppContext';
 import { useRewards } from '../hooks/useRewards';
 import { CurrencyIcon } from '../lib/currency-icons';
 import { t } from '../lib/i18n';
-import { parseDate } from '../lib/helpers';
+import { parseServerInstant } from '../lib/helpers';
 import MemberAvatar from './MemberAvatar';
 import * as api from '../lib/api';
 
@@ -311,7 +311,7 @@ export default function RewardsView() {
           <button className="btn-ghost rewards-history-back" onClick={() => setTab('overview')}>&larr; {t(messages, 'module.rewards.tab_overview')}</button>
           {rw.transactions.map(tx => {
             const memberName = members.find(m => m.user_id === tx.user_id)?.display_name || '?';
-            const date = parseDate(tx.created_at).toLocaleDateString();
+            const date = parseServerInstant(tx.created_at).toLocaleDateString();
             return (
               <div key={tx.id} className="glass-sm rewards-row rewards-history-row">
                 {tx.kind === 'earn' ? <ArrowUpCircle size={14} style={{ color: 'var(--success)' }} /> : <ArrowDownCircle size={14} style={{ color: 'var(--danger)' }} />}

--- a/frontend/components/SetupWizard.js
+++ b/frontend/components/SetupWizard.js
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { Users, ShieldCheck, Upload, CheckCircle, Globe, AlertCircle, Play } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
-import { errorText } from '../lib/helpers';
+import { errorText, parseServerInstant } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import * as api from '../lib/api';
 
@@ -230,7 +230,7 @@ export default function SetupWizard() {
               <CheckCircle size={48} style={{ color: 'var(--success)', marginBottom: 12 }} />
               <h2 style={{ margin: '0 0 8px', fontSize: '1.2rem' }}>{t(messages, 'setup_restore_success')}</h2>
               <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: 16 }}>
-                {restoreMeta.created_at && t(messages, 'setup_restore_date').replace('{date}', new Date(restoreMeta.created_at).toLocaleDateString())}
+                {restoreMeta.created_at && t(messages, 'setup_restore_date').replace('{date}', parseServerInstant(restoreMeta.created_at)?.toLocaleDateString())}
               </p>
               <button className="btn-primary" style={{ width: '100%' }} onClick={finishRestore}>
                 {t(messages, 'setup_restore_login')}

--- a/frontend/components/admin/AuditLogSection.js
+++ b/frontend/components/admin/AuditLogSection.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useApp } from '../../contexts/AppContext';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
+import { parseServerInstant } from '../../lib/helpers';
 
 const ACTION_KEYS = {
   member_created: 'audit_action_member_created',
@@ -62,7 +63,7 @@ export default function AuditLogSection() {
         {entries.map((e) => (
           <div key={e.id} className="audit-entry">
             <span className="audit-time">
-              {new Date(e.created_at).toLocaleString()}
+              {parseServerInstant(e.created_at)?.toLocaleString()}
             </span>
             <span className="audit-action-badge">{formatAction(e)}</span>
             {e.target_display_name && (

--- a/frontend/components/admin/BackupSection.js
+++ b/frontend/components/admin/BackupSection.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
-import { downloadBlob, errorText } from '../../lib/helpers';
+import { downloadBlob, errorText, parseServerInstant } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 import ConfirmDialog from '../ConfirmDialog';
@@ -189,7 +189,7 @@ export default function BackupSection() {
               {status.latest_backup ? (
                 <>
                   <strong>{status.latest_backup.filename}</strong>
-                  <small>{new Date(status.latest_backup.created_at).toLocaleString()} · {formatBytes(status.latest_backup.size_bytes)}</small>
+                  <small>{parseServerInstant(status.latest_backup.created_at)?.toLocaleString()} · {formatBytes(status.latest_backup.size_bytes)}</small>
                 </>
               ) : (
                 <strong>{t(messages, 'backup_last_none')}</strong>
@@ -248,7 +248,7 @@ export default function BackupSection() {
           </div>
           {config?.last_backup && (
             <div className="adm-backup-last">
-              {t(messages, 'backup_last')}: {new Date(config.last_backup).toLocaleString()}
+              {t(messages, 'backup_last')}: {parseServerInstant(config.last_backup)?.toLocaleString()}
               {config.last_backup_status && ` (${config.last_backup_status})`}
             </div>
           )}
@@ -271,7 +271,7 @@ export default function BackupSection() {
             <div>
               <div className="adm-backup-filename">{b.filename}</div>
               <div className="adm-backup-meta">
-                {new Date(b.created_at).toLocaleString()} &middot; {formatBytes(b.size_bytes)}
+                {parseServerInstant(b.created_at)?.toLocaleString()} &middot; {formatBytes(b.size_bytes)}
                 {b.alembic_revision && ` · rev ${b.alembic_revision}`}
               </div>
             </div>

--- a/frontend/components/admin/DisplaysSection.js
+++ b/frontend/components/admin/DisplaysSection.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Check, Copy, X, Monitor, Trash2 } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
-import { copyTextToClipboard, errorText } from '../../lib/helpers';
+import { copyTextToClipboard, errorText, parseServerInstant } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 import ConfirmDialog from '../ConfirmDialog';
@@ -218,9 +218,9 @@ export default function DisplaysSection() {
                 </div>
                 <div className="adm-list-item-meta">
                   {device.last_used_at
-                    ? t(messages, 'display_last_used').replace('{when}', new Date(device.last_used_at).toLocaleString())
+                    ? t(messages, 'display_last_used').replace('{when}', parseServerInstant(device.last_used_at)?.toLocaleString())
                     : t(messages, 'display_never_used')}
-                  {' · '}{t(messages, 'display_created').replace('{when}', new Date(device.created_at).toLocaleDateString())}
+                  {' · '}{t(messages, 'display_created').replace('{when}', parseServerInstant(device.created_at)?.toLocaleDateString())}
                   {' · '}{displayModeLabel(device.display_mode, messages)} · {layoutPresetLabel(device.layout_preset, messages)} · {device.refresh_interval_seconds || 60}s
                 </div>
                 {!device.revoked_at && (

--- a/frontend/components/admin/InviteSection.js
+++ b/frontend/components/admin/InviteSection.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Check, Copy, X, Link, Trash2 } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
-import { copyTextToClipboard, errorText } from '../../lib/helpers';
+import { copyTextToClipboard, errorText, parseServerInstant } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 import ConfirmDialog from '../ConfirmDialog';
@@ -102,7 +102,7 @@ export default function InviteSection() {
 
   function inviteStatus(inv) {
     if (inv.revoked) return { label: t(messages, 'invite_status_revoked'), color: 'var(--text-muted)' };
-    if (new Date(inv.expires_at) < new Date()) return { label: t(messages, 'invite_status_expired'), color: 'var(--text-muted)' };
+    if (parseServerInstant(inv.expires_at) < new Date()) return { label: t(messages, 'invite_status_expired'), color: 'var(--text-muted)' };
     if (inv.max_uses && inv.use_count >= inv.max_uses) return { label: t(messages, 'invite_status_used_up'), color: 'var(--text-muted)' };
     return { label: t(messages, 'invite_status_active'), color: 'var(--success)' };
   }
@@ -199,10 +199,10 @@ export default function InviteSection() {
                     ? t(messages, 'invite_uses').replace('{count}', inv.use_count).replace('{max}', inv.max_uses)
                     : t(messages, 'invite_uses_unlimited').replace('{count}', inv.use_count)
                   }
-                  {' · '}{new Date(inv.expires_at).toLocaleDateString()}
+                  {' · '}{parseServerInstant(inv.expires_at)?.toLocaleDateString()}
                 </div>
               </div>
-              {!inv.revoked && new Date(inv.expires_at) > new Date() && (
+              {!inv.revoked && parseServerInstant(inv.expires_at) > new Date() && (
                 <button className="btn-ghost adm-revoke-btn" onClick={() => handleRevoke(inv.id)}>
                   <Trash2 size={14} /> {t(messages, 'invite_revoke')}
                 </button>

--- a/frontend/components/settings/ApiTokensTab.js
+++ b/frontend/components/settings/ApiTokensTab.js
@@ -3,7 +3,7 @@ import { Key, Plus, Trash2, Copy, Check, X } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
 import { useFamily } from '../../contexts/FamilyContext';
-import { copyTextToClipboard } from '../../lib/helpers';
+import { copyTextToClipboard, parseServerInstant } from '../../lib/helpers';
 import { t } from '../../lib/i18n';
 import * as api from '../../lib/api';
 
@@ -88,7 +88,7 @@ export default function ApiTokensTab() {
 
   function formatDate(iso) {
     if (!iso) return null;
-    return new Date(iso).toLocaleDateString(lang === 'de' ? 'de-DE' : 'en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    return parseServerInstant(iso).toLocaleDateString(lang === 'de' ? 'de-DE' : 'en-US', { year: 'numeric', month: 'short', day: 'numeric' });
   }
 
   function formatScopes(scopeStr) {

--- a/frontend/e2e/tests/display.spec.js
+++ b/frontend/e2e/tests/display.spec.js
@@ -26,10 +26,19 @@ async function gotoDisplayWithToken(page, token) {
   }
 }
 
+function localDateTimeInputValue(date) {
+  const pad = (value) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:00`;
+}
+
 test.describe('Display mode', () => {
   test('renders the paired wall display without normal app bootstrap or personal data', async ({ page, apiCtx, testUser }) => {
     const familyId = await getFamilyId(apiCtx);
-    await seedCalendarEvent(apiCtx, familyId, { title: 'Dinner Plan' });
+    const focusEventTime = new Date(Date.now() + 60 * 60 * 1000);
+    await seedCalendarEvent(apiCtx, familyId, {
+      title: 'Dinner Plan',
+      starts_at: localDateTimeInputValue(focusEventTime),
+    });
     const created = await createDisplayDevice(apiCtx, familyId, 'Kitchen Tablet');
 
     const requested = [];

--- a/frontend/lib/helpers.js
+++ b/frontend/lib/helpers.js
@@ -10,13 +10,34 @@ export function toIsoOrNull(localValue) {
 }
 
 /**
- * Parse a datetime string from the API.
- * Backend stores naive local time (no timezone).
- * Browsers interpret strings without Z as local time, which is correct here.
+ * Parse a local wall-clock datetime from the API.
+ *
+ * Calendar events and other user-entered date/time fields intentionally store
+ * naive local time, so strings without a timezone must stay local here.
  */
 export function parseDate(value) {
   if (!value) return null;
   return new Date(String(value));
+}
+
+const NAIVE_API_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?$/;
+const EXPLICIT_TIMEZONE_RE = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+/**
+ * Parse a server-generated instant from the API.
+ *
+ * Some backend/database timestamps are serialized as UTC-naive strings, for
+ * example "2026-04-30T14:35:00". Browsers interpret those as local time, which
+ * shifts activity/audit/notification metadata by the local UTC offset. Treat
+ * only full date-time strings without an explicit timezone as UTC instants.
+ * Date-only and local wall-clock fields should continue to use parseDate().
+ */
+export function parseServerInstant(value) {
+  if (!value) return null;
+  const s = String(value).trim();
+  if (!s) return null;
+  const normalized = NAIVE_API_DATETIME_RE.test(s) && !EXPLICIT_TIMEZONE_RE.test(s) ? `${s}Z` : s;
+  return new Date(normalized);
 }
 
 export function prettyDate(value, lang = 'en', timeFormat = '24h') {
@@ -51,9 +72,10 @@ export async function copyTextToClipboard(value) {
   }
 }
 
-export function timeAgo(dateStr, lang) {
+export function serverTimeAgo(dateStr, lang) {
   const now = new Date();
-  const date = new Date(dateStr);
+  const date = parseServerInstant(dateStr);
+  if (!date || Number.isNaN(date.getTime())) return '';
   const diff = Math.floor((now - date) / 1000);
   if (diff < 60) return lang === 'de' ? 'Gerade eben' : 'Just now';
   if (diff < 3600) {
@@ -67,6 +89,8 @@ export function timeAgo(dateStr, lang) {
   const d = Math.floor(diff / 86400);
   return lang === 'de' ? `vor ${d} Tag${d > 1 ? 'en' : ''}` : `${d}d ago`;
 }
+
+export const timeAgo = serverTimeAgo;
 
 export function errorText(detail, fallback, messages) {
   if (!detail) return fallback;


### PR DESCRIPTION
## Summary
- Treat UTC-naive server-generated timestamps as UTC instants before rendering them locally.
- Keep local wall-clock parsing unchanged for calendar and date/time-local values.
- Apply the instant parser to activity, notifications, admin metadata, invites, API tokens, setup restore metadata, backups, displays, audit log, and rewards.
- Stabilize the display E2E fixture so its focus event uses local wall-clock event semantics.

## Test plan
- `npm test -- --runTestsByPath __tests__/components/BackupSection.test.js __tests__/components/HouseholdActivityFeed.test.js __tests__/lib/helpers.test.js --runInBand`
- `npm test -- --runInBand`
- `npm run build`
- `npx playwright test e2e/tests/display.spec.js --project="Desktop Chrome" --project="Mobile Chrome" --reporter=list`
- `npx playwright test --reporter=list`  98 passed

Closes #299
