### PR TITLE
Fix Settings language pack layout overflow

### DIFF
--- a/frontend/components/settings/AccountTab.js
+++ b/frontend/components/settings/AccountTab.js
@@ -179,12 +179,14 @@ export default function AccountTab() {
       </div>
 
       {/* Language */}
-      <div className="settings-section">
+      <div className="settings-section language-settings-section">
         <div className="settings-section-title"><Globe size={16} /> {t(messages, 'language')}</div>
-        <div className="lang-toggle">
+        <div className="lang-toggle" role="group" aria-label={t(messages, 'language')}>
           {availableLanguages.map((l) => (
             <button
               key={l.key}
+              type="button"
+              aria-pressed={lang === l.key}
               className={`lang-btn${lang === l.key ? ' active' : ''}`}
               onClick={() => setLang(l.key)}
             >

--- a/frontend/e2e/tests/settings.spec.js
+++ b/frontend/e2e/tests/settings.spec.js
@@ -54,9 +54,28 @@ test.describe('Settings', () => {
       'Gaeilge',
     ]);
 
-    await languageButtons.filter({ hasText: 'Svenska' }).click({ force: true });
+    async function expectLanguageSectionContained() {
+      const metrics = await page.evaluate(() => ({
+        documentWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+        viewportWidth: document.documentElement.clientWidth,
+        languageSectionWidth: document.querySelector('.language-settings-section')?.getBoundingClientRect().width ?? 0,
+        settingsGridWidth: document.querySelector('.settings-grid')?.getBoundingClientRect().width ?? 0,
+        languageToggleWidth: document.querySelector('.lang-toggle')?.getBoundingClientRect().width ?? 0,
+      }));
+      expect(metrics.documentWidth).toBeLessThanOrEqual(metrics.viewportWidth + 1);
+      expect(metrics.languageSectionWidth).toBeLessThanOrEqual(metrics.settingsGridWidth + 1);
+      expect(metrics.languageToggleWidth).toBeLessThanOrEqual(metrics.languageSectionWidth + 1);
+    }
+
+    await expectLanguageSectionContained();
+
+    const swedishButton = languageButtons.filter({ hasText: 'Svenska' });
+    await expect(swedishButton).toBeVisible();
+    await swedishButton.click();
     await expect(page.locator('.settings-section-title', { hasText: 'Språk' })).toBeVisible();
     await expect(page.locator('.lang-toggle .lang-btn.active')).toHaveText('Svenska');
+
+    await expectLanguageSectionContained();
   });
 
   test('switch theme and verify data-theme attribute', async ({ authedPage: page }) => {

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1328,8 +1328,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
    SETTINGS
    ═══════════════════════════════════════════ */
 /* Layout */
-.settings-layout { display: grid; grid-template-columns: 220px 1fr; gap: var(--space-lg); max-width: 900px; }
-.settings-sidebar { position: sticky; top: var(--space-md); align-self: start; display: flex; flex-direction: column; gap: 2px; }
+.settings-layout { display: grid; grid-template-columns: minmax(180px, 220px) minmax(0, 1fr); gap: var(--space-lg); max-width: min(900px, 100%); min-width: 0; }
+.settings-sidebar { position: sticky; top: var(--space-md); align-self: start; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .settings-sidebar-group { font-size: 0.68rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; padding: 12px 12px 4px; }
 .settings-sidebar-item { display: flex; align-items: center; gap: 10px; padding: 10px 12px; border-radius: var(--radius-sm); border: none; background: transparent; color: var(--text-secondary); font-family: inherit; font-size: 0.88rem; font-weight: 500; cursor: pointer; transition: all 0.15s; width: 100%; text-align: left; }
 .settings-sidebar-item:hover { background: rgba(124, 58, 237, 0.06); color: var(--text-primary); }
@@ -1357,8 +1357,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .admin-sidebar .settings-sidebar-item { width: auto; }
 }
 /* Section cards */
-.settings-grid { display: grid; gap: var(--space-md); max-width: 640px; }
-.settings-section { padding: var(--space-lg); border-radius: var(--radius-lg); }
+.settings-grid { display: grid; gap: var(--space-md); max-width: min(640px, 100%); min-width: 0; }
+.settings-section { padding: var(--space-lg); border-radius: var(--radius-lg); min-width: 0; max-width: 100%; }
 .settings-section:not(.glass):not(.glass-sm) { background: var(--void-surface); border: 1px solid var(--glass-border); }
 .settings-section-title { font-size: 0.78rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: var(--space-md); display: flex; align-items: center; gap: 8px; }
 .settings-divider { height: 1px; background: var(--glass-border); margin: var(--space-sm) 0; }
@@ -1381,8 +1381,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .theme-item-info { flex: 1; }
 .theme-item-name { font-weight: 500; font-size: 0.9rem; }
 .theme-item-desc { font-size: 0.75rem; color: var(--text-muted); }
-.lang-toggle { display: flex; gap: var(--space-sm); }
-.lang-btn { padding: 9px 20px; border-radius: var(--radius-sm); border: 1px solid var(--glass-border); background: transparent; color: var(--text-secondary); font-family: inherit; font-size: 0.88rem; font-weight: 500; cursor: pointer; transition: all 0.2s; }
+.lang-toggle { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(9rem, 100%), 1fr)); gap: var(--space-sm); max-width: 100%; min-width: 0; }
+.lang-btn { width: 100%; min-width: 0; min-height: 40px; padding: 8px 12px; border-radius: var(--radius-sm); border: 1px solid var(--glass-border); background: transparent; color: var(--text-secondary); font-family: inherit; font-size: 0.84rem; font-weight: 500; cursor: pointer; transition: all 0.2s; white-space: normal; overflow-wrap: anywhere; line-height: 1.2; }
 .lang-btn.active { background: var(--amethyst); color: white; border-color: var(--amethyst); }
 .token-display { font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; background: rgba(0,0,0,0.2); padding: 8px 12px; border-radius: var(--radius-sm); word-break: break-all; flex: 1; display: block; }
 
@@ -1723,15 +1723,16 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 /* ═══════════════════════════════════════════
    PACK REGISTRY (Theme & Language)
    ═══════════════════════════════════════════ */
-.pack-list { display: grid; gap: 6px; }
-.pack-card { padding: 12px 14px; }
-.pack-card-header { display: flex; align-items: center; gap: var(--space-sm); margin-bottom: 4px; }
-.pack-card-name { font-weight: 500; font-size: 0.9rem; }
+.pack-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr)); gap: 8px; min-width: 0; }
+.pack-card { padding: 12px 14px; min-width: 0; }
+.pack-card-header { display: flex; align-items: center; gap: var(--space-sm); margin-bottom: 4px; min-width: 0; flex-wrap: wrap; }
+.pack-card-name { font-weight: 500; font-size: 0.9rem; min-width: 0; overflow-wrap: anywhere; }
 .pack-badge { font-size: 0.68rem; font-weight: 600; padding: 2px 8px; border-radius: var(--radius-pill); background: rgba(124, 58, 237, 0.1); color: var(--amethyst); font-family: 'JetBrains Mono', monospace; }
-.pack-meta { display: flex; gap: var(--space-md); font-size: 0.75rem; color: var(--text-muted); font-family: 'JetBrains Mono', monospace; }
-.pack-progress-row { display: flex; align-items: center; gap: var(--space-sm); margin-top: 8px; }
-.pack-progress-label { font-size: 0.72rem; color: var(--text-muted); flex-shrink: 0; }
-.pack-progress { flex: 1; height: 6px; background: rgba(255, 255, 255, 0.06); border-radius: 3px; overflow: hidden; }
+.pack-meta { display: flex; flex-wrap: wrap; gap: 4px var(--space-md); min-width: 0; font-size: 0.75rem; color: var(--text-muted); font-family: 'JetBrains Mono', monospace; }
+.pack-meta span { min-width: 0; overflow-wrap: anywhere; }
+.pack-progress-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: var(--space-sm); margin-top: 8px; min-width: 0; }
+.pack-progress-label { font-size: 0.72rem; color: var(--text-muted); }
+.pack-progress { min-width: 0; height: 6px; background: rgba(255, 255, 255, 0.06); border-radius: 3px; overflow: hidden; }
 .pack-progress-fill { height: 100%; background: var(--grad-primary); border-radius: 3px; transition: width 0.3s var(--ease-out-expo); }
 .pack-progress-value { font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; color: var(--text-secondary); flex-shrink: 0; min-width: 32px; text-align: right; }
 


### PR DESCRIPTION
## Summary
- Keep the 24-language selector contained with a responsive chip grid.
- Make installed pack cards denser and bounded on desktop and mobile.
- Add overflow regression coverage for the Settings language section before and after switching languages.

## Verification
- `npm test -- --runInBand --runTestsByPath __tests__/lib/i18n.test.js`
- `npm test -- --runInBand --runTestsByPath __tests__/components/NavigationTab.test.js`
- `npm run build`
- `BASE_URL=http://localhost:3019 npm run e2e -- e2e/tests/settings.spec.js --grep "full language pack" --project "Desktop Chrome" --project "Mobile Chrome"`
- `BASE_URL=http://localhost:3019 npm run e2e`
- `git diff --check`

Closes #319.
