### PR TITLE
Fix shopping autocomplete on empty mobile focus

### DIFF
--- a/frontend/__tests__/components/ShoppingView.test.js
+++ b/frontend/__tests__/components/ShoppingView.test.js
@@ -100,7 +100,7 @@ function setup(overrides = {}, appOverrides = {}) {
 }
 
 describe('ShoppingView quick add', () => {
-  test('offers checked items as quick-add suggestions', () => {
+  test('keeps quick-add suggestions inactive until the user types a real query', () => {
     setup({
       items: [
         { id: 1, name: 'Milk', spec: null, checked: true },
@@ -112,9 +112,41 @@ describe('ShoppingView quick add', () => {
     });
 
     const input = screen.getByPlaceholderText('Add an item...');
+    expect(input).not.toHaveAttribute('list');
+    expect(document.querySelectorAll('#shopping-item-suggestions option')).toHaveLength(0);
+  });
+
+  test('keeps quick-add suggestions inactive for whitespace-only input', () => {
+    setup({
+      newItemName: '  ',
+      items: [
+        { id: 1, name: 'Milk', spec: null, checked: true },
+        { id: 2, name: 'Bread', spec: null, checked: false },
+      ],
+    });
+
+    const input = screen.getByPlaceholderText('Add an item...');
+    expect(input).not.toHaveAttribute('list');
+    expect(document.querySelectorAll('#shopping-item-suggestions option')).toHaveLength(0);
+  });
+
+  test('filters quick-add suggestions after typed input', () => {
+    setup({
+      newItemName: 'mi',
+      items: [
+        { id: 1, name: 'Milk', spec: null, checked: true },
+        { id: 2, name: 'Bread', spec: null, checked: false },
+        { id: 3, name: 'Milk', spec: null, checked: false },
+      ],
+      checkedItems: [{ id: 1, name: 'Milk', spec: null, checked: true }],
+      uncheckedItems: [{ id: 2, name: 'Bread', spec: null, checked: false }, { id: 3, name: 'Milk', spec: null, checked: false }],
+    });
+
+    const input = screen.getByPlaceholderText('Add an item...');
+
     expect(input).toHaveAttribute('list', 'shopping-item-suggestions');
     const options = Array.from(document.querySelectorAll('#shopping-item-suggestions option')).map((option) => option.value);
-    expect(options).toEqual(['Bread', 'Milk']);
+    expect(options).toEqual(['Milk']);
   });
 
   test('adds a category field and groups items into collapsible category sections', () => {

--- a/frontend/components/ShoppingView.js
+++ b/frontend/components/ShoppingView.js
@@ -258,7 +258,13 @@ export default function ShoppingView() {
   const [editingTemplate, setEditingTemplate] = useState(null);
   const [templatesExpanded, setTemplatesExpanded] = useState(false);
   const [collapsedCategories, setCollapsedCategories] = useState({});
-  const itemSuggestions = Array.from(new Set((sh.items || []).map((item) => item.name).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+  const itemSuggestionQuery = sh.newItemName.trim().toLocaleLowerCase();
+  const itemSuggestions = itemSuggestionQuery
+    ? Array.from(new Set((sh.items || [])
+        .map((item) => item.name)
+        .filter((name) => name && name.toLocaleLowerCase().includes(itemSuggestionQuery))))
+        .sort((a, b) => a.localeCompare(b))
+    : [];
   const uncheckedGroups = groupItemsByCategory(sh.uncheckedItems, messages);
   const templatesVisible = !isMobile || templatesExpanded || showTemplateForm;
   const templatesToggleLabel = templatesVisible
@@ -453,7 +459,7 @@ export default function ShoppingView() {
                     value={sh.newItemName}
                     onChange={(e) => sh.setNewItemName(e.target.value)}
                     onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); sh.itemInputRef.current?.form?.requestSubmit(); } }}
-                    list="shopping-item-suggestions"
+                    {...(itemSuggestions.length > 0 ? { list: 'shopping-item-suggestions' } : {})}
                     required
                   />
                   <datalist id="shopping-item-suggestions">

--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -211,6 +211,14 @@ test.describe('Shopping', () => {
     const quickAdd = page.locator('input[placeholder="Add an item..."]');
     await quickAdd.focus();
     await expect(quickAdd).toBeFocused();
+    await expect(quickAdd).not.toHaveAttribute('list', 'shopping-item-suggestions');
+
+    await quickAdd.fill('Mi');
+    await expect(quickAdd).toHaveAttribute('list', 'shopping-item-suggestions');
+    await expect.poll(async () => page.locator('#shopping-item-suggestions option').evaluateAll((options) => options.map((option) => option.value))).toEqual(['Milk']);
+
+    await quickAdd.clear();
+    await expect(quickAdd).not.toHaveAttribute('list', 'shopping-item-suggestions');
     await page.locator('[role="checkbox"][aria-label="Apples"]').click();
     await expect(quickAdd).not.toBeFocused();
 


### PR DESCRIPTION
## Summary
- Prevent the shopping quick-add suggestions from opening on empty or whitespace-only input.
- Attach the native datalist only after the user types a real query.
- Filter matching item names case-insensitively and keep duplicate suggestions out.

## Notes
The quick-add field still uses the browser datalist. The difference is that the input has no `list` attribute until there is something to search for, so focusing the field on mobile just opens the keyboard.

## Validation
- `npm test -- --runTestsByPath __tests__/components/ShoppingView.test.js --runInBand`
- `BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/tests/shopping.spec.js -g "mobile in-store layout" --project="Mobile Chrome"`
- `BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/tests/shopping.spec.js`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

Closes #332
