### PR TITLE
Fix mobile shopping menu opacity on reopen

### DIFF
--- a/frontend/__tests__/components/AppShellMobileNav.test.js
+++ b/frontend/__tests__/components/AppShellMobileNav.test.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AppShell from '../../components/AppShell';
@@ -124,5 +126,11 @@ describe('AppShell mobile bottom navigation', () => {
     fireEvent.click(adminItem);
     expect(setActiveView).toHaveBeenCalledWith('admin');
     expect(document.querySelector('.bottom-nav-overflow')).not.toBeInTheDocument();
+  });
+
+  it('keeps the opened mobile sidebar on an opaque theme surface', () => {
+    const css = fs.readFileSync(path.join(process.cwd(), 'styles', 'globals.css'), 'utf8');
+
+    expect(css).toMatch(/@media \(max-width: 768px\) \{[\s\S]*\.sidebar\.mobile-open \{ transform: translateX\(0\); background: var\(--void-surface\); \}/);
   });
 });

--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -229,7 +229,7 @@ test.describe('Shopping', () => {
     await expect(page.locator('[role="checkbox"][aria-label="Bananas"]')).toBeVisible({ timeout: 10000 });
   });
 
-  test('mobile shopping menu stays opaque while quick add is focused', async ({ authedPage: page, apiCtx }) => {
+  test('mobile shopping menu stays opaque while quick add is focused and reopened', async ({ authedPage: page, apiCtx }) => {
     const viewport = page.viewportSize();
     test.skip(!viewport || viewport.width >= 768, 'Mobile-only shopping menu opacity check');
 
@@ -244,21 +244,31 @@ test.describe('Shopping', () => {
 
     await page.evaluate(() => {
       document.documentElement.setAttribute('data-theme', 'light');
-      document.documentElement.setAttribute('data-display-mode', 'standalone');
+      document.documentElement.removeAttribute('data-display-mode');
     });
 
     const quickAdd = page.locator('input[placeholder="Add an item..."]');
     await quickAdd.focus();
     await expect(quickAdd).toBeFocused();
 
-    await page.getByRole('button', { name: 'Open menu' }).click();
     const sidebar = page.locator('.sidebar.mobile-open');
-    await expect(sidebar).toBeVisible();
+    const assertOpaqueSidebar = async () => {
+      const sidebarBackground = await sidebar.evaluate((element) => getComputedStyle(element).backgroundColor);
+      const alphaMatch = sidebarBackground.match(/rgba?\(([^)]+)\)/);
+      const alpha = alphaMatch?.[1]?.split(',').map((part) => Number(part.trim()))[3] ?? 1;
+      expect(alpha).toBe(1);
+    };
 
-    const sidebarBackground = await sidebar.evaluate((element) => getComputedStyle(element).backgroundColor);
-    const alphaMatch = sidebarBackground.match(/rgba?\(([^)]+)\)/);
-    const alpha = alphaMatch?.[1]?.split(',').map((part) => Number(part.trim()))[3] ?? 1;
-    expect(alpha).toBe(1);
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    await expect(sidebar).toBeVisible();
+    await assertOpaqueSidebar();
+
+    await page.mouse.click(350, 120);
+    await expect(sidebar).toBeHidden();
+
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    await expect(sidebar).toBeVisible();
+    await assertOpaqueSidebar();
   });
 
   test('768px shopping breakpoint keeps items before templates in DOM order', async ({ authedPage: page, apiCtx }) => {

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1767,7 +1767,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 
 @media (max-width: 768px) {
   .sidebar { position: fixed; left: 0; top: 0; width: 260px; min-width: 260px; transform: translateX(-100%); transition: transform 0.3s var(--ease-out-expo); z-index: 60; padding-top: env(safe-area-inset-top); }
-  .sidebar.mobile-open { transform: translateX(0); }
+  .sidebar.mobile-open { transform: translateX(0); background: var(--void-surface); }
   .main-content { margin-left: 0; width: 100%; padding: var(--space-md); padding-bottom: calc(100px + env(safe-area-inset-bottom)); }
   .mobile-header { display: flex; }
   .bottom-nav { display: block; }


### PR DESCRIPTION
## Summary

- Keep the mobile shopping menu opaque every time it is opened.
- Cover the reported reopen path: open the menu, close it, reopen it without leaving Shopping, and verify the menu stays readable.
- Add a small CSS regression guard for the mobile sidebar open state.

Closes #334

## Test plan

- [x] `npm test -- --runInBand`
- [x] `BACKEND_URL=http://127.0.0.1:18000 npm run build`
- [x] `BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/tests/shopping.spec.js --project="Mobile Chrome"`

## Docs impact

No docs changes needed. This is a focused mobile menu readability fix.
