### PR TITLE
Fix transparent mobile menu on shopping lists

### DIFF
--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -229,6 +229,37 @@ test.describe('Shopping', () => {
     await expect(page.locator('[role="checkbox"][aria-label="Bananas"]')).toBeVisible({ timeout: 10000 });
   });
 
+  test('mobile shopping menu stays opaque while quick add is focused', async ({ authedPage: page, apiCtx }) => {
+    const viewport = page.viewportSize();
+    test.skip(!viewport || viewport.width >= 768, 'Mobile-only shopping menu opacity check');
+
+    const familyId = await getFamilyId(apiCtx);
+    await seedShoppingList(apiCtx, familyId, 'Opaque Menu Market List');
+
+    await navigateTo(page, 'Shopping');
+    await page.reload();
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
+    await navigateTo(page, 'Shopping');
+    await page.getByText('Opaque Menu Market List').click();
+
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      document.documentElement.setAttribute('data-display-mode', 'standalone');
+    });
+
+    const quickAdd = page.locator('input[placeholder="Add an item..."]');
+    await quickAdd.focus();
+    await expect(quickAdd).toBeFocused();
+
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    const sidebar = page.locator('.sidebar.mobile-open');
+    await expect(sidebar).toBeVisible();
+
+    const sidebarBackground = await sidebar.evaluate((element) => getComputedStyle(element).backgroundColor);
+    const alphaMatch = sidebarBackground.match(/rgba?\(([^)]+)\)/);
+    const alpha = alphaMatch?.[1]?.split(',').map((part) => Number(part.trim()))[3] ?? 1;
+    expect(alpha).toBe(1);
+  });
 
   test('768px shopping breakpoint keeps items before templates in DOM order', async ({ authedPage: page, apiCtx }) => {
     await page.setViewportSize({ width: 768, height: 900 });

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1663,10 +1663,24 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   -webkit-backdrop-filter: none !important;
 }
 
+:root[data-display-mode="standalone"] .sidebar,
+:root[data-display-mode="standalone"] .bottom-nav,
+:root[data-display-mode="standalone"] .search-overlay,
+:root[data-display-mode="standalone"] .bottom-nav-overflow {
+  background: var(--void-surface);
+}
+
 [data-theme="light"] .bottom-nav-overflow {
   background: rgba(255, 255, 255, 0.92);
   border: 1px solid rgba(0, 0, 0, 0.08);
   box-shadow: 0 -4px 24px -4px rgba(0, 0, 0, 0.12);
+}
+
+:root[data-display-mode="standalone"][data-theme="light"] .sidebar,
+:root[data-display-mode="standalone"][data-theme="light"] .bottom-nav,
+:root[data-display-mode="standalone"][data-theme="light"] .search-overlay,
+:root[data-display-mode="standalone"][data-theme="light"] .bottom-nav-overflow {
+  background: var(--void-surface);
 }
 
 [data-theme="light"] .bottom-nav-overflow-item:hover {


### PR DESCRIPTION
## Summary
- Make standalone/PWA mobile navigation surfaces use solid theme backgrounds when backdrop blur is disabled.
- Cover the shopping quick-add focus case with a mobile Playwright regression.

## Verification
- `npm test -- --runInBand` → 338 passed
- `npm run build` → passed
- `BASE_URL=http://127.0.0.1:3010 npx playwright test --list` → 108 tests collected
- `BASE_URL=http://127.0.0.1:3010 npx playwright test` → 106 passed, 2 skipped

Closes #334
