### PR TITLE
Restrict E2E workflow permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   POSTGRES_PASSWORD: testpassword
   JWT_SECRET: e2e-test-secret-key

--- a/tests/test_workflow_permissions.py
+++ b/tests/test_workflow_permissions.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOWS = Path('.github/workflows')
+
+
+def test_e2e_workflow_declares_read_only_permissions():
+    workflow_text = (WORKFLOWS / 'e2e.yml').read_text()
+    workflow = yaml.safe_load(workflow_text)
+
+    assert workflow['permissions'] == {'contents': 'read'}
+    assert workflow_text.index('\npermissions:\n') < workflow_text.index('\njobs:\n')


### PR DESCRIPTION
## Summary
- Restrict the E2E workflow token to read-only repository contents
- Add a workflow regression test that keeps the E2E permissions explicit and least-privilege

## Verification
- backend/.venv/bin/python -m pytest tests/test_workflow_permissions.py tests/test_docker_workflow.py -q
- /tmp/actionlint-tribu/actionlint .github/workflows/e2e.yml
- git diff --check

Fixes code scanning alert #18.
