### PR TITLE
Show member avatars on the Shared Home Display

### DIFF
--- a/backend/app/modules/display_router.py
+++ b/backend/app/modules/display_router.py
@@ -46,6 +46,7 @@ from app.schemas import (
     DisplayDeviceUpdate,
     DisplayDeviceConfig,
     DisplayMeResponse,
+    sanitize_profile_image_data_url,
 )
 from app.security import generate_display_token
 
@@ -286,6 +287,7 @@ def display_dashboard(
         DisplayDashboardMember(
             display_name=m.user.display_name,
             color=m.color,
+            profile_image=sanitize_profile_image_data_url(m.user.profile_image),
         )
         for m in memberships
         if m.user

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,7 +7,7 @@ import re
 
 from enum import Enum
 
-from pydantic import BaseModel, EmailStr, ConfigDict, Field, field_validator
+from pydantic import BaseModel, EmailStr, ConfigDict, Field, ValidationError, field_validator
 
 from app.core.calendar_icons import normalize_calendar_event_icon
 from app.core.notification_preferences import normalize_push_categories
@@ -129,6 +129,16 @@ class ProfileImageUpdate(BaseModel):
             raise ValueError(f"Image too large ({len(decoded)} bytes). Maximum: {_PROFILE_IMAGE_MAX_BYTES} bytes (2 MB)")
 
         return v
+
+
+def sanitize_profile_image_data_url(value: Optional[str]) -> Optional[str]:
+    """Return a validated avatar data URL, or None for legacy/corrupt values."""
+    if not value:
+        return None
+    try:
+        return ProfileImageUpdate(profile_image=value).profile_image
+    except ValidationError:
+        return None
 
 
 class LeaveFamilyRequest(BaseModel):
@@ -1776,14 +1786,15 @@ class DisplayMeResponse(BaseModel):
 class DisplayDashboardMember(BaseModel):
     """Family member info safe for a public-ish home display.
 
-    Intentionally minimal: only the visible chip data (display name +
-    optional color). Excludes user_id, email, is_adult, profile image,
-    role, and any other personal/admin metadata so a token leak from a
-    wall tablet cannot reveal account identifiers, link members back
-    to a User row, or expose family role structure.
+    Intentionally narrow: only visible chip data (display name,
+    optional color, and optional avatar image). Excludes user_id,
+    email, is_adult, role, and any other personal/admin metadata so a
+    token leak from a wall tablet cannot reveal account identifiers,
+    link members back to a User row, or expose family role structure.
     """
     display_name: str = Field(..., description="Display name (rendered on the wall display)")
     color: Optional[str] = Field(None, description="Personal color hex code, if set")
+    profile_image: Optional[str] = Field(None, description="Avatar image data URL, if set")
 
 
 class DisplayDashboardEvent(BaseModel):
@@ -1818,13 +1829,12 @@ class DisplayDashboardResponse(BaseModel):
     Family-bound by the display token: the device cannot pass a
     different ``family_id`` to widen its view. Contains only fields
     safe to render on a wall screen — no emails, no user IDs, no
-    profile images, no admin data, no PAT scopes, no audit-log
-    fragments, no source URLs.
+    admin data, no PAT scopes, no audit-log fragments, no source URLs.
     """
     family_id: int = Field(..., description="Family ID (the display is bound to this family)")
     family_name: str = Field(..., description="Family name")
     device_name: str = Field(..., description="Name of the display device requesting the dashboard")
-    members: list[DisplayDashboardMember] = Field(..., description="Family members (display name + color only)")
+    members: list[DisplayDashboardMember] = Field(..., description="Family members (display name, color, and avatar only)")
     next_events: list[DisplayDashboardEvent] = Field(..., description="Upcoming events within 14 days (display-safe fields only)")
     upcoming_birthdays: list[DisplayDashboardBirthday] = Field(..., description="Upcoming birthdays within 28 days")
     config: DisplayDeviceConfig = Field(..., description="Resolved display render config")

--- a/backend/tests/test_display_devices.py
+++ b/backend/tests/test_display_devices.py
@@ -77,6 +77,7 @@ def _seed_member_with_pat(
     scopes: str = "*",
     family_id: int | None = None,
     email: str | None = None,
+    profile_image: str | None = None,
 ) -> tuple[str, int, int]:
     """Seed a user + family + membership + PAT. Returns (token, user_id, family_id)."""
     db = TestSession()
@@ -84,6 +85,7 @@ def _seed_member_with_pat(
         email=email or f"display-{suffix}@example.com",
         password_hash=hash_password("password"),
         display_name=f"User {suffix}",
+        profile_image=profile_image,
     )
     db.add(user)
     db.flush()
@@ -251,13 +253,21 @@ class TestDisplayRuntime:
         assert "secret-admin@example.com" not in raw
         assert "secret-kid@example.com" not in raw
 
-    def test_display_dashboard_member_fields_are_minimal(self):
-        """Only display_name + color. No user_id, is_adult, profile_image, role."""
+    def test_display_dashboard_member_fields_are_display_safe_with_avatar(self):
+        """Only display_name + color + profile_image. No user_id, is_adult, role, email."""
+        avatar = "data:image/png;base64,iVBORw0KGgo="
         admin_token, _, family_id = _seed_member_with_pat(
-            "minAdmin", role="admin", is_adult=True
+            "minAdmin", role="admin", is_adult=True, profile_image=avatar
         )
         _seed_member_with_pat(
             "minKid", role="member", is_adult=False, family_id=family_id
+        )
+        _seed_member_with_pat(
+            "badAvatar",
+            role="member",
+            is_adult=False,
+            family_id=family_id,
+            profile_image="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
         )
 
         resp = client.post(
@@ -272,11 +282,14 @@ class TestDisplayRuntime:
         body = dash.json()
         assert body["members"], "expected at least one member"
         for m in body["members"]:
-            assert set(m.keys()) == {"display_name", "color"}, m
+            assert set(m.keys()) == {"display_name", "color", "profile_image"}, m
+        assert any(m["profile_image"] == avatar for m in body["members"])
+        assert any(m["profile_image"] is None for m in body["members"])
+        assert "image/svg+xml" not in dash.text
         # Defensive: even if a future serializer leaks, the field
         # NAMES themselves must not appear in the JSON for a member.
         members_json = json_module.dumps(body["members"])
-        for forbidden in ("user_id", "is_adult", "profile_image", "role", "email"):
+        for forbidden in ("user_id", "is_adult", "role", "email"):
             assert forbidden not in members_json, forbidden
 
     def test_display_dashboard_event_fields_are_display_safe(self):

--- a/frontend/__tests__/components/DisplayDashboard.test.js
+++ b/frontend/__tests__/components/DisplayDashboard.test.js
@@ -24,9 +24,9 @@ function buildDashboard(overrides = {}) {
     family_name: 'Mueller',
     device_name: 'Kitchen Tablet',
     members: [
-      { display_name: 'Anna', color: '#7c3aed' },
-      { display_name: 'Mia', color: null },
-      { display_name: 'Grandma Ilse', color: '#f43f5e' },
+      { display_name: 'Anna', color: '#7c3aed', profile_image: 'data:image/png;base64,anna' },
+      { display_name: 'Mia', color: null, profile_image: null },
+      { display_name: 'Grandma Ilse', color: '#f43f5e', profile_image: null },
     ],
     next_events: [],
     upcoming_birthdays: [],
@@ -226,13 +226,16 @@ describe('DisplayDashboard — celebration + members', () => {
     expect(ilse.className).toMatch(/display-member--celebrant/);
   });
 
-  test('renders avatar initials for each member without exposing IDs', () => {
+  test('renders configured member avatar images and falls back to initials without exposing IDs', () => {
     renderWithFixedNow(buildDashboard(), new Date('2026-04-27T08:00:00'));
 
     const members = screen.getByTestId('display-members');
     expect(within(members).getByText('Anna')).toBeInTheDocument();
     expect(within(members).getByText('Mia')).toBeInTheDocument();
-    // Initial cells render uppercase initials only; never show IDs.
+    const annaAvatar = within(members).getByRole('img', { name: 'Anna' });
+    expect(annaAvatar).toHaveAttribute('src', 'data:image/png;base64,anna');
+    expect(within(members).getByText('M')).toBeInTheDocument();
+    expect(within(members).getByText('GI')).toBeInTheDocument();
     expect(members.textContent).not.toMatch(/\bID:/i);
     expect(members.textContent).not.toMatch(/\buser_id\b/i);
   });

--- a/frontend/components/DisplayDashboard.js
+++ b/frontend/components/DisplayDashboard.js
@@ -8,8 +8,9 @@ import { Calendar, Cake, Users } from 'lucide-react';
  * controls are rendered. The component receives only the data
  * returned by `/display/dashboard`, which is already a curated
  * server-side projection: `family_name`, `device_name`, `members`
- * (display_name + optional color only — no user_id, email, or
- * profile image), display-safe events, and birthday countdowns.
+ * (display_name + optional color/profile_image only — no user_id,
+ * email, role, or admin metadata), display-safe events, and birthday
+ * countdowns.
  *
  * Layout follows the "Tribu Hearth" three-column grid in landscape
  * (Pulse | Horizon | Tribe) and collapses to a single vertical stack
@@ -298,7 +299,7 @@ function MembersCard({ members, imminentNames }) {
                 style={{ '--member-tint': tint }}
                 data-testid="display-member"
               >
-                <span className="display-member-avatar" aria-hidden="true">{initials(m.display_name)}</span>
+                <DisplayMemberAvatar member={m} />
                 <span className="display-member-name">{m.display_name}</span>
                 {isCelebrant && (
                   <span className="display-member-badge" aria-label="Birthday soon" title="Birthday soon">🎂</span>
@@ -311,6 +312,24 @@ function MembersCard({ members, imminentNames }) {
         <EmptyHearth tone="soft" message="No family members yet." />
       )}
     </div>
+  );
+}
+
+function DisplayMemberAvatar({ member }) {
+  if (member?.profile_image) {
+    return (
+      <img
+        className="display-member-avatar"
+        src={member.profile_image}
+        alt={member.display_name || ''}
+      />
+    );
+  }
+
+  return (
+    <span className="display-member-avatar" aria-hidden="true">
+      {initials(member?.display_name)}
+    </span>
   );
 }
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -3087,6 +3087,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   width: clamp(64px, 6vw, 84px);
   height: clamp(64px, 6vw, 84px);
   border-radius: 50%;
+  object-fit: cover;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Adds validated member avatar images to the Shared Home Display member payload
- Renders configured avatars on the display while keeping initials as the fallback
- Keeps the display payload narrow and strips invalid legacy avatar data

## Test Plan
- `DATABASE_URL=sqlite:///./test_display_devices.db JWT_SECRET=test-secret PYTHONPATH=$PWD .venv/bin/python -m pytest -q tests/test_display_devices.py tests/test_avatar_validation.py`
- `npm test -- --runTestsByPath __tests__/components/DisplayDashboard.test.js __tests__/pages/DisplayPage.test.js __tests__/pages/DisplayAppWrapper.test.js --runInBand`
- `npm test -- --runInBand`
- `npm run build`
- `npx playwright test e2e/tests/display.spec.js --project="Desktop Chrome" --project="Mobile Chrome" --reporter=list`

Closes #301
