### PR TITLE
Fix shopping quick-add suggestions reopening transparent

### DIFF
--- a/frontend/__tests__/components/ShoppingView.test.js
+++ b/frontend/__tests__/components/ShoppingView.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ShoppingView from '../../components/ShoppingView';
 
@@ -113,7 +113,7 @@ describe('ShoppingView quick add', () => {
 
     const input = screen.getByPlaceholderText('Add an item...');
     expect(input).not.toHaveAttribute('list');
-    expect(document.querySelectorAll('#shopping-item-suggestions option')).toHaveLength(0);
+    expect(screen.queryByRole('listbox', { name: 'Add an item...' })).not.toBeInTheDocument();
   });
 
   test('keeps quick-add suggestions inactive for whitespace-only input', () => {
@@ -127,7 +127,7 @@ describe('ShoppingView quick add', () => {
 
     const input = screen.getByPlaceholderText('Add an item...');
     expect(input).not.toHaveAttribute('list');
-    expect(document.querySelectorAll('#shopping-item-suggestions option')).toHaveLength(0);
+    expect(screen.queryByRole('listbox', { name: 'Add an item...' })).not.toBeInTheDocument();
   });
 
   test('filters quick-add suggestions after typed input', () => {
@@ -143,10 +143,60 @@ describe('ShoppingView quick add', () => {
     });
 
     const input = screen.getByPlaceholderText('Add an item...');
+    fireEvent.focus(input);
 
-    expect(input).toHaveAttribute('list', 'shopping-item-suggestions');
-    const options = Array.from(document.querySelectorAll('#shopping-item-suggestions option')).map((option) => option.value);
+    expect(input).not.toHaveAttribute('list');
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    const options = screen.getAllByRole('option').map((option) => option.textContent);
     expect(options).toEqual(['Milk']);
+  });
+
+  test('supports keyboard selection in the app-controlled quick-add suggestions', () => {
+    setup({
+      newItemName: 'm',
+      items: [
+        { id: 1, name: 'Milk', spec: null, checked: true },
+        { id: 2, name: 'Muesli', spec: null, checked: false },
+      ],
+    });
+
+    const input = screen.getByPlaceholderText('Add an item...');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(input).toHaveAttribute('aria-activedescendant', 'shopping-item-suggestion-0');
+    expect(screen.getByRole('option', { name: 'Milk' })).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input).toHaveAttribute('aria-activedescendant', 'shopping-item-suggestion-1');
+    expect(screen.getByRole('option', { name: 'Muesli' })).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockShoppingState.setNewItemName).toHaveBeenCalledWith('Muesli');
+  });
+
+  test('reopens quick-add suggestions as an opaque app-controlled list after clearing and typing again', () => {
+    const { rerender } = setup({
+      newItemName: 'mi',
+      items: [
+        { id: 1, name: 'Milk', spec: null, checked: true },
+        { id: 2, name: 'Bread', spec: null, checked: false },
+      ],
+    });
+
+    const input = screen.getByPlaceholderText('Add an item...');
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox', { name: 'Add an item...' })).toHaveClass('shopping-item-suggestions');
+
+    mockShoppingState.newItemName = '';
+    rerender(<ShoppingView />);
+    expect(screen.queryByRole('listbox', { name: 'Add an item...' })).not.toBeInTheDocument();
+
+    mockShoppingState.newItemName = 'br';
+    rerender(<ShoppingView />);
+    fireEvent.focus(screen.getByPlaceholderText('Add an item...'));
+    expect(screen.getByRole('option', { name: 'Bread' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: 'Add an item...' })).toHaveClass('shopping-item-suggestions');
   });
 
   test('adds a category field and groups items into collapsible category sections', () => {
@@ -242,7 +292,7 @@ describe('ShoppingView mobile store flow', () => {
     }, { isMobile: true });
 
     const input = screen.getByPlaceholderText('Add an item...');
-    input.focus();
+    act(() => input.focus());
     expect(document.activeElement).toBe(input);
 
     const item = screen.getByRole('checkbox', { name: 'Apples' });

--- a/frontend/components/ShoppingView.js
+++ b/frontend/components/ShoppingView.js
@@ -258,6 +258,8 @@ export default function ShoppingView() {
   const [editingTemplate, setEditingTemplate] = useState(null);
   const [templatesExpanded, setTemplatesExpanded] = useState(false);
   const [collapsedCategories, setCollapsedCategories] = useState({});
+  const [itemSuggestionsOpen, setItemSuggestionsOpen] = useState(false);
+  const [activeItemSuggestion, setActiveItemSuggestion] = useState(null);
   const itemSuggestionQuery = sh.newItemName.trim().toLocaleLowerCase();
   const itemSuggestions = itemSuggestionQuery
     ? Array.from(new Set((sh.items || [])
@@ -270,6 +272,53 @@ export default function ShoppingView() {
   const templatesToggleLabel = templatesVisible
     ? t(messages, 'module.shopping.hide_templates')
     : t(messages, 'module.shopping.show_templates');
+  const showItemSuggestions = itemSuggestionsOpen && itemSuggestions.length > 0;
+  const selectedItemSuggestion = showItemSuggestions && activeItemSuggestion !== null
+    ? itemSuggestions[Math.min(activeItemSuggestion, itemSuggestions.length - 1)]
+    : null;
+
+  function closeItemSuggestions() {
+    setItemSuggestionsOpen(false);
+    setActiveItemSuggestion(null);
+  }
+
+  function selectItemSuggestion(name) {
+    sh.setNewItemName(name);
+    closeItemSuggestions();
+    sh.itemInputRef.current?.focus();
+  }
+
+  function handleItemSuggestionKeyDown(e) {
+    if (e.key === 'Enter') {
+      if (selectedItemSuggestion) {
+        e.preventDefault();
+        selectItemSuggestion(selectedItemSuggestion);
+        return;
+      }
+      e.preventDefault();
+      sh.itemInputRef.current?.form?.requestSubmit();
+      return;
+    }
+
+    if (!showItemSuggestions) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveItemSuggestion((current) => {
+        if (current === null) return 0;
+        return Math.min(current + 1, itemSuggestions.length - 1);
+      });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveItemSuggestion((current) => {
+        if (current === null) return itemSuggestions.length - 1;
+        return Math.max(current - 1, 0);
+      });
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeItemSuggestions();
+    }
+  }
 
   function toggleCategory(category) {
     setCollapsedCategories((prev) => ({ ...prev, [category]: !prev[category] }));
@@ -452,19 +501,58 @@ export default function ShoppingView() {
               {/* Quick-Add Bar */}
               {!isChild && (
                 <form onSubmit={sh.addItem} className="quick-add-bar">
-                  <input
-                    ref={sh.itemInputRef}
-                    className="quick-add-input"
-                    placeholder={t(messages, 'module.shopping.item_name_placeholder')}
-                    value={sh.newItemName}
-                    onChange={(e) => sh.setNewItemName(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); sh.itemInputRef.current?.form?.requestSubmit(); } }}
-                    {...(itemSuggestions.length > 0 ? { list: 'shopping-item-suggestions' } : {})}
-                    required
-                  />
-                  <datalist id="shopping-item-suggestions">
-                    {itemSuggestions.map((name) => <option key={name} value={name}>{name}</option>)}
-                  </datalist>
+                  <div
+                    className="shopping-item-suggest-field"
+                    onBlur={(e) => {
+                      if (!e.currentTarget.contains(e.relatedTarget)) closeItemSuggestions();
+                    }}
+                  >
+                    <input
+                      ref={sh.itemInputRef}
+                      className="quick-add-input"
+                      placeholder={t(messages, 'module.shopping.item_name_placeholder')}
+                      value={sh.newItemName}
+                      onChange={(e) => {
+                        sh.setNewItemName(e.target.value);
+                        setItemSuggestionsOpen(true);
+                        setActiveItemSuggestion(null);
+                      }}
+                      onFocus={() => setItemSuggestionsOpen(true)}
+                      onKeyDown={handleItemSuggestionKeyDown}
+                      autoComplete="off"
+                      aria-autocomplete="list"
+                      aria-expanded={showItemSuggestions}
+                      aria-controls="shopping-item-suggestions"
+                      {...(selectedItemSuggestion ? { 'aria-activedescendant': `shopping-item-suggestion-${activeItemSuggestion}` } : {})}
+                      required
+                    />
+                    {showItemSuggestions && (
+                      <div
+                        id="shopping-item-suggestions"
+                        className="shopping-item-suggestions"
+                        role="listbox"
+                        aria-label={t(messages, 'module.shopping.item_name_placeholder')}
+                      >
+                        {itemSuggestions.map((name, index) => (
+                          <button
+                            id={`shopping-item-suggestion-${index}`}
+                            key={name}
+                            className={`shopping-item-suggestion${selectedItemSuggestion === name ? ' active' : ''}`}
+                            type="button"
+                            role="option"
+                            aria-selected={selectedItemSuggestion === name}
+                            onMouseDown={(e) => e.preventDefault()}
+                            onPointerDown={(e) => e.preventDefault()}
+                            onMouseEnter={() => setActiveItemSuggestion(index)}
+                            onFocus={() => setActiveItemSuggestion(index)}
+                            onClick={() => selectItemSuggestion(name)}
+                          >
+                            {name}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                   <input
                     className="quick-add-input shopping-spec-input"
                     placeholder={t(messages, 'module.shopping.item_spec_placeholder')}

--- a/frontend/e2e/tests/shopping.spec.js
+++ b/frontend/e2e/tests/shopping.spec.js
@@ -214,11 +214,26 @@ test.describe('Shopping', () => {
     await expect(quickAdd).not.toHaveAttribute('list', 'shopping-item-suggestions');
 
     await quickAdd.fill('Mi');
-    await expect(quickAdd).toHaveAttribute('list', 'shopping-item-suggestions');
-    await expect.poll(async () => page.locator('#shopping-item-suggestions option').evaluateAll((options) => options.map((option) => option.value))).toEqual(['Milk']);
+    await expect(quickAdd).not.toHaveAttribute('list', 'shopping-item-suggestions');
+    const suggestionList = page.locator('#shopping-item-suggestions');
+    await expect(suggestionList).toBeVisible();
+    await expect.poll(async () => suggestionList.getByRole('option').evaluateAll((options) => options.map((option) => option.textContent))).toEqual(['Milk']);
+    await expect.poll(async () => suggestionList.evaluate((element) => {
+      const color = getComputedStyle(element).backgroundColor;
+      const alpha = color.match(/rgba?\(([^)]+)\)/)?.[1]?.split(',').map((part) => Number(part.trim()))[3] ?? 1;
+      return alpha;
+    })).toBe(1);
 
     await quickAdd.clear();
-    await expect(quickAdd).not.toHaveAttribute('list', 'shopping-item-suggestions');
+    await expect(suggestionList).toBeHidden();
+    await quickAdd.fill('Mi');
+    await expect(suggestionList).toBeVisible();
+    await expect.poll(async () => suggestionList.evaluate((element) => {
+      const color = getComputedStyle(element).backgroundColor;
+      const alpha = color.match(/rgba?\(([^)]+)\)/)?.[1]?.split(',').map((part) => Number(part.trim()))[3] ?? 1;
+      return alpha;
+    })).toBe(1);
+    await quickAdd.clear();
     await page.locator('[role="checkbox"][aria-label="Apples"]').click();
     await expect(quickAdd).not.toBeFocused();
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1145,6 +1145,43 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .tasks-filter-btn.active { background: var(--void-elevated); color: var(--text-primary); }
 .tasks-count { font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; color: var(--text-muted); margin-left: auto; }
 .quick-add-bar { display: flex; gap: var(--space-sm); padding: var(--space-md); align-items: center; }
+.shopping-item-suggest-field { position: relative; flex: 1; min-width: 0; }
+.shopping-item-suggest-field .quick-add-input { width: 100%; }
+.shopping-item-suggestions {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: grid;
+  gap: 2px;
+  max-height: min(240px, 45vh);
+  overflow-y: auto;
+  padding: 6px;
+  background: var(--void-surface);
+  border: 1px solid var(--glass-border-strong, var(--glass-border));
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  opacity: 1;
+}
+.shopping-item-suggestion {
+  width: 100%;
+  padding: 12px 14px;
+  border: 0;
+  border-radius: calc(var(--radius-sm) - 4px);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.shopping-item-suggestion:hover,
+.shopping-item-suggestion.active { background: var(--void-hover); }
+.shopping-item-suggestion:focus-visible {
+  background: var(--void-hover);
+  outline: 2px solid var(--amethyst);
+  outline-offset: -2px;
+}
 .quick-add-input { flex: 1; background: rgba(255,255,255,0.04); border: 1px solid var(--glass-border); border-radius: var(--radius-sm); padding: 14px 16px; font-family: inherit; font-size: 0.95rem; color: var(--text-primary); transition: all 0.2s; min-height: 44px; }
 .quick-add-input::placeholder { color: var(--text-muted); }
 .quick-add-input:focus-visible { border-color: var(--amethyst); box-shadow: 0 0 0 3px var(--amethyst-glow); outline: 2px solid var(--amethyst); outline-offset: 2px; }
@@ -1803,7 +1840,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .view-title { font-size: 1.3rem; }
   .calendar-month-label { min-width: auto; }
   .quick-add-bar { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 48px; gap: var(--space-xs); align-items: stretch; padding: var(--space-sm); }
-  .quick-add-bar .quick-add-input:first-of-type { grid-column: 1 / 3; grid-row: 1; min-width: 0; width: 100%; }
+  .quick-add-bar .shopping-item-suggest-field { grid-column: 1 / 3; grid-row: 1; min-width: 0; width: 100%; }
+  .quick-add-bar .quick-add-input:first-of-type { min-width: 0; width: 100%; }
   .quick-add-bar .shopping-spec-input { grid-column: 1 / 2; grid-row: 2; width: 100%; min-width: 0; flex: none !important; }
   .quick-add-bar .shopping-category-input { grid-column: 2 / 4; grid-row: 2; width: 100%; min-width: 0; flex: none !important; }
   .quick-add-btn { grid-column: 3; grid-row: 1; width: 48px; min-width: 48px; min-height: 48px; }


### PR DESCRIPTION
## Summary
- Replaces the shopping quick-add name suggestions with an app-controlled opaque list.
- Keeps the native `list`/`datalist` path out of the PWA quick-add flow so suggestions reopen cleanly after clear and retype.
- Adds keyboard navigation and visible focus handling for the custom suggestions.

## Validation
- `git diff --check`
- `npm test -- --runTestsByPath __tests__/components/ShoppingView.test.js --runInBand`
- `npm test -- --runInBand`
- `BACKEND_URL=http://127.0.0.1:18000 npm run build`
- `BASE_URL=http://127.0.0.1:3010 npx playwright test e2e/tests/shopping.spec.js --project="Mobile Chrome"`
- `BASE_URL=http://127.0.0.1:3010 npx playwright test`

Fixes #334
