### PR TITLE
Polish school timetable editor UI

### DIFF
--- a/frontend/components/SchoolTimetablesView.js
+++ b/frontend/components/SchoolTimetablesView.js
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { GraduationCap, Plus, Save, Trash2 } from 'lucide-react';
+import { Check, ChevronDown, Coffee, GraduationCap, Plus, Save, Sparkles, Trash2 } from 'lucide-react';
+import MemberAvatar from './MemberAvatar';
 import { useApp } from '../contexts/AppContext';
 import {
   apiCreateSchoolTimetable,
@@ -10,12 +11,22 @@ import {
 import { t } from '../lib/i18n';
 
 const WEEKDAYS = [
-  { value: 1, short: 'Mon' },
-  { value: 2, short: 'Tue' },
-  { value: 3, short: 'Wed' },
-  { value: 4, short: 'Thu' },
-  { value: 5, short: 'Fri' },
-  { value: 6, short: 'Sat' },
+  { value: 1, short: 'Mo', full: 'Montag' },
+  { value: 2, short: 'Di', full: 'Dienstag' },
+  { value: 3, short: 'Mi', full: 'Mittwoch' },
+  { value: 4, short: 'Do', full: 'Donnerstag' },
+  { value: 5, short: 'Fr', full: 'Freitag' },
+  { value: 6, short: 'Sa', full: 'Samstag' },
+];
+
+const SUBJECT_PALETTE = [
+  { bg: 'rgba(124, 58, 237, 0.12)', fg: '#7c3aed' },
+  { bg: 'rgba(59, 130, 246, 0.12)', fg: '#2563eb' },
+  { bg: 'rgba(16, 185, 129, 0.13)', fg: '#059669' },
+  { bg: 'rgba(245, 158, 11, 0.15)', fg: '#d97706' },
+  { bg: 'rgba(244, 63, 94, 0.12)', fg: '#e11d48' },
+  { bg: 'rgba(6, 182, 212, 0.14)', fg: '#0891b2' },
+  { bg: 'rgba(168, 85, 247, 0.12)', fg: '#9333ea' },
 ];
 
 const DEFAULT_PERIODS = [
@@ -54,6 +65,17 @@ function buildLessonMap(lessons) {
   return map;
 }
 
+function subjectPalette(subject) {
+  if (!subject) return null;
+  const key = subject.trim().toLowerCase();
+  if (!key) return null;
+  let hash = 0;
+  for (let i = 0; i < key.length; i += 1) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return SUBJECT_PALETTE[hash % SUBJECT_PALETTE.length];
+}
+
 function payloadFromForm(form, familyId) {
   return {
     family_id: Number(familyId),
@@ -90,21 +112,23 @@ export default function SchoolTimetablesView() {
   const [form, setForm] = useState(() => emptyForm(familyId));
   const [status, setStatus] = useState('');
   const [saving, setSaving] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [mobileDay, setMobileDay] = useState(1);
 
   const childCandidates = useMemo(
     () => (members || []).filter((m) => !m.is_adult),
     [members]
   );
-  const lessonPeriods = (form.periods || []).filter((p) => p.kind !== 'break');
   const visibleWeekdays = WEEKDAYS.filter((d) => d.value <= 5 || form.include_saturday);
   const lessonMap = buildLessonMap(form.lessons);
+  const activeMobileDay = visibleWeekdays.find((d) => d.value === mobileDay) || visibleWeekdays[0];
 
   async function load() {
     if (!familyId || demoMode) return;
     const { ok, data } = await apiListSchoolTimetables(familyId);
     if (ok && Array.isArray(data)) {
       setTimetables(data);
-      if (!selectedId && data.length > 0) {
+      if (!selectedId && !creating && data.length > 0) {
         selectTimetable(data[0]);
       }
     }
@@ -114,11 +138,19 @@ export default function SchoolTimetablesView() {
     setForm(emptyForm(familyId));
     setSelectedId(null);
     setTimetables([]);
+    setCreating(false);
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [familyId, demoMode]);
 
+  useEffect(() => {
+    if (!visibleWeekdays.some((d) => d.value === mobileDay)) {
+      setMobileDay(visibleWeekdays[0]?.value ?? 1);
+    }
+  }, [form.include_saturday]); // eslint-disable-line react-hooks/exhaustive-deps
+
   function selectTimetable(item) {
+    setCreating(false);
     setSelectedId(item.id);
     setForm({
       family_id: item.family_id,
@@ -137,6 +169,7 @@ export default function SchoolTimetablesView() {
     setSelectedId(null);
     setForm(emptyForm(familyId));
     setStatus('');
+    setCreating(true);
   }
 
   function updatePeriod(index, key, value) {
@@ -146,6 +179,30 @@ export default function SchoolTimetablesView() {
       const nextLessons = key === 'kind' && value === 'break'
         ? (current.lessons || []).filter((lesson) => Number(lesson.period_position) !== Number(changed.position))
         : current.lessons;
+      return { ...current, periods: nextPeriods, lessons: nextLessons };
+    });
+  }
+
+  function removePeriod(index) {
+    setForm((current) => {
+      const removed = current.periods[index];
+      if (!removed) return current;
+
+      const positionMap = new Map();
+      const nextPeriods = current.periods
+        .filter((_, idx) => idx !== index)
+        .map((period, idx) => {
+          const nextPosition = idx + 1;
+          positionMap.set(Number(period.position), nextPosition);
+          return { ...period, position: nextPosition };
+        });
+      const nextLessons = (current.lessons || [])
+        .filter((lesson) => Number(lesson.period_position) !== Number(removed.position))
+        .map((lesson) => ({
+          ...lesson,
+          period_position: positionMap.get(Number(lesson.period_position)) ?? lesson.period_position,
+        }));
+
       return { ...current, periods: nextPeriods, lessons: nextLessons };
     });
   }
@@ -215,13 +272,31 @@ export default function SchoolTimetablesView() {
       setStatus(result.data?.detail || 'Löschen fehlgeschlagen.');
       return;
     }
-    startNew();
+    setCreating(false);
+    setSelectedId(null);
+    setForm(emptyForm(familyId));
+    setStatus('');
     await load();
   }
 
   if (demoMode) {
-    return <div className="view"><div className="empty-state">School timetables are available in family mode.</div></div>;
+    return (
+      <div className="view school-timetables-view">
+        <div className="view-header">
+          <div>
+            <h1 className="view-title"><GraduationCap size={24} /> {t(messages, 'module.school_timetables.name')}</h1>
+            <p className="view-subtitle">{t(messages, 'module.school_timetables.subtitle')}</p>
+          </div>
+        </div>
+        <div className="school-empty-rich">
+          <div className="school-empty-icon-wrap"><GraduationCap size={32} aria-hidden="true" /></div>
+          <p>School timetables are available in family mode.</p>
+        </div>
+      </div>
+    );
   }
+
+  const showEmptyState = timetables.length === 0 && !creating && !selectedId;
 
   return (
     <div className="view school-timetables-view">
@@ -230,82 +305,342 @@ export default function SchoolTimetablesView() {
           <h1 className="view-title"><GraduationCap size={24} /> {t(messages, 'module.school_timetables.name')}</h1>
           <p className="view-subtitle">{t(messages, 'module.school_timetables.subtitle')}</p>
         </div>
-        <button type="button" className="btn-primary" onClick={startNew}><Plus size={16} /> {t(messages, 'module.school_timetables.add')}</button>
+        {!showEmptyState && (
+          <button type="button" className="btn-primary school-add-btn" onClick={startNew}>
+            <Plus size={16} aria-hidden="true" /> {t(messages, 'module.school_timetables.add')}
+          </button>
+        )}
       </div>
 
-      <div className="school-layout">
-        <aside className="school-list-card">
-          {timetables.length === 0 ? (
-            <p className="muted">{t(messages, 'module.school_timetables.empty')}</p>
-          ) : timetables.map((item) => (
-            <button key={item.id} type="button" className={`school-list-item${selectedId === item.id ? ' active' : ''}`} onClick={() => selectTimetable(item)}>
-              <strong>{item.name}</strong>
-              <span>{item.class_label || 'Ohne Klasse'}</span>
-              <small>{(item.assigned_members || []).map((m) => m.display_name).join(', ')}</small>
-            </button>
-          ))}
-        </aside>
+      {showEmptyState ? (
+        <div className="school-empty-rich">
+          <div className="school-empty-icon-wrap" aria-hidden="true"><GraduationCap size={36} /></div>
+          <h2 className="school-empty-title">{t(messages, 'module.school_timetables.empty')}</h2>
+          <p className="school-empty-body">
+            Lege einen Wochenplan an, damit Fächer, Pausen und Stundenzeiten übersichtlich an einem Ort liegen.
+          </p>
+          <button type="button" className="btn-primary school-empty-cta" onClick={startNew}>
+            <Sparkles size={16} aria-hidden="true" /> Ersten Stundenplan erstellen
+          </button>
+        </div>
+      ) : (
+        <div className="school-layout">
+          <aside className="school-list-card" aria-label="Stundenpläne">
+            <div className="school-list-header">
+              <span className="school-list-title">Pläne</span>
+              <span className="school-list-count">{timetables.length}</span>
+            </div>
+            {timetables.length === 0 && creating && (
+              <p className="muted school-list-empty">Neuer Plan in Bearbeitung…</p>
+            )}
+            <div className="school-list-items">
+              {timetables.map((item) => {
+                const active = selectedId === item.id;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className={`school-list-item${active ? ' active' : ''}`}
+                    onClick={() => selectTimetable(item)}
+                    aria-current={active ? 'true' : undefined}
+                  >
+                    <div className="school-list-item-name">{item.name}</div>
+                    <div className="school-list-item-meta">
+                      <span className="school-list-item-class">{item.class_label || 'Ohne Klasse'}</span>
+                      {(item.assigned_members || []).length > 0 && (
+                        <span className="school-list-item-children" aria-label="Zugeordnete Kinder">
+                          {item.assigned_members.map((m, i) => (
+                            <MemberAvatar key={m.user_id ?? i} member={m} index={i} size={20} />
+                          ))}
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </aside>
 
-        <main className="school-editor-card">
-          <div className="form-grid two">
-            <label>Name<input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="Klasse 4b" /></label>
-            <label>{t(messages, 'module.school_timetables.class_label')}<input value={form.class_label} onChange={(e) => setForm({ ...form, class_label: e.target.value })} placeholder="4b" /></label>
-          </div>
-          <label className="checkbox-row"><input type="checkbox" checked={form.include_saturday} onChange={(e) => setForm({ ...form, include_saturday: e.target.checked })} /> {t(messages, 'module.school_timetables.include_saturday')}</label>
-
-          <section>
-            <h2>{t(messages, 'module.school_timetables.assigned_children')}</h2>
-            <div className="school-chip-grid">
-              {childCandidates.length === 0 ? <p className="muted">Keine Kinder in der Familie gefunden.</p> : childCandidates.map((member) => (
-                <label key={member.user_id} className="school-child-chip">
-                  <input type="checkbox" checked={(form.assigned_member_user_ids || []).includes(member.user_id)} onChange={() => toggleMember(member.user_id)} />
-                  <span>{member.display_name}</span>
+          <main className="school-editor-card">
+            <section className="school-editor-section school-meta-section">
+              <div className="school-meta-grid">
+                <label className="school-field">
+                  <span>Name</span>
+                  <input
+                    className="form-input"
+                    value={form.name}
+                    onChange={(e) => setForm({ ...form, name: e.target.value })}
+                    placeholder="Klasse 4b"
+                  />
                 </label>
-              ))}
-            </div>
-          </section>
+                <label className="school-field">
+                  <span>{t(messages, 'module.school_timetables.class_label')}</span>
+                  <input
+                    className="form-input"
+                    value={form.class_label}
+                    onChange={(e) => setForm({ ...form, class_label: e.target.value })}
+                    placeholder="4b"
+                  />
+                </label>
+              </div>
+              <label className="school-toggle">
+                <input
+                  type="checkbox"
+                  checked={form.include_saturday}
+                  onChange={(e) => setForm({ ...form, include_saturday: e.target.checked })}
+                />
+                <span className="school-toggle-track" aria-hidden="true">
+                  <span className="school-toggle-thumb" />
+                </span>
+                <span className="school-toggle-label">{t(messages, 'module.school_timetables.include_saturday')}</span>
+              </label>
+            </section>
 
-          <section>
-            <div className="section-row">
-              <h2>{t(messages, 'module.school_timetables.periods')}</h2>
-              <div><button type="button" onClick={() => addPeriod('lesson')}>+ Stunde</button> <button type="button" onClick={() => addPeriod('break')}>+ Pause</button></div>
-            </div>
-            <div className="school-periods">
-              {form.periods.map((period, index) => (
-                <div key={index} className="school-period-row">
-                  <input aria-label="Label" value={period.label} onChange={(e) => updatePeriod(index, 'label', e.target.value)} />
-                  <select value={period.kind} onChange={(e) => updatePeriod(index, 'kind', e.target.value)}><option value="lesson">Stunde</option><option value="break">Pause</option></select>
-                  <input type="time" value={normalizeTime(period.start_time)} onChange={(e) => updatePeriod(index, 'start_time', e.target.value)} />
-                  <input type="time" value={normalizeTime(period.end_time)} onChange={(e) => updatePeriod(index, 'end_time', e.target.value)} />
+            <section className="school-editor-section">
+              <h2 className="school-section-title">Für wen ist dieser Plan?</h2>
+              <div
+                className="school-children-row"
+                role="group"
+                aria-label={t(messages, 'module.school_timetables.assigned_children')}
+              >
+                {childCandidates.length === 0 ? (
+                  <p className="muted">Keine Kinder in der Familie gefunden.</p>
+                ) : childCandidates.map((member, i) => {
+                  const active = (form.assigned_member_user_ids || []).includes(member.user_id);
+                  return (
+                    <button
+                      key={member.user_id}
+                      type="button"
+                      role="checkbox"
+                      aria-checked={active}
+                      aria-label={`${member.display_name}${active ? ' zugeordnet' : ''}`}
+                      className={`school-child-chip${active ? ' active' : ''}`}
+                      onClick={() => toggleMember(member.user_id)}
+                    >
+                      <MemberAvatar member={member} index={i} size={28} />
+                      <span className="school-child-chip-name">{member.display_name}</span>
+                      {active && (
+                        <span className="school-child-chip-check" aria-hidden="true">
+                          <Check size={12} strokeWidth={3} />
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="school-editor-section school-grid-section">
+              <div className="school-section-head">
+                <h2 className="school-section-title">{t(messages, 'module.school_timetables.lessons')}</h2>
+                <p className="school-section-hint">Tippe in eine Zelle, um ein Fach einzutragen.</p>
+              </div>
+
+              <div className="school-day-pager" role="tablist" aria-label="Wochentag wählen">
+                {visibleWeekdays.map((day) => (
+                  <button
+                    key={day.value}
+                    type="button"
+                    role="tab"
+                    aria-selected={mobileDay === day.value}
+                    className={`school-day-tab${mobileDay === day.value ? ' active' : ''}`}
+                    onClick={() => setMobileDay(day.value)}
+                  >
+                    {day.short}
+                  </button>
+                ))}
+              </div>
+
+              <div
+                className="school-grid"
+                role="grid"
+                aria-label="Stundenplan"
+                style={{ '--school-columns': visibleWeekdays.length }}
+              >
+                <div className="school-grid-corner" role="presentation" />
+                {visibleWeekdays.map((day) => (
+                  <div key={day.value} role="columnheader" className="school-grid-day-head">
+                    <span className="school-grid-day-short" aria-hidden="true">{day.short}</span>
+                    <span className="school-grid-day-full">{day.full}</span>
+                  </div>
+                ))}
+
+                {form.periods.map((period) => {
+                  const time = `${normalizeTime(period.start_time)}–${normalizeTime(period.end_time)}`;
+                  if (period.kind === 'break') {
+                    return (
+                      <div
+                        key={`brk-${period.position}`}
+                        className="school-grid-row school-grid-row--break"
+                        role="row"
+                      >
+                        <div className="school-grid-time school-grid-time--break" role="rowheader">
+                          <span className="school-grid-time-range">{time}</span>
+                        </div>
+                        <div
+                          className="school-grid-break-bar"
+                          aria-label={`Pause ${time}`}
+                        >
+                          <Coffee size={14} aria-hidden="true" />
+                          <span>{period.break_label || period.label || 'Pause'}</span>
+                        </div>
+                      </div>
+                    );
+                  }
+                  return (
+                    <div key={`row-${period.position}`} className="school-grid-row" role="row">
+                      <div className="school-grid-time" role="rowheader">
+                        <span className="school-grid-time-num">{period.label}</span>
+                        <span className="school-grid-time-range">{time}</span>
+                      </div>
+                      {visibleWeekdays.map((day) => {
+                        const lesson = lessonMap.get(lessonKey(day.value, Number(period.position)));
+                        const subject = lesson?.subject || '';
+                        const palette = subjectPalette(subject);
+                        const cellStyle = palette ? { '--st-bg': palette.bg, '--st-fg': palette.fg } : undefined;
+                        const cellLabel = `${day.full}, ${period.label}. Stunde${subject ? ', ' + subject : ', leer'}`;
+                        return (
+                          <div
+                            key={`${day.value}-${period.position}`}
+                            role="gridcell"
+                            className={`school-cell${subject ? ' school-cell--filled' : ''}`}
+                            style={cellStyle}
+                          >
+                            <input
+                              className="school-cell-input"
+                              value={subject}
+                              onChange={(e) => updateLesson(day.value, Number(period.position), e.target.value)}
+                              placeholder="—"
+                              aria-label={cellLabel}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="school-day-list" aria-label={`Plan für ${activeMobileDay?.full || ''}`}>
+                {form.periods.map((period) => {
+                  const time = `${normalizeTime(period.start_time)}–${normalizeTime(period.end_time)}`;
+                  if (period.kind === 'break') {
+                    return (
+                      <div key={`mbrk-${period.position}`} className="school-day-list-item school-day-list-item--break">
+                        <div className="school-day-list-time">{time}</div>
+                        <div className="school-grid-break-bar">
+                          <Coffee size={14} aria-hidden="true" />
+                          <span>{period.break_label || 'Pause'}</span>
+                        </div>
+                      </div>
+                    );
+                  }
+                  if (!activeMobileDay) return null;
+                  const lesson = lessonMap.get(lessonKey(activeMobileDay.value, Number(period.position)));
+                  const subject = lesson?.subject || '';
+                  const palette = subjectPalette(subject);
+                  const cellStyle = palette ? { '--st-bg': palette.bg, '--st-fg': palette.fg } : undefined;
+                  return (
+                    <div
+                      key={`mlsn-${period.position}`}
+                      className={`school-day-list-item${subject ? ' school-day-list-item--filled' : ''}`}
+                      style={cellStyle}
+                    >
+                      <div className="school-day-list-time">
+                        <span className="school-day-list-num">{period.label}</span>
+                        <span className="school-day-list-range">{time}</span>
+                      </div>
+                      <input
+                        className="school-cell-input school-day-list-input"
+                        value={subject}
+                        onChange={(e) => updateLesson(activeMobileDay.value, Number(period.position), e.target.value)}
+                        placeholder="Fach eintragen"
+                        aria-label={`Fach ${activeMobileDay.full} ${period.label}. Stunde`}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <details className="school-editor-section school-periods-config">
+              <summary>
+                <span className="school-section-title">{t(messages, 'module.school_timetables.periods')}</span>
+                <ChevronDown size={16} aria-hidden="true" className="school-periods-chevron" />
+              </summary>
+              <div className="school-periods">
+                {form.periods.map((period, index) => (
+                  <div key={index} className={`school-period-row school-period-row--${period.kind}`}>
+                    <input
+                      className="form-input school-period-label"
+                      aria-label="Bezeichnung"
+                      value={period.label}
+                      onChange={(e) => updatePeriod(index, 'label', e.target.value)}
+                    />
+                    <select
+                      className="form-input school-period-kind"
+                      aria-label="Art"
+                      value={period.kind}
+                      onChange={(e) => updatePeriod(index, 'kind', e.target.value)}
+                    >
+                      <option value="lesson">Stunde</option>
+                      <option value="break">Pause</option>
+                    </select>
+                    <input
+                      className="form-input school-period-time"
+                      type="time"
+                      aria-label="Beginn"
+                      value={normalizeTime(period.start_time)}
+                      onChange={(e) => updatePeriod(index, 'start_time', e.target.value)}
+                    />
+                    <input
+                      className="form-input school-period-time"
+                      type="time"
+                      aria-label="Ende"
+                      value={normalizeTime(period.end_time)}
+                      onChange={(e) => updatePeriod(index, 'end_time', e.target.value)}
+                    />
+                    <button
+                      type="button"
+                      className="school-period-remove"
+                      aria-label="Eintrag entfernen"
+                      onClick={() => removePeriod(index)}
+                    >
+                      <Trash2 size={14} aria-hidden="true" />
+                    </button>
+                  </div>
+                ))}
+                <div className="school-periods-actions">
+                  <button type="button" className="btn-ghost" onClick={() => addPeriod('lesson')}>
+                    <Plus size={14} aria-hidden="true" /> Stunde
+                  </button>
+                  <button type="button" className="btn-ghost" onClick={() => addPeriod('break')}>
+                    <Coffee size={14} aria-hidden="true" /> Pause
+                  </button>
                 </div>
-              ))}
-            </div>
-          </section>
+              </div>
+            </details>
 
-          <section>
-            <h2>{t(messages, 'module.school_timetables.lessons')}</h2>
-            <div className="school-grid" style={{ '--school-columns': visibleWeekdays.length + 1 }}>
-              <div className="school-grid-head">Zeit</div>
-              {visibleWeekdays.map((day) => <div key={day.value} className="school-grid-head">{day.short}</div>)}
-              {lessonPeriods.map((period) => (
-                <div key={`row-${period.position}`} className="school-grid-row-contents">
-                  <div className="school-grid-time"><strong>{period.label}</strong><span>{normalizeTime(period.start_time)}-{normalizeTime(period.end_time)}</span></div>
-                  {visibleWeekdays.map((day) => {
-                    const lesson = lessonMap.get(lessonKey(day.value, Number(period.position)));
-                    return <input key={`${day.value}-${period.position}`} value={lesson?.subject || ''} onChange={(e) => updateLesson(day.value, Number(period.position), e.target.value)} placeholder="Fach" />;
-                  })}
-                </div>
-              ))}
-            </div>
-          </section>
+            {status && <p className="form-status school-form-status" role="status">{status}</p>}
 
-          {status && <p className="form-status">{status}</p>}
-          <div className="button-row">
-            <button type="button" className="btn-primary" onClick={save} disabled={saving}><Save size={16} /> {t(messages, 'module.school_timetables.save')}</button>
-            {selectedId && <button type="button" className="btn-danger" onClick={remove}><Trash2 size={16} /> {t(messages, 'module.school_timetables.delete')}</button>}
-          </div>
-        </main>
-      </div>
+            <div className="school-action-bar">
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={save}
+                disabled={saving}
+              >
+                <Save size={16} aria-hidden="true" /> {t(messages, 'module.school_timetables.save')}
+              </button>
+              {selectedId && (
+                <button type="button" className="btn-danger" onClick={remove}>
+                  <Trash2 size={16} aria-hidden="true" /> {t(messages, 'module.school_timetables.delete')}
+                </button>
+              )}
+            </div>
+          </main>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -3953,5 +3953,706 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .muted-text { color: var(--text-muted); font-size: 0.82rem; margin-top: 2px; }
 @media (max-width: 768px) { .settings-list-item { flex-direction: column; } .settings-row-actions { justify-content: flex-start; } }
 
-/* School timetables */
-.school-layout{display:grid;grid-template-columns:minmax(220px,280px) 1fr;gap:1rem;align-items:start}.school-list-card,.school-editor-card{background:var(--card-bg,#fff);border:1px solid var(--border,#e5e7eb);border-radius:18px;padding:1rem;box-shadow:0 12px 30px rgba(15,23,42,.06)}.school-list-item{display:flex;flex-direction:column;gap:.25rem;width:100%;text-align:left;border:1px solid transparent;border-radius:14px;background:transparent;padding:.75rem;margin-bottom:.5rem;cursor:pointer}.school-list-item.active,.school-list-item:hover{border-color:#8b5cf6;background:#f5f3ff}.school-list-item span,.school-list-item small,.muted{color:#64748b}.form-grid.two{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1rem}.form-grid label,.school-editor-card label{display:flex;flex-direction:column;gap:.35rem;font-weight:600}.form-grid input,.school-period-row input,.school-period-row select,.school-grid input{border:1px solid #d1d5db;border-radius:10px;padding:.55rem}.checkbox-row{display:flex!important;flex-direction:row!important;align-items:center;margin:1rem 0}.school-chip-grid{display:flex;flex-wrap:wrap;gap:.5rem}.school-child-chip{display:flex!important;flex-direction:row!important;align-items:center;border:1px solid #d1d5db;border-radius:999px;padding:.45rem .7rem;background:#fff}.section-row{display:flex;justify-content:space-between;gap:1rem;align-items:center}.school-periods{display:grid;gap:.5rem}.school-period-row{display:grid;grid-template-columns:1fr 130px 120px 120px;gap:.5rem}.school-grid{display:grid;grid-template-columns:130px repeat(var(--school-columns),minmax(110px,1fr));gap:.35rem;overflow:auto}.school-grid-row-contents{display:contents}.school-grid-head,.school-grid-time{font-weight:700;background:#f8fafc;border-radius:10px;padding:.5rem}.school-grid-time{display:flex;flex-direction:column;gap:.1rem}.button-row{display:flex;gap:.75rem;margin-top:1rem}.btn-danger{display:inline-flex;align-items:center;gap:.35rem;border:1px solid #fecaca;background:#fee2e2;color:#991b1b;border-radius:10px;padding:.6rem .8rem}.form-status{color:#475569}.display-school-today{margin-bottom:1rem;padding:.8rem;border:1px solid rgba(148,163,184,.28);border-radius:20px;background:rgba(255,255,255,.08)}.display-school-today-title{display:flex;align-items:center;gap:.45rem;font-weight:800;margin-bottom:.65rem}.display-school-groups{display:grid;gap:.65rem}.display-school-group{border-radius:16px;background:rgba(15,23,42,.08);padding:.65rem}.display-school-group-head{display:flex;justify-content:space-between;gap:.5rem;align-items:center}.display-school-children{display:flex;flex-wrap:wrap;gap:.35rem;margin:.45rem 0}.display-school-child{border-left:4px solid var(--child-color,#8b5cf6);background:rgba(255,255,255,.12);border-radius:999px;padding:.15rem .45rem;font-size:.82rem}.display-school-lessons{display:grid;gap:.3rem;margin:0;padding:0;list-style:none}.display-school-lesson{display:grid;grid-template-columns:95px 1fr;gap:.45rem;font-size:.9rem}.display-school-lesson-time{opacity:.78}.display-school-lesson--break{opacity:.78}@media(max-width:900px){.school-layout,.form-grid.two{grid-template-columns:1fr}.school-period-row{grid-template-columns:1fr 110px 1fr 1fr}}
+/* ═══════════════════════════════════════════
+   School timetables
+   ═══════════════════════════════════════════ */
+
+/* Generic helpers kept for backwards compat with this view */
+.muted { color: var(--text-muted); font-size: 0.85rem; }
+.form-status { color: var(--text-secondary); font-size: 0.88rem; }
+.school-timetables-view .btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border: 1px solid rgba(239, 68, 68, 0.32);
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--danger);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.18s;
+}
+.school-timetables-view .btn-danger:hover {
+  background: rgba(239, 68, 68, 0.14);
+  border-color: var(--danger);
+}
+[data-theme="light"] .school-timetables-view .btn-danger {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+/* Empty state */
+.school-empty-rich {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-2xl) var(--space-md);
+  text-align: center;
+  color: var(--text-secondary);
+}
+.school-empty-icon-wrap {
+  width: 80px;
+  height: 80px;
+  border-radius: var(--radius-pill);
+  background: var(--amethyst-glow);
+  color: var(--amethyst);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.school-empty-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+.school-empty-body {
+  max-width: 460px;
+  margin: 0;
+  line-height: 1.55;
+  font-size: 0.95rem;
+}
+.school-empty-cta {
+  margin-top: var(--space-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Header action */
+.school-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  font-size: 0.92rem;
+}
+
+/* Two-column desktop layout */
+.school-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: var(--space-md);
+  align-items: start;
+}
+
+/* Cards */
+.school-list-card,
+.school-editor-card {
+  background: var(--void-surface);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow: 0 8px 32px -12px rgba(0, 0, 0, 0.35);
+}
+[data-theme="light"] .school-list-card,
+[data-theme="light"] .school-editor-card {
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04), 0 12px 32px -8px rgba(15, 23, 42, 0.08);
+}
+
+/* Editor card stack */
+.school-editor-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+.school-editor-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+.school-section-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.school-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+.school-section-hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+/* Plan list */
+.school-list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: var(--space-md);
+}
+.school-list-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+.school-list-count {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: rgba(120, 130, 180, 0.14);
+  border-radius: var(--radius-pill);
+  padding: 2px 10px;
+  min-width: 28px;
+  text-align: center;
+}
+.school-list-empty { margin: 0 0 var(--space-sm); }
+.school-list-items {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.school-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  color: var(--text-primary);
+  transition: background 0.15s, border-color 0.15s;
+}
+.school-list-item:hover {
+  background: rgba(124, 58, 237, 0.06);
+  border-color: rgba(124, 58, 237, 0.18);
+}
+.school-list-item.active {
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.16), rgba(59, 130, 246, 0.10));
+  border-color: rgba(124, 58, 237, 0.4);
+  box-shadow: 0 4px 16px -8px var(--amethyst-glow);
+}
+.school-list-item-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+.school-list-item-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.school-list-item-class { font-weight: 500; }
+.school-list-item-children { display: inline-flex; align-items: center; }
+.school-list-item-children > * + * { margin-left: -6px; }
+
+/* Meta section */
+.school-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-md);
+}
+.school-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.school-field > span {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Saturday toggle */
+.school-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+  align-self: flex-start;
+}
+.school-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+.school-toggle-track {
+  position: relative;
+  display: inline-block;
+  width: 42px;
+  height: 24px;
+  background: rgba(120, 130, 180, 0.28);
+  border-radius: var(--radius-pill);
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+.school-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s var(--ease-spring);
+}
+.school-toggle input:checked + .school-toggle-track {
+  background: var(--grad-primary);
+}
+.school-toggle input:checked + .school-toggle-track .school-toggle-thumb {
+  transform: translateX(18px);
+}
+.school-toggle input:focus-visible + .school-toggle-track {
+  outline: 2px solid var(--amethyst);
+  outline-offset: 2px;
+}
+.school-toggle-label {
+  font-size: 0.92rem;
+  color: var(--text-primary);
+}
+
+/* Child avatar chips */
+.school-children-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+.school-child-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 14px 5px 5px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9rem;
+  transition: all 0.18s;
+}
+.school-child-chip:hover {
+  border-color: rgba(124, 58, 237, 0.4);
+  background: rgba(124, 58, 237, 0.08);
+}
+.school-child-chip.active {
+  border-color: var(--amethyst);
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.18), rgba(59, 130, 246, 0.10));
+  box-shadow: 0 4px 14px -8px var(--amethyst-glow);
+}
+.school-child-chip-name { font-weight: 500; }
+.school-child-chip-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--amethyst);
+  color: #fff;
+}
+[data-theme="light"] .school-child-chip {
+  background: rgba(255, 255, 255, 0.7);
+}
+
+/* Day pager (mobile-only tabs) */
+.school-day-pager {
+  display: none;
+  gap: 4px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  background: rgba(120, 130, 180, 0.08);
+  padding: 4px;
+  border-radius: var(--radius-md);
+}
+.school-day-tab {
+  flex: 1 1 0;
+  min-width: 48px;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.school-day-tab:hover { color: var(--text-primary); }
+.school-day-tab.active {
+  background: var(--grad-primary);
+  color: var(--text-on-primary);
+  box-shadow: 0 2px 10px -4px var(--amethyst-glow);
+}
+
+/* Desktop classic timetable grid */
+.school-grid {
+  display: grid;
+  grid-template-columns: 120px repeat(var(--school-columns, 5), minmax(110px, 1fr));
+  gap: 0;
+  padding: 0;
+  background: rgba(120, 130, 180, 0.08);
+  border: 1px solid rgba(120, 130, 180, 0.20);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.school-grid-corner { background: transparent; }
+.school-grid-day-head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 10px 8px;
+  border-radius: 0;
+  border-right: 1px solid rgba(120, 130, 180, 0.18);
+  border-bottom: 1px solid rgba(120, 130, 180, 0.18);
+  background: rgba(124, 58, 237, 0.08);
+  text-align: center;
+}
+.school-grid-day-short {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.school-grid-day-full {
+  font-size: 0.7rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/* Row wrappers participate in the parent grid via display:contents */
+.school-grid-row,
+.school-grid-row--break { display: contents; }
+
+.school-grid-time {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 14px;
+  background: rgba(120, 130, 180, 0.10);
+  border-right: 1px solid rgba(120, 130, 180, 0.18);
+  border-bottom: 1px solid rgba(120, 130, 180, 0.18);
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+.school-grid-time-num {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.school-grid-time-range {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.school-grid-time--break { background: rgba(245, 158, 11, 0.10); }
+
+.school-grid-break-bar {
+  grid-column: 2 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 0;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.16), rgba(244, 63, 94, 0.10));
+  color: var(--warning);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 0;
+  border-bottom: 1px solid rgba(245, 158, 11, 0.26);
+}
+
+/* Subject cells — palette tokens come from inline style on the cell */
+.school-cell {
+  --st-bg: rgba(255, 255, 255, 0.02);
+  --st-fg: var(--text-primary);
+  display: flex;
+  background: var(--st-bg);
+  border: 0;
+  border-right: 1px solid rgba(120, 130, 180, 0.16);
+  border-bottom: 1px solid rgba(120, 130, 180, 0.16);
+  border-radius: 0;
+  min-height: 56px;
+  transition: border-color 0.15s, transform 0.15s;
+}
+[data-theme="light"] .school-cell {
+  background: rgba(255, 255, 255, 0.65);
+}
+.school-cell:hover {
+  border-color: rgba(124, 58, 237, 0.32);
+}
+.school-cell--filled {
+  background: var(--st-bg);
+  border-color: transparent;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+.school-cell-input {
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--st-fg);
+  text-align: center;
+}
+.school-cell-input::placeholder {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+.school-cell-input:focus-visible {
+  outline: 2px solid var(--amethyst);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Mobile day list */
+.school-day-list { display: none; }
+.school-day-list-item {
+  --st-bg: rgba(255, 255, 255, 0.03);
+  --st-fg: var(--text-primary);
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--st-bg);
+}
+[data-theme="light"] .school-day-list-item {
+  background: rgba(255, 255, 255, 0.7);
+}
+.school-day-list-item--filled {
+  background: var(--st-bg);
+  border-color: transparent;
+}
+.school-day-list-item--break {
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.12), rgba(244, 63, 94, 0.06));
+  border-color: rgba(245, 158, 11, 0.28);
+  color: var(--warning);
+}
+.school-day-list-time {
+  display: flex;
+  flex-direction: column;
+  font-variant-numeric: tabular-nums;
+}
+.school-day-list-num {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.school-day-list-range {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+.school-day-list-input {
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: left;
+  padding: 12px;
+  color: var(--st-fg);
+  min-height: 44px;
+}
+
+/* Periods configuration (collapsible) */
+.school-periods-config {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: rgba(120, 130, 180, 0.04);
+  padding: 0;
+}
+.school-periods-config > summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 14px 16px;
+  cursor: pointer;
+  font-weight: 600;
+}
+.school-periods-config > summary::-webkit-details-marker { display: none; }
+.school-periods-chevron {
+  transition: transform 0.2s;
+  color: var(--text-muted);
+}
+.school-periods-config[open] .school-periods-chevron { transform: rotate(180deg); }
+.school-periods-config[open] > summary {
+  border-bottom: 1px solid var(--glass-border);
+}
+.school-periods {
+  display: grid;
+  gap: 8px;
+  padding: 14px 16px;
+}
+.school-period-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) 110px 110px 110px 40px;
+  gap: 8px;
+  align-items: center;
+}
+.school-period-row--break .school-period-label {
+  color: var(--warning);
+  font-style: italic;
+}
+.school-period-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.school-period-remove:hover {
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--danger);
+}
+.school-periods-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+/* Status + action bar */
+.school-form-status {
+  margin: 0;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: rgba(120, 130, 180, 0.08);
+  border: 1px solid var(--glass-border);
+}
+.school-action-bar {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--glass-border);
+}
+
+/* Display dashboard "school today" — preserved from previous styles */
+.display-school-today {
+  margin-bottom: 1rem;
+  padding: 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.08);
+}
+.display-school-today-title {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 800;
+  margin-bottom: 0.65rem;
+}
+.display-school-groups { display: grid; gap: 0.65rem; }
+.display-school-group {
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.65rem;
+}
+.display-school-group-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: center;
+}
+.display-school-children {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.45rem 0;
+}
+.display-school-child {
+  border-left: 4px solid var(--child-color, #8b5cf6);
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.82rem;
+}
+.display-school-lessons {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.display-school-lesson {
+  display: grid;
+  grid-template-columns: 95px 1fr;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+}
+.display-school-lesson-time { opacity: 0.78; }
+.display-school-lesson--break { opacity: 0.78; }
+
+/* Mobile (< 760px): stack layout, hide desktop grid, show day pager + list */
+@media (max-width: 760px) {
+  .school-layout {
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+  }
+  .school-list-card,
+  .school-editor-card {
+    padding: var(--space-md);
+  }
+  .school-editor-card {
+    margin-bottom: calc(88px + env(safe-area-inset-bottom));
+  }
+  .school-meta-grid { grid-template-columns: 1fr; }
+  .school-grid { display: none; }
+  .school-day-pager { display: flex; }
+  .school-day-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .school-period-row {
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .school-period-label { grid-column: 1 / -1; }
+  .school-period-remove {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+  .school-action-bar > * {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- Restyles the school timetable editor into a classic weekly timetable grid on desktop.
- Replaces the squeezed mobile table with day tabs and stacked lesson cards.
- Moves period and break setup into a secondary accordion and keeps destructive styling scoped to the timetable view.

## Validation
- `node --check frontend/components/SchoolTimetablesView.js`
- `npm test -- --runInBand __tests__/components/DisplayDashboard.test.js __tests__/lib/i18n.test.js __tests__/components/NavigationTab.test.js` — 3 suites, 45 tests passed
- `npm run build`
- Browser screenshot check for desktop and mobile timetable editor layouts
- Review pass after blocker fixes

Closes #308
