### PR TITLE
Improve mobile shopping UX

### DIFF
--- a/frontend/__tests__/components/ShoppingView.test.js
+++ b/frontend/__tests__/components/ShoppingView.test.js
@@ -30,6 +30,8 @@ const messages = {
   'module.shopping.no_lists': 'No shopping lists yet',
   'module.shopping.templates': 'Templates',
   'module.shopping.new_template': 'New template',
+  'module.shopping.show_templates': 'Show templates',
+  'module.shopping.hide_templates': 'Hide templates',
   'module.shopping.template_name_placeholder': 'e.g. Weekly groceries',
   'module.shopping.template_item_name_placeholder': 'Template item',
   'module.shopping.template_item_spec_placeholder': 'Amount/details',
@@ -46,7 +48,7 @@ const messages = {
   'aria.add_item': 'Add item',
 };
 
-function setup(overrides = {}) {
+function setup(overrides = {}, appOverrides = {}) {
   mockAppState = {
     familyId: '1',
     families: [{ family_id: 1, family_name: 'Test Family' }],
@@ -54,6 +56,7 @@ function setup(overrides = {}) {
     messages,
     isMobile: false,
     isChild: false,
+    ...appOverrides,
   };
   mockShoppingState = {
     shoppingLists: [{ id: 10, name: 'Groceries', item_count: 0, checked_count: 0 }],
@@ -174,4 +177,60 @@ describe('ShoppingView templates', () => {
 
     await waitFor(() => expect(mockShoppingState.updateTemplate).toHaveBeenCalledWith(5, expect.objectContaining({ name: 'Weekly restock' })));
   });
+});
+
+
+describe('ShoppingView mobile store flow', () => {
+  test('keeps templates collapsed by default on mobile and expands them for planning', () => {
+    const { rerender } = setup({}, { isMobile: true });
+
+    expect(screen.getByRole('heading', { name: 'Templates' })).toBeInTheDocument();
+    expect(screen.queryByText('Weekly groceries')).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: 'Show templates' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole('button', { name: 'Hide templates' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Weekly groceries')).toBeInTheDocument();
+
+    const itemsPanel = document.querySelector('.shopping-items-panel');
+    const templatesPanel = document.querySelector('.shopping-templates-panel');
+    expect(itemsPanel.compareDocumentPosition(templatesPanel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    rerender(<ShoppingView />);
+    expect(screen.getByText('Weekly groceries')).toBeInTheDocument();
+  });
+
+  test('blurs the quick-add input when checking items on mobile', () => {
+    setup({
+      uncheckedItems: [{ id: 1, name: 'Apples', spec: '6', category: 'Produce', checked: false }],
+      checkedItems: [],
+      items: [{ id: 1, name: 'Apples', spec: '6', category: 'Produce', checked: false }],
+    }, { isMobile: true });
+
+    const input = screen.getByPlaceholderText('Add an item...');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const item = screen.getByRole('checkbox', { name: 'Apples' });
+    fireEvent.pointerDown(item);
+    fireEvent.click(item);
+
+    expect(document.activeElement).not.toBe(input);
+    expect(mockShoppingState.toggleItem).toHaveBeenCalledWith(1, false);
+  });
+});
+
+
+test('mobile template toggle closes an open template form when hiding templates', () => {
+  setup({}, { isMobile: true });
+
+  fireEvent.click(screen.getByRole('button', { name: 'Show templates' }));
+  fireEvent.click(screen.getByRole('button', { name: 'New template' }));
+  expect(screen.getByPlaceholderText('e.g. Weekly groceries')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Hide templates' }));
+  expect(screen.queryByPlaceholderText('e.g. Weekly groceries')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Show templates' })).toHaveAttribute('aria-expanded', 'false');
 });

--- a/frontend/__tests__/contexts/AppContext.test.js
+++ b/frontend/__tests__/contexts/AppContext.test.js
@@ -6,12 +6,13 @@ import * as api from '../../lib/api';
 jest.mock('../../lib/api');
 
 function Probe() {
-  const { loading, loggedIn, familyId } = useApp();
+  const { loading, loggedIn, familyId, isMobile } = useApp();
   return (
     <div>
       <span data-testid="loading">{loading ? 'loading' : 'ready'}</span>
       <span data-testid="logged-in">{loggedIn ? 'yes' : 'no'}</span>
       <span data-testid="family-id">{familyId}</span>
+      <span data-testid="is-mobile">{isMobile ? 'mobile' : 'desktop'}</span>
     </div>
   );
 }
@@ -51,6 +52,18 @@ describe('AppProvider bootstrap', () => {
     api.apiGetUnreadCount.mockResolvedValue({ ok: true, data: { count: 0 } });
     api.apiGetNotifications.mockResolvedValue({ ok: true, data: [] });
     api.connectNotificationStream.mockReturnValue({ close: jest.fn() });
+  });
+
+  test('treats the 768px CSS breakpoint as mobile runtime state', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 768 });
+
+    render(
+      <AppProvider>
+        <Probe />
+      </AppProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('is-mobile')).toHaveTextContent('mobile'));
   });
 
   test('does not keep the app shell blocked by slow secondary data loaders', async () => {

--- a/frontend/components/ShoppingView.js
+++ b/frontend/components/ShoppingView.js
@@ -60,6 +60,14 @@ function ShoppingCategoryGroup({ group, collapsed, onToggle, children }) {
   );
 }
 
+function blurActiveTextInput() {
+  if (typeof document === 'undefined') return;
+  const active = document.activeElement;
+  if (active && ['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName)) {
+    active.blur();
+  }
+}
+
 function ShoppingItem({ item, checked, members, messages, onToggle, onDelete }) {
   const addedBy = members.find((m) => m.user_id === item.added_by_user_id);
   const memberIdx = addedBy ? members.indexOf(addedBy) : 0;
@@ -78,6 +86,7 @@ function ShoppingItem({ item, checked, members, messages, onToggle, onDelete }) 
       aria-checked={checked}
       aria-label={item.name}
       tabIndex={0}
+      onPointerDown={blurActiveTextInput}
       onClick={() => onToggle(item.id, item.checked)}
       onKeyDown={handleKeyDown}
     >
@@ -247,9 +256,14 @@ export default function ShoppingView() {
   const [confirmAction, setConfirmAction] = useState(null);
   const [showTemplateForm, setShowTemplateForm] = useState(false);
   const [editingTemplate, setEditingTemplate] = useState(null);
+  const [templatesExpanded, setTemplatesExpanded] = useState(false);
   const [collapsedCategories, setCollapsedCategories] = useState({});
   const itemSuggestions = Array.from(new Set((sh.items || []).map((item) => item.name).filter(Boolean))).sort((a, b) => a.localeCompare(b));
   const uncheckedGroups = groupItemsByCategory(sh.uncheckedItems, messages);
+  const templatesVisible = !isMobile || templatesExpanded || showTemplateForm;
+  const templatesToggleLabel = templatesVisible
+    ? t(messages, 'module.shopping.hide_templates')
+    : t(messages, 'module.shopping.show_templates');
 
   function toggleCategory(category) {
     setCollapsedCategories((prev) => ({ ...prev, [category]: !prev[category] }));
@@ -257,6 +271,7 @@ export default function ShoppingView() {
 
   function openTemplateForm(template = null) {
     setEditingTemplate(template);
+    setTemplatesExpanded(true);
     setShowTemplateForm(true);
   }
 
@@ -368,18 +383,35 @@ export default function ShoppingView() {
         </div>
 
         {/* Templates Panel */}
-        {!isChild && (
+        {!isChild && !isMobile && (
           <section className="shopping-templates-panel" aria-label={t(messages, 'module.shopping.templates')}>
             <div className="shopping-templates-header">
               <h2>{t(messages, 'module.shopping.templates')}</h2>
-              <button
-                className="shopping-add-list-btn"
-                type="button"
-                onClick={() => openTemplateForm()}
-              >
-                <Plus size={16} aria-hidden="true" />
-                <span>{t(messages, 'module.shopping.new_template')}</span>
-              </button>
+              <div className="shopping-templates-actions">
+                {isMobile && (
+                  <button
+                    className="btn-ghost shopping-template-toggle"
+                    type="button"
+                    aria-expanded={templatesVisible}
+                    onClick={() => {
+                      if (templatesVisible) closeTemplateForm();
+                      setTemplatesExpanded((prev) => !prev);
+                    }}
+                  >
+                    {templatesToggleLabel}
+                  </button>
+                )}
+                {templatesVisible && (
+                  <button
+                    className="shopping-add-list-btn"
+                    type="button"
+                    onClick={() => openTemplateForm()}
+                  >
+                    <Plus size={16} aria-hidden="true" />
+                    <span>{t(messages, 'module.shopping.new_template')}</span>
+                  </button>
+                )}
+              </div>
             </div>
             {showTemplateForm && (
               <ShoppingTemplateForm
@@ -390,18 +422,20 @@ export default function ShoppingView() {
                 onCancel={closeTemplateForm}
               />
             )}
-            <div className="shopping-template-list">
-              {(sh.templates || []).map((template) => (
-                <ShoppingTemplateCard
-                  key={template.id}
-                  template={template}
-                  messages={messages}
-                  onApply={sh.applyTemplate}
-                  onEdit={openTemplateForm}
-                  onDelete={sh.deleteTemplate}
-                />
-              ))}
-            </div>
+            {templatesVisible && (
+              <div className="shopping-template-list">
+                {(sh.templates || []).map((template) => (
+                  <ShoppingTemplateCard
+                    key={template.id}
+                    template={template}
+                    messages={messages}
+                    onApply={sh.applyTemplate}
+                    onEdit={openTemplateForm}
+                    onDelete={sh.deleteTemplate}
+                  />
+                ))}
+              </div>
+            )}
           </section>
         )}
 
@@ -516,6 +550,63 @@ export default function ShoppingView() {
               <p>{t(messages, 'module.shopping.no_lists')}</p>
             </div>
           )}
+
+        {/* Templates Panel */}
+        {!isChild && isMobile && (
+          <section className="shopping-templates-panel" aria-label={t(messages, 'module.shopping.templates')}>
+            <div className="shopping-templates-header">
+              <h2>{t(messages, 'module.shopping.templates')}</h2>
+              <div className="shopping-templates-actions">
+                {isMobile && (
+                  <button
+                    className="btn-ghost shopping-template-toggle"
+                    type="button"
+                    aria-expanded={templatesVisible}
+                    onClick={() => {
+                      if (templatesVisible) closeTemplateForm();
+                      setTemplatesExpanded((prev) => !prev);
+                    }}
+                  >
+                    {templatesToggleLabel}
+                  </button>
+                )}
+                {templatesVisible && (
+                  <button
+                    className="shopping-add-list-btn"
+                    type="button"
+                    onClick={() => openTemplateForm()}
+                  >
+                    <Plus size={16} aria-hidden="true" />
+                    <span>{t(messages, 'module.shopping.new_template')}</span>
+                  </button>
+                )}
+              </div>
+            </div>
+            {showTemplateForm && (
+              <ShoppingTemplateForm
+                key={editingTemplate?.id || 'new'}
+                messages={messages}
+                initialTemplate={editingTemplate}
+                onSubmit={submitTemplate}
+                onCancel={closeTemplateForm}
+              />
+            )}
+            {templatesVisible && (
+              <div className="shopping-template-list">
+                {(sh.templates || []).map((template) => (
+                  <ShoppingTemplateCard
+                    key={template.id}
+                    template={template}
+                    messages={messages}
+                    onApply={sh.applyTemplate}
+                    onEdit={openTemplateForm}
+                    onDelete={sh.deleteTemplate}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
         </div>
       </div>
     </div>

--- a/frontend/contexts/AppContext.js
+++ b/frontend/contexts/AppContext.js
@@ -180,7 +180,7 @@ function AppOrchestrator({ children }) {
     };
     window.addEventListener('popstate', onPopState);
 
-    const onResize = () => setIsMobile(window.innerWidth < 768);
+    const onResize = () => setIsMobile(window.innerWidth <= 768);
     onResize();
     window.addEventListener('resize', onResize);
 

--- a/frontend/e2e/helpers/navigation.js
+++ b/frontend/e2e/helpers/navigation.js
@@ -31,7 +31,7 @@ const ALWAYS_OVERFLOW = new Set(['Settings', 'Admin']);
  */
 async function navigateTo(page, viewName) {
   const viewport = page.viewportSize();
-  const isMobile = viewport ? viewport.width < 768 : false;
+  const isMobile = viewport ? viewport.width <= 768 : false;
 
   const desktopName = Object.entries(MOBILE_ALIASES)
     .find(([, mobile]) => mobile === viewName)?.[0] || viewName;

--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -5,6 +5,13 @@ const { navigateTo } = require('../helpers/navigation');
 test.describe('Shopping', () => {
   test.setTimeout(90000);
 
+  async function expandTemplatesIfCollapsed(page) {
+    const showTemplates = page.getByRole('button', { name: 'Show templates' });
+    if (await showTemplates.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await showTemplates.click();
+    }
+  }
+
   test('create a shopping list', async ({ authedPage: page }) => {
     await navigateTo(page, 'Shopping');
 
@@ -100,6 +107,7 @@ test.describe('Shopping', () => {
     await navigateTo(page, 'Shopping');
 
     await page.getByText('Template Target List').click();
+    await expandTemplatesIfCollapsed(page);
     await page.getByRole('button', { name: 'New template' }).click();
     await page.locator('input[placeholder="e.g. Weekly groceries"]').fill('Weekly groceries');
     await page.locator('input[placeholder="Template item"]').first().fill('Milk');
@@ -142,6 +150,7 @@ test.describe('Shopping', () => {
     await navigateTo(page, 'Shopping');
 
     await page.getByText('Seeded Template Target').click();
+    await expandTemplatesIfCollapsed(page);
     await page.getByRole('button', { name: 'Add to list: Seeded weekly groceries' }).click();
 
     await expect(page.locator('[role="checkbox"][aria-label="Oats"]')).toBeVisible({ timeout: 10000 });
@@ -165,4 +174,79 @@ test.describe('Shopping', () => {
 
     await expect(page.getByText('Delete This List')).not.toBeVisible({ timeout: 10000 });
   });
+
+  test('mobile in-store layout prioritizes active items and keeps keyboard focus out of the checklist', async ({ authedPage: page, apiCtx }) => {
+    const viewport = page.viewportSize();
+    test.skip(!viewport || viewport.width >= 768, 'Mobile-only shopping layout check');
+
+    const familyId = await getFamilyId(apiCtx);
+    const list = await seedShoppingList(apiCtx, familyId, 'Mobile Market List');
+    await seedShoppingItem(apiCtx, list.id, 'Apples', '6', 'Produce');
+    await seedShoppingItem(apiCtx, list.id, 'Milk', '2 L', 'Dairy');
+    await seedShoppingTemplate(apiCtx, familyId, 'Mobile breakfast plan', [
+      { name: 'Eggs', spec: '12', category: 'Dairy' },
+    ]);
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
+    await navigateTo(page, 'Shopping');
+    await page.getByText('Mobile Market List').click();
+
+    const itemsPanel = page.locator('.shopping-items-panel');
+    const templatesPanel = page.locator('.shopping-templates-panel');
+    await expect(itemsPanel).toBeVisible({ timeout: 10000 });
+    await expect(templatesPanel).toBeVisible({ timeout: 10000 });
+
+    const [itemsBox, templatesBox] = await Promise.all([
+      itemsPanel.boundingBox(),
+      templatesPanel.boundingBox(),
+    ]);
+    expect(itemsBox.y).toBeLessThan(templatesBox.y);
+
+    await expect(page.getByText('Mobile breakfast plan')).not.toBeVisible();
+    await page.getByRole('button', { name: 'Show templates' }).click();
+    await expect(page.getByText('Mobile breakfast plan')).toBeVisible({ timeout: 10000 });
+
+    const quickAdd = page.locator('input[placeholder="Add an item..."]');
+    await quickAdd.focus();
+    await expect(quickAdd).toBeFocused();
+    await page.locator('[role="checkbox"][aria-label="Apples"]').click();
+    await expect(quickAdd).not.toBeFocused();
+
+    await quickAdd.fill('Bananas');
+    await expect(quickAdd).toBeFocused();
+    await page.getByRole('button', { name: 'Add item' }).click();
+    await expect(quickAdd).not.toBeFocused();
+    await expect(page.locator('[role="checkbox"][aria-label="Bananas"]')).toBeVisible({ timeout: 10000 });
+  });
+
+
+  test('768px shopping breakpoint keeps items before templates in DOM order', async ({ authedPage: page, apiCtx }) => {
+    await page.setViewportSize({ width: 768, height: 900 });
+    const familyId = await getFamilyId(apiCtx);
+    const list = await seedShoppingList(apiCtx, familyId, 'Breakpoint Market List');
+    await seedShoppingItem(apiCtx, list.id, 'Tea', '1 box', 'Pantry');
+    await seedShoppingTemplate(apiCtx, familyId, 'Breakpoint planning template', [
+      { name: 'Coffee', spec: '1 bag', category: 'Pantry' },
+    ]);
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
+    await navigateTo(page, 'Shopping');
+    await page.getByText('Breakpoint Market List').click();
+
+    await expect(page.locator('.shopping-items-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.shopping-templates-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Breakpoint planning template')).not.toBeVisible();
+
+    const ordering = await page.evaluate(() => {
+      const items = document.querySelector('.shopping-items-panel');
+      const templates = document.querySelector('.shopping-templates-panel');
+      return Boolean(items && templates && (items.compareDocumentPosition(templates) & Node.DOCUMENT_POSITION_FOLLOWING));
+    });
+    expect(ordering).toBe(true);
+  });
+
 });

--- a/frontend/hooks/useShopping.js
+++ b/frontend/hooks/useShopping.js
@@ -40,7 +40,7 @@ export function findReusableCheckedItem(items, payload) {
 export function useShopping() {
   const {
     shoppingLists, setShoppingLists, familyId, messages,
-    loadShoppingLists, demoMode,
+    loadShoppingLists, demoMode, isMobile,
   } = useApp();
   const { error: toastError } = useToast();
 
@@ -265,7 +265,7 @@ export function useShopping() {
     setNewItemName('');
     setNewItemSpec('');
     setNewItemCategory('');
-    itemInputRef.current?.focus();
+    if (!isMobile) itemInputRef.current?.focus();
   }
 
   async function toggleItem(id, currentChecked) {

--- a/frontend/i18n/modules/shopping/bg.json
+++ b/frontend/i18n/modules/shopping/bg.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Добавете първия елемент",
   "module.shopping.templates": "Шаблони",
   "module.shopping.new_template": "Нов шаблон",
+  "module.shopping.show_templates": "Показване на шаблони",
+  "module.shopping.hide_templates": "Скриване на шаблони",
   "module.shopping.template_name_placeholder": "напр. Седмични хранителни стоки",
   "module.shopping.template_item_name_placeholder": "Шаблонен елемент",
   "module.shopping.template_item_spec_placeholder": "Сума/подробности",

--- a/frontend/i18n/modules/shopping/cs.json
+++ b/frontend/i18n/modules/shopping/cs.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Přidejte první položku",
   "module.shopping.templates": "Šablony",
   "module.shopping.new_template": "Nová šablona",
+  "module.shopping.show_templates": "Zobrazit šablony",
+  "module.shopping.hide_templates": "Skrýt šablony",
   "module.shopping.template_name_placeholder": "např. Týdenní potraviny",
   "module.shopping.template_item_name_placeholder": "Položka šablony",
   "module.shopping.template_item_spec_placeholder": "Částka/podrobnosti",

--- a/frontend/i18n/modules/shopping/da.json
+++ b/frontend/i18n/modules/shopping/da.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Tilføj første vare",
   "module.shopping.templates": "Skabeloner",
   "module.shopping.new_template": "Ny skabelon",
+  "module.shopping.show_templates": "Vis skabeloner",
+  "module.shopping.hide_templates": "Skjul skabeloner",
   "module.shopping.template_name_placeholder": "f.eks. Ugentlige dagligvarer",
   "module.shopping.template_item_name_placeholder": "Skabelonelement",
   "module.shopping.template_item_spec_placeholder": "Beløb/detaljer",

--- a/frontend/i18n/modules/shopping/de.json
+++ b/frontend/i18n/modules/shopping/de.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Ersten Artikel hinzufügen",
   "module.shopping.templates": "Vorlagen",
   "module.shopping.new_template": "Neue Vorlage",
+  "module.shopping.show_templates": "Vorlagen anzeigen",
+  "module.shopping.hide_templates": "Vorlagen ausblenden",
   "module.shopping.template_name_placeholder": "z.B. Wocheneinkauf",
   "module.shopping.template_item_name_placeholder": "Vorlagenartikel",
   "module.shopping.template_item_spec_placeholder": "Menge/Details",

--- a/frontend/i18n/modules/shopping/el.json
+++ b/frontend/i18n/modules/shopping/el.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Προσθήκη πρώτου στοιχείου",
   "module.shopping.templates": "Πρότυπα",
   "module.shopping.new_template": "Νέο πρότυπο",
+  "module.shopping.show_templates": "Εμφάνιση προτύπων",
+  "module.shopping.hide_templates": "Απόκρυψη προτύπων",
   "module.shopping.template_name_placeholder": "π.χ. Εβδομαδιαία παντοπωλεία",
   "module.shopping.template_item_name_placeholder": "Στοιχείο προτύπου",
   "module.shopping.template_item_spec_placeholder": "Ποσό/λεπτομέρειες",

--- a/frontend/i18n/modules/shopping/en.json
+++ b/frontend/i18n/modules/shopping/en.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Add first item",
   "module.shopping.templates": "Templates",
   "module.shopping.new_template": "New template",
+  "module.shopping.show_templates": "Show templates",
+  "module.shopping.hide_templates": "Hide templates",
   "module.shopping.template_name_placeholder": "e.g. Weekly groceries",
   "module.shopping.template_item_name_placeholder": "Template item",
   "module.shopping.template_item_spec_placeholder": "Amount/details",

--- a/frontend/i18n/modules/shopping/es.json
+++ b/frontend/i18n/modules/shopping/es.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Añadir primer artículo",
   "module.shopping.templates": "Plantillas",
   "module.shopping.new_template": "Nueva plantilla",
+  "module.shopping.show_templates": "Mostrar plantillas",
+  "module.shopping.hide_templates": "Ocultar plantillas",
   "module.shopping.template_name_placeholder": "p. ej., Compra semanal",
   "module.shopping.template_item_name_placeholder": "Artículo de plantilla",
   "module.shopping.template_item_spec_placeholder": "Cantidad/detalles",

--- a/frontend/i18n/modules/shopping/et.json
+++ b/frontend/i18n/modules/shopping/et.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Lisa esimene üksus",
   "module.shopping.templates": "Mallid",
   "module.shopping.new_template": "Uus mall",
+  "module.shopping.show_templates": "Kuva mallid",
+  "module.shopping.hide_templates": "Peida mallid",
   "module.shopping.template_name_placeholder": "nt. Iganädalased toidukaubad",
   "module.shopping.template_item_name_placeholder": "Malli üksus",
   "module.shopping.template_item_spec_placeholder": "Summa/andmed",

--- a/frontend/i18n/modules/shopping/fi.json
+++ b/frontend/i18n/modules/shopping/fi.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Lisää ensimmäinen kohde",
   "module.shopping.templates": "Mallit",
   "module.shopping.new_template": "Uusi malli",
+  "module.shopping.show_templates": "Näytä mallit",
+  "module.shopping.hide_templates": "Piilota mallit",
   "module.shopping.template_name_placeholder": "esim. Viikoittaiset päivittäistavarat",
   "module.shopping.template_item_name_placeholder": "Mallikohde",
   "module.shopping.template_item_spec_placeholder": "Määrä/tiedot",

--- a/frontend/i18n/modules/shopping/fr.json
+++ b/frontend/i18n/modules/shopping/fr.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Ajouter le premier article",
   "module.shopping.templates": "Modèles",
   "module.shopping.new_template": "Nouveau modèle",
+  "module.shopping.show_templates": "Afficher les modèles",
+  "module.shopping.hide_templates": "Masquer les modèles",
   "module.shopping.template_name_placeholder": "p. ex. Courses de la semaine",
   "module.shopping.template_item_name_placeholder": "Article du modèle",
   "module.shopping.template_item_spec_placeholder": "Quantité/détails",

--- a/frontend/i18n/modules/shopping/ga.json
+++ b/frontend/i18n/modules/shopping/ga.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Cuir an chéad mhír leis",
   "module.shopping.templates": "Teimpléid",
   "module.shopping.new_template": "Teimpléad nua",
+  "module.shopping.show_templates": "Taispeáin teimpléid",
+  "module.shopping.hide_templates": "Folaigh teimpléid",
   "module.shopping.template_name_placeholder": "e.g. Earraí grósaeireachta seachtainiúla",
   "module.shopping.template_item_name_placeholder": "Mír teimpléad",
   "module.shopping.template_item_spec_placeholder": "Méid/sonraí",

--- a/frontend/i18n/modules/shopping/hr.json
+++ b/frontend/i18n/modules/shopping/hr.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Dodajte prvu stavku",
   "module.shopping.templates": "Predlošci",
   "module.shopping.new_template": "Novi predložak",
+  "module.shopping.show_templates": "Prikaži predloške",
+  "module.shopping.hide_templates": "Sakrij predloške",
   "module.shopping.template_name_placeholder": "npr. Tjedne namirnice",
   "module.shopping.template_item_name_placeholder": "Stavka predloška",
   "module.shopping.template_item_spec_placeholder": "Iznos/pojedinosti",

--- a/frontend/i18n/modules/shopping/hu.json
+++ b/frontend/i18n/modules/shopping/hu.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Adja hozzá az első elemet",
   "module.shopping.templates": "Sablonok",
   "module.shopping.new_template": "Új sablon",
+  "module.shopping.show_templates": "Sablonok megjelenítése",
+  "module.shopping.hide_templates": "Sablonok elrejtése",
   "module.shopping.template_name_placeholder": "pl. Heti élelmiszerek",
   "module.shopping.template_item_name_placeholder": "Sablon elem",
   "module.shopping.template_item_spec_placeholder": "Összeg/részletek",

--- a/frontend/i18n/modules/shopping/it.json
+++ b/frontend/i18n/modules/shopping/it.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Aggiungi il primo elemento",
   "module.shopping.templates": "Modelli",
   "module.shopping.new_template": "Nuovo modello",
+  "module.shopping.show_templates": "Mostra modelli",
+  "module.shopping.hide_templates": "Nascondi modelli",
   "module.shopping.template_name_placeholder": "ad es. Generi alimentari settimanali",
   "module.shopping.template_item_name_placeholder": "Elemento modello",
   "module.shopping.template_item_spec_placeholder": "Importo/dettagli",

--- a/frontend/i18n/modules/shopping/lt.json
+++ b/frontend/i18n/modules/shopping/lt.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Pridėkite pirmąjį elementą",
   "module.shopping.templates": "Šablonai",
   "module.shopping.new_template": "Naujas šablonas",
+  "module.shopping.show_templates": "Rodyti šablonus",
+  "module.shopping.hide_templates": "Slėpti šablonus",
   "module.shopping.template_name_placeholder": "pvz. Savaitės bakalėjos",
   "module.shopping.template_item_name_placeholder": "Šablono elementas",
   "module.shopping.template_item_spec_placeholder": "Suma / detalės",

--- a/frontend/i18n/modules/shopping/lv.json
+++ b/frontend/i18n/modules/shopping/lv.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Pievienojiet pirmo vienumu",
   "module.shopping.templates": "Veidnes",
   "module.shopping.new_template": "Jauna veidne",
+  "module.shopping.show_templates": "Rādīt veidnes",
+  "module.shopping.hide_templates": "Slēpt veidnes",
   "module.shopping.template_name_placeholder": "piem. Iknedēļas pārtikas preces",
   "module.shopping.template_item_name_placeholder": "Veidnes vienums",
   "module.shopping.template_item_spec_placeholder": "Summa/detaļas",

--- a/frontend/i18n/modules/shopping/nb.json
+++ b/frontend/i18n/modules/shopping/nb.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Legg til første element",
   "module.shopping.templates": "Maler",
   "module.shopping.new_template": "Ny mal",
+  "module.shopping.show_templates": "Vis maler",
+  "module.shopping.hide_templates": "Skjul maler",
   "module.shopping.template_name_placeholder": "f.eks. Ukentlige dagligvarer",
   "module.shopping.template_item_name_placeholder": "Malelement",
   "module.shopping.template_item_spec_placeholder": "Beløp/detaljer",

--- a/frontend/i18n/modules/shopping/nl.json
+++ b/frontend/i18n/modules/shopping/nl.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Voeg het eerste item toe",
   "module.shopping.templates": "Sjablonen",
   "module.shopping.new_template": "Nieuw sjabloon",
+  "module.shopping.show_templates": "Sjablonen tonen",
+  "module.shopping.hide_templates": "Sjablonen verbergen",
   "module.shopping.template_name_placeholder": "bijv. Wekelijkse boodschappen",
   "module.shopping.template_item_name_placeholder": "Sjabloonitem",
   "module.shopping.template_item_spec_placeholder": "Bedrag/details",

--- a/frontend/i18n/modules/shopping/pl.json
+++ b/frontend/i18n/modules/shopping/pl.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Dodaj pierwszy produkt",
   "module.shopping.templates": "Szablony",
   "module.shopping.new_template": "Nowy szablon",
+  "module.shopping.show_templates": "Pokaż szablony",
+  "module.shopping.hide_templates": "Ukryj szablony",
   "module.shopping.template_name_placeholder": "np. Zakupy tygodniowe",
   "module.shopping.template_item_name_placeholder": "Produkt w szablonie",
   "module.shopping.template_item_spec_placeholder": "Ilość/szczegóły",

--- a/frontend/i18n/modules/shopping/pt.json
+++ b/frontend/i18n/modules/shopping/pt.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Adicione o primeiro item",
   "module.shopping.templates": "Modelos",
   "module.shopping.new_template": "Novo modelo",
+  "module.shopping.show_templates": "Mostrar modelos",
+  "module.shopping.hide_templates": "Ocultar modelos",
   "module.shopping.template_name_placeholder": "por exemplo Compras semanais",
   "module.shopping.template_item_name_placeholder": "Item de modelo",
   "module.shopping.template_item_spec_placeholder": "Valor/detalhes",

--- a/frontend/i18n/modules/shopping/ro.json
+++ b/frontend/i18n/modules/shopping/ro.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Adăugați primul articol",
   "module.shopping.templates": "Șabloane",
   "module.shopping.new_template": "Șablon nou",
+  "module.shopping.show_templates": "Afișează șabloanele",
+  "module.shopping.hide_templates": "Ascunde șabloanele",
   "module.shopping.template_name_placeholder": "de ex. Băcănii săptămânale",
   "module.shopping.template_item_name_placeholder": "Element șablon",
   "module.shopping.template_item_spec_placeholder": "Suma/detalii",

--- a/frontend/i18n/modules/shopping/sk.json
+++ b/frontend/i18n/modules/shopping/sk.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Pridajte prvú položku",
   "module.shopping.templates": "Šablóny",
   "module.shopping.new_template": "Nová šablóna",
+  "module.shopping.show_templates": "Zobraziť šablóny",
+  "module.shopping.hide_templates": "Skryť šablóny",
   "module.shopping.template_name_placeholder": "napr. Týždenné potraviny",
   "module.shopping.template_item_name_placeholder": "Položka šablóny",
   "module.shopping.template_item_spec_placeholder": "Suma/podrobnosti",

--- a/frontend/i18n/modules/shopping/sl.json
+++ b/frontend/i18n/modules/shopping/sl.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Dodajte prvi element",
   "module.shopping.templates": "Predloge",
   "module.shopping.new_template": "Nova predloga",
+  "module.shopping.show_templates": "Prikaži predloge",
+  "module.shopping.hide_templates": "Skrij predloge",
   "module.shopping.template_name_placeholder": "npr. Tedenska živila",
   "module.shopping.template_item_name_placeholder": "Element predloge",
   "module.shopping.template_item_spec_placeholder": "Znesek/podrobnosti",

--- a/frontend/i18n/modules/shopping/sv.json
+++ b/frontend/i18n/modules/shopping/sv.json
@@ -22,6 +22,8 @@
   "module.shopping.add_first_item": "Lägg till första objektet",
   "module.shopping.templates": "Mallar",
   "module.shopping.new_template": "Ny mall",
+  "module.shopping.show_templates": "Visa mallar",
+  "module.shopping.hide_templates": "Dölj mallar",
   "module.shopping.template_name_placeholder": "t.ex. Inköp varje vecka",
   "module.shopping.template_item_name_placeholder": "Mallobjekt",
   "module.shopping.template_item_spec_placeholder": "Belopp/detaljer",

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1196,6 +1196,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .shopping-lists-panel { display: flex; flex-direction: column; gap: var(--space-sm); }
 .shopping-templates-panel { background: var(--void-surface); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); padding: var(--space-md); display: flex; flex-direction: column; gap: var(--space-md); min-width: 0; }
 .shopping-templates-header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); }
+.shopping-templates-actions { display: flex; align-items: center; justify-content: flex-end; gap: var(--space-xs); flex-wrap: wrap; }
+.shopping-template-toggle { min-height: 44px; }
 .shopping-templates-header h2 { margin: 0; font-size: 0.9rem; font-weight: 600; }
 .shopping-template-list { display: flex; flex-direction: column; gap: var(--space-sm); }
 .shopping-template-card { border: 1px solid var(--glass-border); border-radius: var(--radius-md); padding: var(--space-sm); display: flex; flex-direction: column; gap: var(--space-sm); background: rgba(255,255,255,0.03); }
@@ -1580,6 +1582,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .shopping-check:focus-visible,
 .mobile-hamburger:focus-visible,
 .shopping-list-card:focus-visible,
+.shopping-item:focus-visible,
+.shopping-template-toggle:focus-visible,
 .shopping-list-delete:focus-visible,
 .shopping-item-delete:focus-visible,
 .theme-item:focus-visible,
@@ -1773,8 +1777,10 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .calendar-view-toggle { margin-left: 0; }
   .birthday-list { grid-template-columns: 1fr; }
   .contacts-grid { grid-template-columns: 1fr; }
-  .shopping-layout { grid-template-columns: 1fr; }
-  .shopping-lists-panel { flex-direction: row; overflow-x: auto; padding-bottom: var(--space-sm); scrollbar-width: none; }
+  .shopping-layout { grid-template-columns: 1fr; gap: var(--space-sm); }
+  .shopping-lists-panel { order: 1; flex-direction: row; overflow-x: auto; padding-bottom: var(--space-sm); scrollbar-width: none; }
+  .shopping-items-panel { order: 2; }
+  .shopping-templates-panel { order: 3; padding: var(--space-sm); gap: var(--space-sm); }
   .shopping-lists-panel::-webkit-scrollbar { display: none; }
   .shopping-lists-panel .shopping-list-card { min-width: 140px; flex-shrink: 0; }
   .shopping-template-item-row { grid-template-columns: 1fr; }
@@ -1782,7 +1788,13 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .shopping-list-delete { opacity: 1; }
   .view-title { font-size: 1.3rem; }
   .calendar-month-label { min-width: auto; }
-  .quick-add-bar { flex-wrap: wrap; }
+  .quick-add-bar { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 48px; gap: var(--space-xs); align-items: stretch; padding: var(--space-sm); }
+  .quick-add-bar .quick-add-input:first-of-type { grid-column: 1 / 3; grid-row: 1; min-width: 0; width: 100%; }
+  .quick-add-bar .shopping-spec-input { grid-column: 1 / 2; grid-row: 2; width: 100%; min-width: 0; flex: none !important; }
+  .quick-add-bar .shopping-category-input { grid-column: 2 / 4; grid-row: 2; width: 100%; min-width: 0; flex: none !important; }
+  .quick-add-btn { grid-column: 3; grid-row: 1; width: 48px; min-width: 48px; min-height: 48px; }
+  .shopping-items-list { padding-bottom: calc(96px + env(safe-area-inset-bottom)); }
+  .shopping-item .shopping-category-pill { display: none; }
   .rewards-earn-form { flex-direction: column; }
   .rewards-earn-select, .rewards-earn-amount, .rewards-earn-note { width: 100%; min-width: 0; flex: unset; }
   .rewards-balances { margin-left: calc(-1 * var(--space-md)); margin-right: calc(-1 * var(--space-md)); padding-left: var(--space-md); padding-right: var(--space-md); }


### PR DESCRIPTION
## Summary
- improve the mobile shopping flow so active list items are prioritized before planning/templates in visual and DOM order
- collapse shopping templates by default on mobile, with localized show/hide controls and form cleanup when hiding
- prevent mobile keyboard persistence by blurring checklist interactions and avoiding quick-add refocus on mobile
- align the 768px runtime breakpoint with the CSS breakpoint and cover it in E2E/navigation tests

## Verification
- Backend: `450 passed, 32 warnings`
- Frontend Jest: `332 passed`
- Frontend build: passed
- i18n pack check: `OK: checked_files=336, checked_values=30816`
- i18n parity: `tasks files 24 parity ok`
- Shopping mobile i18n check: `shopping mobile i18n keys ok: 24 locale files`
- Targeted E2E: Desktop 768px shopping breakpoint passed
- Targeted E2E: Mobile Chrome shopping spec `9 passed`
- Full Playwright E2E: `105 passed, 1 skipped`
- Codex review: no blockers

Closes #327
