### PR TITLE
Show participant colors on display events

### DIFF
--- a/backend/app/modules/display_router.py
+++ b/backend/app/modules/display_router.py
@@ -20,6 +20,7 @@ account identifiers.
 """
 
 from datetime import date, timedelta
+import re
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -53,6 +54,38 @@ from app.security import generate_display_token
 
 admin_router = APIRouter(prefix="/families", tags=["display"], responses={**AUTH_RESPONSES})
 display_router = APIRouter(prefix="/display", tags=["display"], responses={**AUTH_RESPONSES})
+
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-f]{3}|[0-9a-f]{6})$", re.IGNORECASE)
+
+
+def _sanitize_display_color(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    return trimmed if _HEX_COLOR_RE.fullmatch(trimmed) else None
+
+
+def _participant_colors(assigned_to, member_colors_by_user_id: dict[int, str]) -> list[str]:
+    """Return display-safe member colors for an event assignment."""
+    if assigned_to == "all":
+        return list(dict.fromkeys(member_colors_by_user_id.values()))
+    if not isinstance(assigned_to, list):
+        return []
+
+    colors: list[str] = []
+    seen: set[str] = set()
+    for value in assigned_to:
+        if isinstance(value, bool):
+            continue
+        try:
+            user_id = int(value)
+        except (TypeError, ValueError):
+            continue
+        color = member_colors_by_user_id.get(user_id)
+        if color and color not in seen:
+            seen.add(color)
+            colors.append(color)
+    return colors
 
 
 def _device_config(device: DisplayDevice) -> DisplayDeviceConfig:
@@ -279,8 +312,10 @@ def display_dashboard(
 
     memberships = (
         db.query(Membership)
+        .join(User, User.id == Membership.user_id)
         .options(joinedload(Membership.user))
         .filter(Membership.family_id == device.family_id)
+        .order_by(User.display_name.asc(), Membership.user_id.asc())
         .all()
     )
     members = [
@@ -292,6 +327,11 @@ def display_dashboard(
         for m in memberships
         if m.user
     ]
+    member_colors_by_user_id = {
+        int(m.user_id): color
+        for m in memberships
+        if (color := _sanitize_display_color(m.color))
+    }
 
     now = utcnow()
     range_end = now + timedelta(days=14)
@@ -330,6 +370,7 @@ def display_dashboard(
             color=o.get("color"),
             category=o.get("category"),
             icon=o.get("icon"),
+            participant_colors=_participant_colors(o.get("assigned_to"), member_colors_by_user_id),
         )
         for o in occurrences[:8]
     ]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1802,9 +1802,9 @@ class DisplayDashboardEvent(BaseModel):
 
     Mirrors only the fields the glanceable layout actually renders.
     Drops user IDs (created_by_user_id, assigned_to), refresh URLs
-    (source_url), and other operational metadata that has no display
-    purpose and would constitute additional surface area on a token
-    leak.
+    (source_url), and other operational metadata. Participant colors
+    are derived server-side from the assignment list so the display can
+    show who is involved without exposing identifiers.
     """
     title: str = Field(..., description="Event title")
     starts_at: datetime = Field(..., description="Start date/time")
@@ -1814,6 +1814,7 @@ class DisplayDashboardEvent(BaseModel):
     color: Optional[str] = Field(None, description="Event color as hex string, if set")
     category: Optional[str] = Field(None, description="Event category label")
     icon: Optional[str] = Field(None, description="Allowlisted calendar event icon key")
+    participant_colors: list[str] = Field(default_factory=list, description="Display-safe participant member colors")
 
 
 class DisplayDashboardBirthday(BaseModel):

--- a/backend/tests/test_display_devices.py
+++ b/backend/tests/test_display_devices.py
@@ -78,6 +78,7 @@ def _seed_member_with_pat(
     family_id: int | None = None,
     email: str | None = None,
     profile_image: str | None = None,
+    color: str | None = None,
 ) -> tuple[str, int, int]:
     """Seed a user + family + membership + PAT. Returns (token, user_id, family_id)."""
     db = TestSession()
@@ -97,7 +98,7 @@ def _seed_member_with_pat(
         family_id = int(family.id)
     assert family_id is not None
 
-    db.add(Membership(user_id=user.id, family_id=family_id, role=role, is_adult=is_adult))
+    db.add(Membership(user_id=user.id, family_id=family_id, role=role, is_adult=is_adult, color=color))
 
     plain = f"{PAT_PREFIX}displaytest-{suffix}"
     lookup = hashlib.sha256(plain.encode()).hexdigest()
@@ -338,7 +339,7 @@ class TestDisplayRuntime:
         # Whitelist exactly the keys we expect.
         assert set(evt.keys()) == {
             "title", "starts_at", "ends_at", "all_day",
-            "occurrence_date", "color", "category", "icon",
+            "occurrence_date", "color", "category", "icon", "participant_colors",
         }, evt
         assert evt["icon"] == "soccer"
         # Defensive: forbidden fields must not appear in the event JSON.
@@ -352,6 +353,82 @@ class TestDisplayRuntime:
             assert forbidden not in events_json, forbidden
         # And the literal source_url must NEVER appear in the response.
         assert "leak.example.com" not in dash.text
+
+    def test_display_dashboard_event_participant_colors_are_display_safe(self):
+        """Expose only participant colors for assigned events, never user identifiers."""
+        admin_token, admin_user_id, family_id = _seed_member_with_pat(
+            "participantAdmin", role="admin", is_adult=True, color="#7c3aed"
+        )
+        _, kid_user_id, _ = _seed_member_with_pat(
+            "participantKid",
+            role="member",
+            is_adult=False,
+            family_id=family_id,
+            color="#f43f5e",
+        )
+        _, invalid_color_user_id, _ = _seed_member_with_pat(
+            "participantBadColor",
+            role="member",
+            is_adult=False,
+            family_id=family_id,
+            color="url(https://example.com/bad)",
+        )
+        _, outsider_user_id, _ = _seed_member_with_pat(
+            "participantOutsider", role="member", is_adult=False, color="#10b981"
+        )
+
+        from datetime import datetime, timedelta, timezone
+        from app.models import CalendarEvent
+
+        db = TestSession()
+        future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=1)
+        db.add(CalendarEvent(
+            family_id=family_id,
+            title="Two kids practice",
+            starts_at=future,
+            ends_at=future + timedelta(hours=1),
+            all_day=False,
+            assigned_to=[admin_user_id, kid_user_id, invalid_color_user_id, outsider_user_id, 999999],
+        ))
+        db.add(CalendarEvent(
+            family_id=family_id,
+            title="Family dinner",
+            starts_at=future + timedelta(hours=2),
+            ends_at=future + timedelta(hours=3),
+            all_day=False,
+            assigned_to="all",
+        ))
+        db.add(CalendarEvent(
+            family_id=family_id,
+            title="General reminder",
+            starts_at=future + timedelta(hours=4),
+            ends_at=future + timedelta(hours=5),
+            all_day=False,
+            assigned_to=None,
+        ))
+        db.commit()
+        db.close()
+
+        resp = client.post(
+            f"/families/{family_id}/display-devices",
+            json={"name": "Kitchen"},
+            headers=_auth(admin_token),
+        )
+        token = resp.json()["token"]
+
+        dash = client.get("/display/dashboard", headers=_auth(token))
+        assert dash.status_code == 200, dash.text
+        events = {event["title"]: event for event in dash.json()["next_events"]}
+
+        assert events["Two kids practice"]["participant_colors"] == ["#7c3aed", "#f43f5e"]
+        assert events["Family dinner"]["participant_colors"] == ["#7c3aed", "#f43f5e"]
+        assert events["General reminder"]["participant_colors"] == []
+
+        events_json = json_module.dumps(dash.json()["next_events"])
+        assert "assigned_to" not in events_json
+        assert "user_id" not in events_json
+        assert "#10b981" not in events_json
+        assert "url(https://example.com/bad)" not in events_json
 
 
 class TestDisplayTokenIsolation:

--- a/frontend/__tests__/components/DisplayDashboard.test.js
+++ b/frontend/__tests__/components/DisplayDashboard.test.js
@@ -165,6 +165,45 @@ describe('DisplayDashboard — agenda grouping', () => {
     expect(focus).toHaveTextContent('Family dinner');
   });
 
+  test('shows participant color markers only for assigned display events', () => {
+    const fixedNow = new Date('2026-04-27T08:00:00');
+    renderWithFixedNow(
+      buildDashboard({
+        next_events: [
+          {
+            title: 'Soccer practice',
+            starts_at: isoLocal(new Date('2026-04-27T18:00:00')),
+            ends_at: null,
+            all_day: false,
+            color: '#10b981',
+            category: 'Sports',
+            participant_colors: ['#7c3aed', 'url(https://example.com/bad)', '#f43f5e'],
+          },
+          {
+            title: 'Dentist',
+            starts_at: isoLocal(new Date('2026-04-28T09:00:00')),
+            ends_at: null,
+            all_day: false,
+            color: '#f59e0b',
+            category: null,
+            participant_colors: [],
+          },
+        ],
+      }),
+      fixedNow
+    );
+
+    const events = screen.getByTestId('display-events');
+    const participantGroup = within(events).getByLabelText('2 participants');
+    expect(participantGroup).toHaveAttribute('data-testid', 'display-event-participants');
+    const dots = within(participantGroup).getAllByTestId('display-event-participant-color');
+    expect(dots).toHaveLength(2);
+    expect(dots[0]).toHaveStyle({ '--participant-color': '#7c3aed' });
+    expect(dots[1]).toHaveStyle({ '--participant-color': '#f43f5e' });
+    expect(participantGroup).not.toHaveStyle({ '--participant-color': 'url(https://example.com/bad)' });
+    expect(within(events).queryAllByTestId('display-event-participants')).toHaveLength(1);
+  });
+
   test('shows the friendly empty hearth message when no events', () => {
     renderWithFixedNow(
       buildDashboard({ next_events: [] }),

--- a/frontend/components/DisplayDashboard.js
+++ b/frontend/components/DisplayDashboard.js
@@ -196,6 +196,7 @@ function HomeHeaderCard({ familyName, deviceName, timeLabel, dateLabel, timeIso,
                 <li key={idx} className="display-home-header-event">
                   <span className="display-home-header-when">{formatAgendaWhen(ev)}</span>
                   <span className="display-home-header-title">{ev.title}</span>
+                  <EventParticipantColors event={ev} compact />
                 </li>
               ))
             )}
@@ -406,10 +407,38 @@ function AgendaRow({ event, now }) {
     >
       <span className="display-agenda-when">{formatAgendaWhen(event)}</span>
       <span className="display-agenda-title">{event.title}</span>
-      {event.category && (
-        <span className="display-agenda-category">{event.category}</span>
-      )}
+      <span className="display-agenda-meta">
+        <EventParticipantColors event={event} />
+        {event.category && (
+          <span className="display-agenda-category">{event.category}</span>
+        )}
+      </span>
     </li>
+  );
+}
+
+function EventParticipantColors({ event, compact = false }) {
+  const colors = Array.isArray(event?.participant_colors)
+    ? event.participant_colors.map(sanitizeColor).filter(Boolean)
+    : [];
+  if (colors.length === 0) return null;
+  const label = colors.length === 1 ? '1 participant' : `${colors.length} participants`;
+  return (
+    <span
+      className={`display-event-participants${compact ? ' display-event-participants--compact' : ''}`}
+      aria-label={label}
+      data-testid="display-event-participants"
+    >
+      {colors.map((color, idx) => (
+        <span
+          key={`${color}-${idx}`}
+          className="display-event-participant-color"
+          style={{ '--participant-color': color }}
+          data-testid="display-event-participant-color"
+          aria-hidden="true"
+        />
+      ))}
+    </span>
   );
 }
 

--- a/frontend/e2e/tests/display.spec.js
+++ b/frontend/e2e/tests/display.spec.js
@@ -34,10 +34,27 @@ function localDateTimeInputValue(date) {
 test.describe('Display mode', () => {
   test('renders the paired wall display without normal app bootstrap or personal data', async ({ page, apiCtx, testUser }) => {
     const familyId = await getFamilyId(apiCtx);
+    const membersRes = await apiCtx.get(`/api/families/${familyId}/members`);
+    expect(membersRes.ok()).toBeTruthy();
+    const members = await membersRes.json();
+    const currentMember = members.find((member) => member.email === testUser.email);
+    expect(currentMember).toBeTruthy();
+
+    const colorRes = await apiCtx.patch(`/api/families/${familyId}/members/me/color`, {
+      data: { color: '#7c3aed' },
+    });
+    expect(colorRes.ok()).toBeTruthy();
+
     const focusEventTime = new Date(Date.now() + 60 * 60 * 1000);
     await seedCalendarEvent(apiCtx, familyId, {
       title: 'Dinner Plan',
       starts_at: localDateTimeInputValue(focusEventTime),
+      assigned_to: [currentMember.user_id],
+    });
+    await seedCalendarEvent(apiCtx, familyId, {
+      title: 'General Reminder',
+      starts_at: localDateTimeInputValue(new Date(Date.now() + 2 * 60 * 60 * 1000)),
+      assigned_to: null,
     });
     const created = await createDisplayDevice(apiCtx, familyId, 'Kitchen Tablet');
 
@@ -57,6 +74,9 @@ test.describe('Display mode', () => {
     // each region to avoid strict-mode ambiguity from the duplicate title.
     await expect(page.getByTestId('display-focus')).toContainText('Dinner Plan');
     await expect(page.getByTestId('display-events')).toContainText('Dinner Plan');
+    const participantMarkers = page.getByTestId('display-event-participants');
+    await expect(participantMarkers).toHaveCount(1);
+    await expect(participantMarkers.first()).toHaveAttribute('aria-label', '1 participant');
     await expect(page.getByText(testUser.displayName)).toBeVisible();
 
     await expect(page).toHaveURL(/\/display$/);

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2856,9 +2856,9 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 }
 .display-home-header-event {
   display: grid;
-  grid-template-columns: 4.5rem 1fr;
+  grid-template-columns: 4.5rem 1fr auto;
   gap: 0.6rem;
-  align-items: baseline;
+  align-items: center;
   min-width: 0;
 }
 .display-home-header-when {
@@ -3023,6 +3023,35 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   font-weight: 500;
   word-break: break-word;
   min-width: 0;
+}
+.display-agenda-meta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.45rem;
+  min-width: 0;
+}
+.display-event-participants {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+.display-event-participants--compact {
+  justify-content: flex-end;
+}
+.display-event-participant-color {
+  --participant-color: var(--amethyst);
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 50%;
+  background: var(--participant-color);
+  border: 2px solid var(--void-elevated);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--participant-color) 45%, transparent);
+}
+.display-event-participant-color + .display-event-participant-color {
+  margin-left: -0.22rem;
 }
 .display-agenda-category {
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary

- derive display-safe participant color dots for Shared Home Display events from event assignments
- render one or more member-color dots next to assigned events while leaving unassigned events without member colors
- keep the display payload tight by exposing colors only, not user IDs, emails, roles, or assignment metadata

## Verification

- `DATABASE_URL=sqlite:///./test_display_devices.db JWT_SECRET=test-secret PYTHONPATH=$PWD/backend backend/.venv/bin/python -m pytest -q backend/tests/test_display_devices.py backend/tests/test_avatar_validation.py`
- `backend/.venv/bin/python -m py_compile backend/app/modules/display_router.py backend/app/schemas.py backend/tests/test_display_devices.py`
- `cd frontend && npm test -- --runTestsByPath __tests__/components/DisplayDashboard.test.js __tests__/pages/DisplayPage.test.js __tests__/pages/DisplayAppWrapper.test.js --runInBand`
- `cd frontend && npm run build`
- `cd frontend && npx playwright test e2e/tests/display.spec.js --list`
- `cd frontend && BASE_URL=http://127.0.0.1:3000 BACKEND_URL=http://127.0.0.1:8000 npx playwright test e2e/tests/display.spec.js --reporter=list` — 6 passed across Desktop Chrome and Mobile Chrome
- `git diff --check`

Closes #304
