### PR TITLE
fix: bump python-multipart

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ python-dateutil==2.9.0.post0
 icalendar==7.0.1
 alembic==1.18.4
 apscheduler==3.11.2
-python-multipart==0.0.26
+python-multipart==0.0.27
 redis==5.2.1
 pywebpush==2.0.1
 httpx==0.28.1


### PR DESCRIPTION
## Summary

Fixes Dependabot alert 21 by updating the vulnerable backend runtime dependency `python-multipart` to the first patched release.

- Bump `python-multipart` from `0.0.26` to `0.0.27`
- Keep the change limited to the affected backend manifest
- Verify FastAPI multipart import and upload-adjacent backend tests

## Verification

- `uv run --with-requirements requirements.txt --with pytest python -m pip check`
- `uv run --with-requirements requirements.txt --with pytest python -m pytest tests/test_setup_restore_security.py tests/test_avatar_validation.py -q`
- `uv run --with-requirements requirements.txt --with pytest python -m pytest tests -q`
- Codex review: approved
