### PR TITLE
Keep task locale modules trackable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ node_modules/
 .internal/
 
 # Agent memory (session context)
-tasks/
+/tasks/
 
 # Playwright
 e2e/test-results/

--- a/frontend/__tests__/lib/i18n.test.js
+++ b/frontend/__tests__/lib/i18n.test.js
@@ -1,3 +1,4 @@
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -48,7 +49,23 @@ describe('i18n no empty strings', () => {
 
 const expectedLanguages = ['de', 'en', 'es', 'fr', 'it', 'nl', 'pl', 'pt'];
 
+const projectRoot = path.join(process.cwd(), '..');
 const i18nRoot = path.join(process.cwd(), 'i18n');
+
+function gitIgnoreRule(relativePath) {
+  try {
+    return execFileSync('git', ['check-ignore', '-v', relativePath], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    if (error.status === 1) {
+      return '';
+    }
+    throw error;
+  }
+}
 const englishLocaleFiles = fs
   .readdirSync(i18nRoot, { recursive: true })
   .filter((file) => file.endsWith('/en.json'))
@@ -75,6 +92,11 @@ function protectedLiteralSet(value) {
 }
 
 describe('i18n language pack completeness', () => {
+  it('keeps the task module locale directory trackable by git', () => {
+    expect(gitIgnoreRule('frontend/i18n/modules/tasks/sv.json')).toBe('');
+    expect(gitIgnoreRule('tasks/session.json')).toContain('/tasks/');
+  });
+
   it('ships every English locale file for every supported language', () => {
     for (const enFile of englishLocaleFiles) {
       for (const lang of expectedLanguages) {

--- a/frontend/e2e/tests/recipes.spec.js
+++ b/frontend/e2e/tests/recipes.spec.js
@@ -61,6 +61,7 @@ test.describe('Recipes', () => {
     await expect(page.locator('.recipe-scale-preview').getByText('400 g')).toBeVisible();
     await expect(page.locator('.recipe-scale-preview').getByText('600 ml')).toBeVisible();
     await expect(page.getByRole('dialog', { name: 'Edit recipe' })).toBeVisible();
+    await page.locator('.recipe-push-list').selectOption({ label: 'Recipe Shopping List' });
     await page.locator('.recipe-push-btn').click();
     await expect(page.getByLabel('Notifications').getByText('2 ingredients pushed to the shopping list')).toBeVisible({ timeout: 10000 });
     await page.locator('.recipe-form-actions-right').getByRole('button', { name: 'Cancel' }).click();


### PR DESCRIPTION
## Summary

- Narrows the root task/session ignore rule so nested product paths named `tasks` remain trackable.
- Adds an i18n regression guard for future task-module locale files.
- Stabilizes the recipes browser test by selecting the intended shopping list before pushing ingredients.

## Tests

- `git diff --check`
- `git check-ignore -v frontend/i18n/modules/tasks/sv.json`
- `git check-ignore -v tasks/session.json`
- `npm test -- --runTestsByPath __tests__/lib/i18n.test.js --runInBand`
- `npm test -- --runInBand`
- `npm run build`
- `BASE_URL=http://localhost:3014 npm run e2e -- e2e/tests/recipes.spec.js --project "Mobile Chrome" --grep "create a recipe"`
- `BASE_URL=http://localhost:3014 npm run e2e`
- clean `git archive HEAD` frontend build

Closes #314
