### PR TITLE
Fix weekly plan dark theme contrast

### DIFF
--- a/frontend/__tests__/components/WeeklyPlanView.test.js
+++ b/frontend/__tests__/components/WeeklyPlanView.test.js
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import fs from 'fs';
+import path from 'path';
 import WeeklyPlanView, { buildWeeklyPlanSections, getWeekRange } from '../../components/WeeklyPlanView';
 import { apiGetEvents } from '../../lib/api';
 
@@ -181,5 +183,27 @@ describe('WeeklyPlanView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Back to dashboard' }));
     expect(setActiveView).toHaveBeenCalledWith('dashboard');
     expect(screen.queryByRole('link', { name: /share/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('weekly plan theme CSS contract', () => {
+  it('keeps print-card surfaces paired with readable foreground tokens in every app theme', () => {
+    const css = fs.readFileSync(path.join(process.cwd(), 'styles', 'globals.css'), 'utf8');
+    const weeklyPlanStart = css.indexOf('/* ─── Weekly plan print view ─── */');
+    const weeklyPlanEnd = css.indexOf('/* ─── Dashboard activation panel ─── */');
+
+    expect(weeklyPlanStart).toBeGreaterThanOrEqual(0);
+    expect(weeklyPlanEnd).toBeGreaterThan(weeklyPlanStart);
+
+    const weeklyCss = css.slice(weeklyPlanStart, weeklyPlanEnd);
+
+    expect(weeklyCss).toContain('--weekly-plan-surface: #ffffff');
+    expect(weeklyCss).toContain('--weekly-plan-text-primary: #1a1520');
+    expect(weeklyCss).toContain('--weekly-plan-text-secondary: #5e5673');
+    expect(weeklyCss).toContain('background: var(--weekly-plan-surface)');
+    expect(weeklyCss).toContain('color: var(--weekly-plan-text-primary)');
+    expect(weeklyCss).toContain('color: var(--weekly-plan-text-secondary)');
+    expect(weeklyCss).not.toContain('.weekly-plan-section li strong { color: var(--text-primary);');
+    expect(weeklyCss).not.toContain('.weekly-plan-section li span { color: var(--text-secondary);');
   });
 });

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -2,6 +2,26 @@ const { test, expect } = require('../helpers/fixtures');
 const { getFamilyId, seedCalendarEvent, seedTask } = require('../helpers/api-setup');
 const { navigateTo } = require('../helpers/navigation');
 
+function parseRgb(value) {
+  const match = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) throw new Error(`Unsupported color value: ${value}`);
+  return match.slice(1, 4).map(Number);
+}
+
+function relativeLuminance([r, g, b]) {
+  const [rs, gs, bs] = [r, g, b].map((channel) => {
+    const value = channel / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return (0.2126 * rs) + (0.7152 * gs) + (0.0722 * bs);
+}
+
+function contrastRatio(foreground, background) {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
 test.describe('Dashboard', () => {
   test('shows greeting with username', async ({ authedPage: page, testUser }) => {
     const greeting = page.locator('.view-title');
@@ -143,5 +163,53 @@ test.describe('Dashboard', () => {
     await page.getByRole('button', { name: 'Reset layout' }).click();
     await expect(page.locator('[data-dashboard-module="events"]')).toHaveCSS('order', '2');
     await expect(page.locator('[data-dashboard-module="tasks"]')).toHaveCSS('order', '3');
+  });
+
+  test('keeps weekly plan cards and filters readable in all themes', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    await seedCalendarEvent(apiCtx, familyId, { title: 'Weekly contrast event' });
+    await seedTask(apiCtx, familyId, { title: 'Weekly contrast task' });
+
+    for (const theme of ['light', 'dark', 'midnight-glass']) {
+      await page.evaluate((themeKey) => {
+        window.localStorage.setItem('tribu_theme', themeKey);
+      }, theme);
+      await page.reload();
+      await expect(page.locator('html')).toHaveAttribute('data-theme', theme, { timeout: 10000 });
+      await page.locator('#main-content').waitFor({ timeout: 15000 });
+      await page.getByTestId('quick-action-weekly-plan').click();
+      await expect(page.getByRole('heading', { name: 'Weekly plan' })).toBeVisible({ timeout: 10000 });
+
+      const checks = await page.evaluate(() => {
+        const selectors = [
+          '.weekly-plan-header h1',
+          '.weekly-plan-header p',
+          '.weekly-plan-member-filter span',
+          '.weekly-plan-member-filter select',
+          '.weekly-plan-section-filters label',
+          '.weekly-plan-section h2',
+          '.weekly-plan-section li strong',
+          '.weekly-plan-section li span',
+        ];
+        return selectors.map((selector) => {
+          const element = document.querySelector(selector);
+          const surface = element?.closest('.weekly-plan-header, .weekly-plan-section li, .weekly-plan-section, .weekly-plan-filters') || element;
+          const elementStyle = window.getComputedStyle(element);
+          const surfaceStyle = window.getComputedStyle(surface);
+          return {
+            selector,
+            color: elementStyle.color,
+            backgroundColor: surfaceStyle.backgroundColor,
+          };
+        });
+      });
+
+      for (const check of checks) {
+        expect(check.color, `${theme} ${check.selector} color`).toBeTruthy();
+        expect(check.backgroundColor, `${theme} ${check.selector} background`).toBeTruthy();
+        const ratio = contrastRatio(parseRgb(check.color), parseRgb(check.backgroundColor));
+        expect(ratio, `${theme} ${check.selector} contrast`).toBeGreaterThanOrEqual(4.5);
+      }
+    }
   });
 });

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2455,28 +2455,29 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 }
 
 /* ─── Weekly plan print view ─── */
-.weekly-plan-page { max-width: 1120px; margin: 0 auto; padding: var(--space-xl); color: var(--text-primary); }
+.weekly-plan-page { --weekly-plan-surface: #ffffff; --weekly-plan-surface-soft: #f6f3fb; --weekly-plan-text-primary: #1a1520; --weekly-plan-text-secondary: #5e5673; --weekly-plan-border: rgba(26, 21, 32, 0.12); --weekly-plan-shadow: 0 14px 36px -24px rgba(26, 21, 32, 0.45); max-width: 1120px; margin: 0 auto; padding: var(--space-xl); color: var(--weekly-plan-text-primary); }
 .weekly-plan-toolbar { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); margin-bottom: var(--space-lg); flex-wrap: wrap; }
 .weekly-plan-nav { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
 .weekly-plan-toolbar button { display: inline-flex; align-items: center; gap: var(--space-xs); }
-.weekly-plan-filters { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); margin: 0 0 var(--space-lg); padding: var(--space-md); border: 1px solid var(--border); border-radius: var(--radius-lg); background: rgba(255, 255, 255, 0.78); box-shadow: var(--shadow-sm); flex-wrap: wrap; }
-.weekly-plan-member-filter { display: inline-flex; align-items: center; gap: var(--space-sm); color: var(--text-secondary); font-size: 0.9rem; }
-.weekly-plan-member-filter select { min-width: 170px; border: 1px solid var(--border); border-radius: var(--radius-md); background: #fff; color: var(--text-primary); padding: 0.55rem 0.7rem; font: inherit; }
+.weekly-plan-filters { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); margin: 0 0 var(--space-lg); padding: var(--space-md); border: 1px solid var(--weekly-plan-border); border-radius: var(--radius-lg); background: rgba(255, 255, 255, 0.92); box-shadow: var(--weekly-plan-shadow); flex-wrap: wrap; color: var(--weekly-plan-text-primary); }
+.weekly-plan-member-filter { display: inline-flex; align-items: center; gap: var(--space-sm); color: var(--weekly-plan-text-secondary); font-size: 0.9rem; }
+.weekly-plan-member-filter select { min-width: 170px; border: 1px solid var(--weekly-plan-border); border-radius: var(--radius-md); background: var(--weekly-plan-surface); color: var(--weekly-plan-text-primary); padding: 0.55rem 0.7rem; font: inherit; color-scheme: light; }
+.weekly-plan-member-filter select option { background: var(--weekly-plan-surface); color: var(--weekly-plan-text-primary); }
 .weekly-plan-section-filters { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
-.weekly-plan-section-filters label { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.45rem 0.7rem; border-radius: var(--radius-pill); background: var(--surface-muted); color: var(--text-secondary); font-size: 0.86rem; cursor: pointer; }
+.weekly-plan-section-filters label { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.45rem 0.7rem; border-radius: var(--radius-pill); background: var(--weekly-plan-surface-soft); color: var(--weekly-plan-text-secondary); font-size: 0.86rem; cursor: pointer; border: 1px solid rgba(26, 21, 32, 0.07); }
 .weekly-plan-section-filters input { accent-color: var(--amethyst); }
-.weekly-plan-header { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-xl); padding: var(--space-xl); margin-bottom: var(--space-lg); box-shadow: var(--shadow-sm); }
-.weekly-plan-header h1 { margin: 0 0 var(--space-xs); font-size: clamp(2rem, 5vw, 3.3rem); letter-spacing: -0.045em; }
-.weekly-plan-header p { margin: 0 0 var(--space-md); color: var(--text-secondary); max-width: 720px; }
-.weekly-plan-header strong { font-size: 1.1rem; }
+.weekly-plan-header { background: var(--weekly-plan-surface); color: var(--weekly-plan-text-primary); border: 1px solid var(--weekly-plan-border); border-radius: var(--radius-xl); padding: var(--space-xl); margin-bottom: var(--space-lg); box-shadow: var(--weekly-plan-shadow); }
+.weekly-plan-header h1 { margin: 0 0 var(--space-xs); font-size: clamp(2rem, 5vw, 3.3rem); letter-spacing: -0.045em; color: var(--weekly-plan-text-primary); }
+.weekly-plan-header p { margin: 0 0 var(--space-md); color: var(--weekly-plan-text-secondary); max-width: 720px; }
+.weekly-plan-header strong { font-size: 1.1rem; color: var(--weekly-plan-text-primary); }
 .weekly-plan-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-lg); align-items: start; }
-.weekly-plan-section { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--space-lg); box-shadow: var(--shadow-sm); break-inside: avoid; }
-.weekly-plan-section h2 { display: flex; align-items: center; gap: var(--space-xs); margin: 0 0 var(--space-md); font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-secondary); }
+.weekly-plan-section { background: var(--weekly-plan-surface); color: var(--weekly-plan-text-primary); border: 1px solid var(--weekly-plan-border); border-radius: var(--radius-lg); padding: var(--space-lg); box-shadow: var(--weekly-plan-shadow); break-inside: avoid; }
+.weekly-plan-section h2 { display: flex; align-items: center; gap: var(--space-xs); margin: 0 0 var(--space-md); font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--weekly-plan-text-secondary); }
 .weekly-plan-section ul { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-sm); }
-.weekly-plan-section li { display: grid; gap: 0.15rem; padding: var(--space-sm); border-radius: var(--radius-md); background: var(--surface-muted); }
-.weekly-plan-section li span { color: var(--text-secondary); font-size: 0.84rem; }
-.weekly-plan-section li strong { color: var(--text-primary); font-weight: 650; }
-.weekly-plan-empty { margin: 0; color: var(--text-secondary); }
+.weekly-plan-section li { display: grid; gap: 0.15rem; padding: var(--space-sm); border-radius: var(--radius-md); background: var(--weekly-plan-surface-soft); }
+.weekly-plan-section li span { color: var(--weekly-plan-text-secondary); font-size: 0.84rem; }
+.weekly-plan-section li strong { color: var(--weekly-plan-text-primary); font-weight: 650; }
+.weekly-plan-empty { margin: 0; color: var(--weekly-plan-text-secondary); }
 @media (max-width: 760px) { .weekly-plan-page { padding: var(--space-md); } .weekly-plan-grid { grid-template-columns: 1fr; } }
 @media print { body { background: #fff !important; } .no-print, .pwa-banner, .sidebar, .mobile-header, .mobile-topbar, .bottom-nav, .app-sidebar, .app-header { display: none !important; } .app-layout, .main-content, .weekly-plan-page { display: block !important; width: 100% !important; max-width: none !important; padding: 0 !important; margin: 0 !important; background: #fff !important; } .weekly-plan-header, .weekly-plan-section { box-shadow: none !important; border-color: #d4d4d8 !important; } .weekly-plan-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; } }
 


### PR DESCRIPTION
## Summary
- Fixes Weekly plan cards, filters, list items, and select controls so they stay readable in dark and midnight-glass themes.
- Keeps the Weekly plan print surface on stable light-card colors instead of inheriting dark-theme text tokens.
- Adds regression coverage for the CSS contract and browser-computed contrast across light, dark, and midnight-glass themes.

## Tests
- `npm test -- --runTestsByPath __tests__/components/WeeklyPlanView.test.js --runInBand`
- `BASE_URL=http://localhost:3000 npm run e2e -- --grep "keeps weekly plan cards and filters readable in all themes"`
- `npm test -- --runInBand`
- `npm run build`
- `BASE_URL=http://localhost:3000 npm run e2e`

Closes #310
