### PR TITLE
Fix auth refresh race

### DIFF
--- a/backend/app/core/auth_sessions.py
+++ b/backend/app/core/auth_sessions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Literal
 
 from fastapi import Response
 from sqlalchemy.orm import Session
@@ -57,32 +58,54 @@ def clear_session_cookies(response: Response) -> None:
     response.delete_cookie(REFRESH_COOKIE_NAME, path="/auth/refresh")
 
 
-def rotate_refresh_session(response: Response, db: Session, refresh_token: str) -> User | None:
+RefreshRotationResult = Literal["ok", "stale", "invalid"]
+
+
+def rotate_refresh_session(response: Response, db: Session, refresh_token: str) -> RefreshRotationResult:
     session = (
         db.query(UserSession)
         .filter(UserSession.token_lookup == refresh_token_lookup_key(refresh_token))
         .first()
     )
-    if not session or session.revoked_at is not None:
-        return None
+    if not session:
+        return "stale"
+    if session.revoked_at is not None:
+        return "invalid"
     now = utcnow()
     if session.expires_at <= now:
         session.revoked_at = now
         db.commit()
-        return None
+        return "invalid"
     if not verify_refresh_token(refresh_token, session.token_hash):
-        return None
+        return "invalid"
     user = db.query(User).filter(User.id == session.user_id).first()
     if not user:
         session.revoked_at = now
         db.commit()
-        return None
+        return "invalid"
 
     next_token, next_hash, next_lookup = generate_refresh_token()
-    session.token_lookup = next_lookup
-    session.token_hash = next_hash
-    session.last_used_at = now
-    session.expires_at = now + timedelta(seconds=REFRESH_COOKIE_MAX_AGE)
+    next_expires_at = now + timedelta(seconds=REFRESH_COOKIE_MAX_AGE)
+    updated = (
+        db.query(UserSession)
+        .filter(
+            UserSession.id == session.id,
+            UserSession.token_lookup == refresh_token_lookup_key(refresh_token),
+            UserSession.revoked_at.is_(None),
+        )
+        .update(
+            {
+                UserSession.token_lookup: next_lookup,
+                UserSession.token_hash: next_hash,
+                UserSession.last_used_at: now,
+                UserSession.expires_at: next_expires_at,
+            },
+            synchronize_session=False,
+        )
+    )
+    if updated != 1:
+        db.rollback()
+        return "stale"
 
     access_token = create_access_token(user_id=user.id, email=user.email)
     response.set_cookie(
@@ -93,7 +116,7 @@ def rotate_refresh_session(response: Response, db: Session, refresh_token: str) 
         REFRESH_COOKIE_NAME, next_token, httponly=True, samesite="lax",
         secure=COOKIE_SECURE, max_age=REFRESH_COOKIE_MAX_AGE, path=REFRESH_COOKIE_PATH,
     )
-    return user
+    return "ok"
 
 
 def revoke_refresh_session(db: Session, refresh_token: str | None) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -422,12 +422,18 @@ def logout(request: Request, db: Session = Depends(get_db)):
     response_description="Session refreshed",
 )
 def refresh_session(request: Request, db: Session = Depends(get_db)):
-    response = JSONResponse(content={"status": "ok"})
     refresh_token = request.cookies.get(REFRESH_COOKIE_NAME)
-    if not refresh_token or not rotate_refresh_session(response, db, refresh_token):
+    if not refresh_token:
         response = JSONResponse(content={"detail": error_detail(INVALID_CREDENTIALS)}, status_code=401)
         clear_session_cookies(response)
         return response
+    response = JSONResponse(content={"status": "ok"})
+    result = rotate_refresh_session(response, db, refresh_token)
+    if result != "ok":
+        failure = JSONResponse(content={"detail": error_detail(INVALID_CREDENTIALS)}, status_code=401)
+        if result == "invalid":
+            clear_session_cookies(failure)
+        return failure
     db.commit()
     return response
 

--- a/backend/tests/test_session_persistence.py
+++ b/backend/tests/test_session_persistence.py
@@ -146,3 +146,61 @@ def test_password_change_revokes_refresh_sessions():
 
     refresh = client.post("/auth/refresh")
     assert refresh.status_code == 401
+
+def test_unknown_refresh_token_does_not_clear_potentially_rotated_cookies():
+    _seed_user()
+    client.cookies.set("tribu_token", "fresh-access", domain="testserver.local", path="/")
+    client.cookies.set("tribu_refresh", "stale-refresh", domain="testserver.local", path="/")
+
+    refresh = client.post("/auth/refresh")
+
+    assert refresh.status_code == 401
+    set_cookie = refresh.headers.get("set-cookie", "")
+    assert 'tribu_token=""' not in set_cookie
+    assert 'tribu_refresh=""' not in set_cookie
+
+
+def test_revoked_refresh_token_clears_session_cookies():
+    _seed_user()
+    login = client.post(
+        "/auth/login",
+        json={"email": "session@example.com", "password": "Secure1Pass"},
+    )
+    assert login.status_code == 200
+    db = TestSession()
+    try:
+        session = db.query(UserSession).one()
+        session.revoked_at = datetime.now(timezone.utc)
+        db.commit()
+    finally:
+        db.close()
+
+    refresh = client.post("/auth/refresh")
+
+    assert refresh.status_code == 401
+    set_cookie = refresh.headers.get("set-cookie", "")
+    assert 'tribu_token=""' in set_cookie
+    assert 'tribu_refresh=""' in set_cookie
+
+
+def test_expired_refresh_token_clears_session_cookies():
+    _seed_user()
+    login = client.post(
+        "/auth/login",
+        json={"email": "session@example.com", "password": "Secure1Pass"},
+    )
+    assert login.status_code == 200
+    db = TestSession()
+    try:
+        session = db.query(UserSession).one()
+        session.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        db.commit()
+    finally:
+        db.close()
+
+    refresh = client.post("/auth/refresh")
+
+    assert refresh.status_code == 401
+    set_cookie = refresh.headers.get("set-cookie", "")
+    assert 'tribu_token=""' in set_cookie
+    assert 'tribu_refresh=""' in set_cookie

--- a/frontend/__tests__/lib/api.test.js
+++ b/frontend/__tests__/lib/api.test.js
@@ -46,6 +46,109 @@ describe('Auth API', () => {
     expect(lastCall()[0]).toBe('/api/auth/logout');
   });
 
+  it('apiLogout waits for an in-flight refresh before clearing the session', async () => {
+    const pendingRefresh = {};
+    pendingRefresh.promise = new Promise((resolve) => { pendingRefresh.resolve = resolve; });
+    global.fetch = jest.fn((url) => {
+      if (url === '/api/auth/refresh') return pendingRefresh.promise;
+      if (url === '/api/auth/me') return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) });
+      if (url === '/api/auth/logout') return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) });
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ id: 1 }) });
+    });
+
+    const me = apiGetMe();
+    await Promise.resolve();
+    await Promise.resolve();
+    const logout = apiLogout();
+    await Promise.resolve();
+
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual(['/api/auth/me', '/api/auth/refresh']);
+
+    pendingRefresh.resolve({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'invalid' }) });
+    await Promise.all([me, logout]);
+
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual(['/api/auth/me', '/api/auth/refresh', '/api/auth/logout']);
+  });
+
+  it('apiLogout prevents retries after a successful in-flight refresh', async () => {
+    const pendingRefresh = {};
+    pendingRefresh.promise = new Promise((resolve) => { pendingRefresh.resolve = resolve; });
+    global.fetch = jest.fn((url) => {
+      if (url === '/api/auth/refresh') return pendingRefresh.promise;
+      if (url === '/api/auth/me') return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) });
+      if (url === '/api/auth/logout') return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) });
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ id: 1 }) });
+    });
+
+    const me = apiGetMe();
+    await Promise.resolve();
+    await Promise.resolve();
+    const logout = apiLogout();
+    await Promise.resolve();
+
+    pendingRefresh.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) });
+    const [meResult] = await Promise.all([me, logout]);
+
+    expect(meResult.status).toBe(401);
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual(['/api/auth/me', '/api/auth/refresh', '/api/auth/logout']);
+  });
+
+  it('apiLogout blocks new refresh attempts while logout is in flight', async () => {
+    const pendingLogout = {};
+    pendingLogout.promise = new Promise((resolve) => { pendingLogout.resolve = resolve; });
+    global.fetch = jest.fn((url) => {
+      if (url === '/api/auth/logout') return pendingLogout.promise;
+      if (url === '/api/auth/me') return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) });
+      if (url === '/api/auth/refresh') return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) });
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ id: 1 }) });
+    });
+
+    const logout = apiLogout();
+    await Promise.resolve();
+    const me = await apiGetMe();
+
+    expect(me.status).toBe(401);
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual(['/api/auth/logout', '/api/auth/me']);
+
+    pendingLogout.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) });
+    await logout;
+  });
+
+  it('shares one refresh request across concurrent expired access cookie responses', async () => {
+    const pendingRefresh = {};
+    pendingRefresh.promise = new Promise((resolve) => { pendingRefresh.resolve = resolve; });
+    const attempts = new Map();
+    global.fetch = jest.fn((url) => {
+      if (url === '/api/auth/refresh') return pendingRefresh.promise;
+      const count = attempts.get(url) || 0;
+      attempts.set(url, count + 1);
+      if (url === '/api/auth/me') {
+        if (count === 0) return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) });
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ email: 'session@example.com' }) });
+      }
+      if (url === '/api/dashboard/summary?family_id=7') {
+        if (count === 0) return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) });
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ today: [] }) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ id: 1 }) });
+    });
+
+    const me = apiGetMe();
+    const dashboard = apiGetDashboard('7');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(global.fetch.mock.calls.filter(([url]) => url === '/api/auth/refresh')).toHaveLength(1);
+
+    pendingRefresh.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) });
+    const results = await Promise.all([me, dashboard]);
+
+    expect(results.map((result) => result.status)).toEqual([200, 200]);
+    expect(results[0].data).toEqual({ email: 'session@example.com' });
+    expect(results[1].data).toEqual({ today: [] });
+    expect(global.fetch.mock.calls.filter(([url]) => url === '/api/auth/refresh')).toHaveLength(1);
+  });
+
   it('apiGetMe refreshes once and retries after an expired access cookie', async () => {
     global.fetch = jest.fn()
       .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) })

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,13 +1,29 @@
 const API = '/api';
 
+let refreshInFlight = null;
+let logoutInFlight = false;
+
+function refreshSession() {
+  if (!refreshInFlight) {
+    refreshInFlight = (async () => {
+      try {
+        return await request('/auth/refresh', { method: 'POST' }, false);
+      } finally {
+        refreshInFlight = null;
+      }
+    })();
+  }
+  return refreshInFlight;
+}
+
 async function request(path, options = {}, allowRefresh = true) {
   const res = await fetch(`${API}${path}`, { credentials: 'include', ...options });
   let data;
   try { data = await res.json(); } catch { data = null; }
 
-  if (res.status === 401 && allowRefresh && path !== '/auth/refresh' && path !== '/auth/login' && path !== '/auth/logout') {
-    const refreshed = await request('/auth/refresh', { method: 'POST' }, false);
-    if (refreshed.ok) return request(path, options, false);
+  if (res.status === 401 && allowRefresh && !logoutInFlight && path !== '/auth/refresh' && path !== '/auth/login' && path !== '/auth/logout') {
+    const refreshed = await refreshSession();
+    if (refreshed.ok && !logoutInFlight) return request(path, options, false);
   }
 
   return { ok: res.ok, status: res.status, data };
@@ -52,8 +68,14 @@ export function apiRegister(email, password, display_name, family_name) {
   return post('/auth/register', { email, password, display_name, family_name });
 }
 
-export function apiLogout() {
-  return post('/auth/logout');
+export async function apiLogout() {
+  logoutInFlight = true;
+  try {
+    if (refreshInFlight) await refreshInFlight.catch(() => null);
+    return await post('/auth/logout');
+  } finally {
+    logoutInFlight = false;
+  }
 }
 
 export function apiGetMe() {


### PR DESCRIPTION
## Summary
- Share a single auth refresh request across concurrent frontend 401 responses.
- Avoid retrying protected requests while logout is in progress.
- Make refresh rotation update the session row atomically and keep stale rotation failures from clearing freshly rotated cookies.
- Keep definitive invalid refresh states, such as revoked or expired sessions, clearing httpOnly auth cookies.

Fixes #330.

## Tests
- `git diff --check`
- `cd frontend && npm test -- --runInBand`
- `cd frontend && npm run build --if-present`
- `cd backend && DATABASE_URL=sqlite:///./test-session-persistence-final.db JWT_SECRET=[REDACTED] python -m pytest tests/test_session_persistence.py -q --tb=short`
- `cd backend && DATABASE_URL=sqlite:////tmp/tribu-auth-refresh-backend-final.db JWT_SECRET=[REDACTED] python -m pytest -q --tb=short`
- `cd frontend && BASE_URL=http://127.0.0.1:3038 npm run e2e`
