### PR TITLE
Harden external notification destinations

### DIFF
--- a/backend/app/core/notification_destinations.py
+++ b/backend/app/core/notification_destinations.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import importlib
+import ipaddress
 import logging
+import os
+import socket
+import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 from urllib.parse import urlsplit
 
+from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy.exc import IntegrityError
 
 from app.core.clock import utcnow
@@ -31,8 +39,13 @@ ALLOWED_APPRISE_SCHEMES = {
     "smtps",
 }
 
+NETWORK_TARGET_SCHEMES = {"gotify", "gotifys", "ntfy", "ntfys", "matrix", "matrixs", "mailto", "mailtos", "smtp", "smtps"}
 REMINDER_EVENT_TYPES = {"calendar.reminder", "task.reminder", "birthday.reminder"}
 TEST_EVENT_TYPE = "notification.test"
+ENCRYPTED_TARGET_PREFIX = "enc:v1:"
+DEFAULT_CONNECT_TIMEOUT_SECONDS = 4.0
+DEFAULT_READ_TIMEOUT_SECONDS = 4.0
+_APPRISE_EGRESS_GUARD_LOCK = threading.Lock()
 SAFE_ERROR_CODES = {
     "invalid_url",
     "provider_unavailable",
@@ -56,13 +69,130 @@ def validate_target_url(value: str) -> str:
         parsed = urlsplit(cleaned)
     except ValueError as exc:
         raise ValueError("Invalid notification destination URL") from exc
-    if not parsed.scheme or parsed.scheme.lower() not in ALLOWED_APPRISE_SCHEMES:
+    scheme = parsed.scheme.lower()
+    if not parsed.scheme or scheme not in ALLOWED_APPRISE_SCHEMES:
         raise ValueError("Invalid notification destination URL")
-    if parsed.scheme.lower() in {"gotify", "gotifys", "ntfy", "ntfys", "tgram", "matrix", "matrixs", "smtp", "smtps"} and not parsed.netloc:
+    if scheme in NETWORK_TARGET_SCHEMES and not parsed.netloc:
         raise ValueError("Invalid notification destination URL")
     if not (parsed.netloc or parsed.path):
         raise ValueError("Invalid notification destination URL")
+    if scheme in NETWORK_TARGET_SCHEMES:
+        _validate_egress_host(parsed.hostname)
     return cleaned
+
+
+def protect_target_url(value: str) -> str:
+    """Validate and encrypt a destination URL before database storage."""
+
+    cleaned = validate_target_url(value)
+    if cleaned.startswith(ENCRYPTED_TARGET_PREFIX):
+        return cleaned
+    token = _target_url_fernet().encrypt(cleaned.encode("utf-8")).decode("ascii")
+    return f"{ENCRYPTED_TARGET_PREFIX}{token}"
+
+
+def reveal_target_url(value: str | None) -> str:
+    """Return the usable destination URL, decrypting new rows and preserving legacy rows."""
+
+    if not value:
+        return ""
+    if not value.startswith(ENCRYPTED_TARGET_PREFIX):
+        return value
+    token = value[len(ENCRYPTED_TARGET_PREFIX):]
+    try:
+        return _target_url_fernet().decrypt(token.encode("ascii")).decode("utf-8")
+    except (InvalidToken, UnicodeDecodeError, ValueError) as exc:
+        raise ValueError("Invalid notification destination URL") from exc
+
+
+def _target_url_fernet() -> Fernet:
+    raw_secret = os.getenv("NOTIFICATION_DESTINATION_SECRET_KEY") or os.getenv("JWT_SECRET") or ""
+    if not raw_secret:
+        raise RuntimeError("NOTIFICATION_DESTINATION_SECRET_KEY or JWT_SECRET is required")
+    key = base64.urlsafe_b64encode(hashlib.sha256(raw_secret.encode("utf-8")).digest())
+    return Fernet(key)
+
+
+def _allowed_private_hosts() -> set[str]:
+    raw = os.getenv("NOTIFICATION_DESTINATION_ALLOWED_HOSTS", "")
+    return {part.strip().lower().strip("[]") for part in raw.replace(";", ",").split(",") if part.strip()}
+
+
+def _private_hosts_globally_allowed() -> bool:
+    return os.getenv("NOTIFICATION_DESTINATION_ALLOW_PRIVATE_HOSTS", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _is_unsafe_address(address: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return True
+    return bool(not ip.is_global or ip.is_multicast)
+
+
+def _host_is_allowlisted(host: str, addresses: list[str]) -> bool:
+    allowed = _allowed_private_hosts()
+    if not allowed:
+        return False
+    host_key = host.lower().strip("[]")
+    return host_key in allowed or any(address.lower().strip("[]") in allowed for address in addresses)
+
+
+def _validate_egress_host(host: str | None) -> None:
+    if not host:
+        raise ValueError("Invalid notification destination URL")
+    normalized = host.lower().strip("[]")
+    if _private_hosts_globally_allowed():
+        return
+
+    addresses = _resolve_egress_addresses(normalized)
+
+    if _host_is_allowlisted(normalized, addresses):
+        return
+    if not addresses or normalized == "localhost" or any(_is_unsafe_address(address) for address in addresses):
+        raise ValueError("Invalid notification destination URL")
+
+
+def _resolve_egress_addresses(host: str) -> list[str]:
+    try:
+        ipaddress.ip_address(host)
+        return [host]
+    except ValueError:
+        if host == "localhost":
+            return ["127.0.0.1"]
+        try:
+            infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+        except socket.gaierror:
+            return []
+        return sorted({str(info[4][0]) for info in infos if info and info[4]})
+
+
+@contextmanager
+def _guard_apprise_egress_resolution():
+    if _private_hosts_globally_allowed():
+        yield
+        return
+
+    with _APPRISE_EGRESS_GUARD_LOCK:
+        original_getaddrinfo = socket.getaddrinfo
+
+        def guarded_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            infos = original_getaddrinfo(host, port, family, type, proto, flags)
+            if host is None:
+                return infos
+            normalized = str(host).lower().strip("[]")
+            addresses = sorted({str(info[4][0]) for info in infos if info and info[4]})
+            if _host_is_allowlisted(normalized, addresses):
+                return infos
+            if not addresses or normalized == "localhost" or any(_is_unsafe_address(address) for address in addresses):
+                raise ValueError("Invalid notification destination URL")
+            return infos
+
+        socket.getaddrinfo = guarded_getaddrinfo
+        try:
+            yield
+        finally:
+            socket.getaddrinfo = original_getaddrinfo
 
 
 def clean_events(events: list[str], *, allow_test: bool = False) -> list[str]:
@@ -78,6 +208,10 @@ def clean_events(events: list[str], *, allow_test: bool = False) -> list[str]:
 
 def redact_target_url(url: str | None) -> str:
     if not url:
+        return "[redacted]"
+    try:
+        url = reveal_target_url(url)
+    except ValueError:
         return "[redacted]"
     try:
         parsed = urlsplit(url)
@@ -139,13 +273,35 @@ def _send_with_apprise(url: str, payload: dict[str, Any]) -> bool:
     notifier = apprise_module.Apprise()
     if not notifier.add(url):
         return False
+    connect_timeout, read_timeout = _apprise_timeout_pair()
+    for server in notifier.servers:
+        if hasattr(server, "socket_connect_timeout"):
+            server.socket_connect_timeout = connect_timeout
+        if hasattr(server, "socket_read_timeout"):
+            server.socket_read_timeout = read_timeout
     title = str(payload.get("title") or "Tribu")
     body_parts = [str(payload.get("body") or "").strip()]
     link = str(payload.get("link") or "").strip()
     if link:
         body_parts.append(link)
     body = "\n".join(part for part in body_parts if part)
-    return bool(notifier.notify(title=title, body=body))
+    with _guard_apprise_egress_resolution():
+        return bool(notifier.notify(title=title, body=body))
+
+
+def _apprise_timeout_pair() -> tuple[float, float]:
+    return (
+        _float_env("NOTIFICATION_DESTINATION_CONNECT_TIMEOUT_SECONDS", DEFAULT_CONNECT_TIMEOUT_SECONDS),
+        _float_env("NOTIFICATION_DESTINATION_READ_TIMEOUT_SECONDS", DEFAULT_READ_TIMEOUT_SECONDS),
+    )
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        value = float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return max(0.5, min(value, 30.0))
 
 
 def _claim_delivery(db, destination: NotificationDestination, payload: dict[str, Any]) -> NotificationDestinationDelivery | None:
@@ -193,7 +349,12 @@ def _deliver_claimed(db, destination: NotificationDestination, delivery: Notific
         return delivery
 
     try:
-        sent = _send_with_apprise(destination.target_url_secret, payload)
+        target_url = reveal_target_url(destination.target_url_secret)
+        validate_target_url(target_url)
+        sent = _send_with_apprise(target_url, payload)
+    except ValueError:
+        delivery.status = "failed"
+        delivery.last_error = "invalid_url"
     except TimeoutError:
         delivery.status = "failed"
         delivery.last_error = "timeout"

--- a/backend/app/modules/notification_destinations_router.py
+++ b/backend/app/modules/notification_destinations_router.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from app.core.deps import current_user, ensure_family_admin
 from app.core.notification_destinations import (
     destination_response,
+    protect_target_url,
     provider_status,
     redact_target_url,
     send_test_notification,
@@ -11,7 +12,7 @@ from app.core.notification_destinations import (
 from app.core.scopes import require_scope
 from app.core.utils import audit_log, ensure_any_admin
 from app.database import get_db
-from app.models import NotificationDestination, User
+from app.models import Membership, NotificationDestination, User
 from app.schemas import (
     AUTH_RESPONSES,
     NOT_FOUND_RESPONSE,
@@ -29,6 +30,19 @@ def _get_destination_or_404(db: Session, destination_id: int) -> NotificationDes
     destination = db.query(NotificationDestination).filter(NotificationDestination.id == destination_id).first()
     if not destination:
         raise HTTPException(status_code=404, detail="Notification destination not found")
+    return destination
+
+
+def _get_destination_for_user_or_404(db: Session, destination_id: int, user_id: int) -> NotificationDestination:
+    destination = _get_destination_or_404(db, destination_id)
+    membership = (
+        db.query(Membership)
+        .filter(Membership.user_id == user_id, Membership.family_id == destination.family_id)
+        .first()
+    )
+    if not membership:
+        raise HTTPException(status_code=404, detail="Notification destination not found")
+    ensure_family_admin(db, user_id, destination.family_id)
     return destination
 
 
@@ -97,7 +111,7 @@ def create_destination(
         family_id=payload.family_id,
         name=payload.name.strip(),
         provider="apprise",
-        target_url_secret=payload.target_url_secret,
+        target_url_secret=protect_target_url(payload.target_url_secret),
         events=payload.events,
         active=payload.active,
         respect_quiet_hours=payload.respect_quiet_hours,
@@ -125,13 +139,12 @@ def update_destination(
     db: Session = Depends(get_db),
     _scope=require_scope("admin:write"),
 ):
-    destination = _get_destination_or_404(db, destination_id)
-    ensure_family_admin(db, user.id, destination.family_id)
+    destination = _get_destination_for_user_or_404(db, destination_id, user.id)
     updates = payload.model_dump(exclude_unset=True)
     if "name" in updates and payload.name is not None:
         destination.name = payload.name.strip()
     if "target_url_secret" in updates and payload.target_url_secret:
-        destination.target_url_secret = payload.target_url_secret
+        destination.target_url_secret = protect_target_url(payload.target_url_secret)
     if "events" in updates and payload.events is not None:
         destination.events = payload.events
     if "active" in updates and payload.active is not None:
@@ -159,8 +172,7 @@ def delete_destination(
     db: Session = Depends(get_db),
     _scope=require_scope("admin:write"),
 ):
-    destination = _get_destination_or_404(db, destination_id)
-    ensure_family_admin(db, user.id, destination.family_id)
+    destination = _get_destination_for_user_or_404(db, destination_id, user.id)
     family_id = destination.family_id
     details = _audit_details(destination, "deleted")
     db.delete(destination)
@@ -182,8 +194,7 @@ def test_destination(
     db: Session = Depends(get_db),
     _scope=require_scope("admin:write"),
 ):
-    destination = _get_destination_or_404(db, destination_id)
-    ensure_family_admin(db, user.id, destination.family_id)
+    destination = _get_destination_for_user_or_404(db, destination_id, user.id)
     audit_log(db, destination.family_id, user.id, "notification_destination_tested", details=_audit_details(destination, "tested"))
     db.commit()
     delivery = send_test_notification(destination.id)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ httpx==0.28.1
 radicale==3.7.1
 a2wsgi==1.10.7
 apprise==1.10.0
+cryptography==46.0.7

--- a/backend/tests/test_notification_destinations.py
+++ b/backend/tests/test_notification_destinations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import socket
+import types
 from datetime import datetime, timedelta
 
 import pytest
@@ -46,6 +48,9 @@ def _set_sqlite_pragma(dbapi_conn, _):
 def setup_db(monkeypatch):
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
+    monkeypatch.setenv("NOTIFICATION_DESTINATION_SECRET_KEY", "notification-destination-test-key")
+    monkeypatch.delenv("NOTIFICATION_DESTINATION_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("NOTIFICATION_DESTINATION_ALLOW_PRIVATE_HOSTS", raising=False)
 
     def _override():
         db = TestSession()
@@ -131,6 +136,7 @@ def _destination(family_id: int, user_id: int, **overrides) -> NotificationDesti
 
 def test_admin_crud_redacts_secret_and_audits_safe_metadata():
     token, family_id, _ = _seed_member()
+    raw_url = "ntfy://ntfy.sh/placeholder-topic?token=placeholder-token"
 
     created = client.post(
         "/notification-destinations",
@@ -138,7 +144,7 @@ def test_admin_crud_redacts_secret_and_audits_safe_metadata():
         json={
             "family_id": family_id,
             "name": "Kitchen ntfy",
-            "target_url_secret": "ntfy://ntfy.sh/placeholder-topic?token=placeholder-token",
+            "target_url_secret": raw_url,
             "events": ["calendar.reminder", "task.reminder"],
             "active": True,
             "respect_quiet_hours": True,
@@ -154,6 +160,19 @@ def test_admin_crud_redacts_secret_and_audits_safe_metadata():
     assert "placeholder-token" not in str(body)
     assert "placeholder-topic" not in str(body)
     assert "target_url_secret" not in body
+
+    db = TestSession()
+    try:
+        stored = db.get(NotificationDestination, body["id"]).target_url_secret
+    finally:
+        db.close()
+
+    from app.core.notification_destinations import reveal_target_url
+
+    assert stored.startswith("enc:v1:")
+    assert raw_url not in stored
+    assert "placeholder-token" not in stored
+    assert reveal_target_url(stored) == raw_url
 
     listed = client.get(f"/notification-destinations?family_id={family_id}", headers=_auth(token))
     assert listed.status_code == 200, listed.json()
@@ -191,7 +210,7 @@ def test_admin_authorization_cross_family_and_pat_scope_split():
         json={
             "family_id": family_id,
             "name": "Gotify",
-            "target_url_secret": "gotify://host.example/token",
+            "target_url_secret": "mailto://user@example.com",
             "events": ["calendar.reminder"],
         },
     )
@@ -209,12 +228,173 @@ def test_admin_authorization_cross_family_and_pat_scope_split():
     assert denied_adult.status_code == 403
 
     denied_outsider = client.delete(f"/notification-destinations/{dest_id}", headers=_auth(outsider_token))
-    assert denied_outsider.status_code == 403
+    assert denied_outsider.status_code == 404
     assert "token" not in str(denied_outsider.json()).lower()
 
 
 @pytest.mark.parametrize("url", [
-    "https://example.com/hook?token=secret-token",
+    "gotify://127.0.0.1/secret-token",
+    "ntfy://localhost/private-topic?token=secret-token",
+    "smtp://169.254.169.254:25?user=secret-token",
+    "gotify://100.64.0.1/secret-token",
+    "mailto://user@127.0.0.1",
+])
+def test_rejects_private_destination_hosts_without_echoing_secret(url):
+    token, family_id, _ = _seed_member()
+
+    resp = client.post(
+        "/notification-destinations",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Unsafe internal",
+            "target_url_secret": url,
+            "events": ["calendar.reminder"],
+        },
+    )
+
+    assert resp.status_code == 422
+    body = str(resp.json())
+    assert "secret-token" not in body
+    assert "private-topic" not in body
+
+
+def test_telegram_destination_token_is_not_treated_as_destination_host(monkeypatch):
+    token, family_id, _ = _seed_member()
+
+    def fail_if_resolved(*_args, **_kwargs):
+        raise AssertionError("Telegram token should not be resolved as a hostname at save time")
+
+    from app.core import notification_destinations as destinations_core
+
+    monkeypatch.setattr(destinations_core.socket, "getaddrinfo", fail_if_resolved)
+
+    resp = client.post(
+        "/notification-destinations",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Telegram reminders",
+            "target_url_secret": "tgram://123456:placeholder-token/987654321",
+            "events": ["calendar.reminder"],
+        },
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["url_redacted"] == "tgram://[redacted]"
+
+
+def test_rejects_network_destination_when_hostname_cannot_be_resolved(monkeypatch):
+    token, family_id, _ = _seed_member()
+
+    def unresolved(*_args, **_kwargs):
+        raise socket.gaierror("name not known")
+
+    from app.core import notification_destinations as destinations_core
+
+    monkeypatch.setattr(destinations_core.socket, "getaddrinfo", unresolved)
+
+    resp = client.post(
+        "/notification-destinations",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Unresolved Gotify",
+            "target_url_secret": "gotify://unresolved.example.test/secret-token",
+            "events": ["calendar.reminder"],
+        },
+    )
+
+    assert resp.status_code == 422
+    assert "secret-token" not in str(resp.json())
+
+
+def test_apprise_send_revalidates_dns_resolution_at_notify_time(monkeypatch):
+    from app.core import notification_destinations as destinations_core
+
+    class FakeServer:
+        pass
+
+    class FakeApprise:
+        def __init__(self):
+            self.servers = [FakeServer()]
+
+        def add(self, _url):
+            return True
+
+        def notify(self, *, title, body):
+            assert title
+            assert body
+            destinations_core.socket.getaddrinfo("rebind.example", 443, proto=socket.IPPROTO_TCP)
+            return True
+
+    def fake_import_module(name):
+        assert name == "apprise"
+        return types.SimpleNamespace(Apprise=FakeApprise)
+
+    def rebound_to_private(*_args, **_kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", 443))]
+
+    monkeypatch.setattr(destinations_core.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(destinations_core.socket, "getaddrinfo", rebound_to_private)
+
+    with pytest.raises(ValueError):
+        destinations_core._send_with_apprise(
+            "gotify://rebind.example/secret-token",
+            {"title": "Test", "body": "Body", "link": None},
+        )
+
+
+def test_private_destination_host_can_be_enabled_with_explicit_allowlist(monkeypatch):
+    token, family_id, _ = _seed_member()
+    monkeypatch.setenv("NOTIFICATION_DESTINATION_ALLOWED_HOSTS", "127.0.0.1")
+
+    resp = client.post(
+        "/notification-destinations",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Allowed local Gotify",
+            "target_url_secret": "gotify://127.0.0.1/secret-token",
+            "events": ["calendar.reminder"],
+        },
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["url_redacted"] == "gotify://[redacted]"
+
+
+def test_existing_private_destination_url_is_blocked_at_delivery_time(monkeypatch):
+    token, family_id, user_id = _seed_member()
+    db = TestSession()
+    try:
+        dest = _destination(family_id, user_id, target_url_secret="gotify://127.0.0.1/secret-token")
+        db.add(dest)
+        db.commit()
+        dest_id = dest.id
+    finally:
+        db.close()
+
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+
+    def fail_if_called(url, payload):
+        calls.append((url, payload))
+        return True
+
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", fail_if_called)
+
+    resp = client.post(f"/notification-destinations/{dest_id}/test", headers=_auth(token))
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["status"] == "failed"
+    assert resp.json()["error"] == "invalid_url"
+    assert calls == []
+
+
+@pytest.mark.parametrize("url", [
+    "https://example.com/hook?token=***",
     "file:///tmp/secret-token",
     "json://localhost",
 ])
@@ -242,7 +422,7 @@ def test_provider_status_and_test_send_with_mocked_sender(monkeypatch):
     token, family_id, user_id = _seed_member()
     db = TestSession()
     try:
-        dest = _destination(family_id, user_id, target_url_secret="mailto://user@mail.example")
+        dest = _destination(family_id, user_id, target_url_secret="mailto://user@example.com")
         db.add(dest)
         db.commit()
         dest_id = dest.id
@@ -267,7 +447,7 @@ def test_provider_status_and_test_send_with_mocked_sender(monkeypatch):
     resp = client.post(f"/notification-destinations/{dest_id}/test", headers=_auth(token))
     assert resp.status_code == 200, resp.json()
     assert resp.json()["status"] == "delivered"
-    assert calls[0][0] == "mailto://user@mail.example"
+    assert calls[0][0] == "mailto://user@example.com"
     assert calls[0][1]["event_type"] == "notification.test"
     assert "password" not in str(resp.json())
 

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -18,7 +18,7 @@ This page gives visitors and contributors a quick view of what Tribu ships today
 | Templates | Repeatable household plans | Reusable task and routine templates. |
 | Gifts | Gift planning | Gift ideas and planning around family dates. |
 | Rewards | Family motivation | Token economy, reward catalog, earning rules, and progress. |
-| Notifications | In-app reminders | Household activity, overdue tasks, upcoming events, and relevant alerts. |
+| Notifications | In-app, browser push, and external reminder destinations | Household activity, overdue tasks, upcoming events, and Apprise-backed human reminder channels with encrypted destination URLs and private-host guardrails. |
 | Activity | Household timeline | Recent changes and quick context. |
 | Search | Global search | Fast lookup across core household data. |
 | Shared Home Display | Read-only household screen | Pairable device tokens for kitchen tablets, hallway screens, and wall displays. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -49,7 +49,11 @@ See [Self-Hosting: Push Notifications](https://github.com/itsDNNS/tribu/wiki/Sel
 
 Admins can add Apprise-backed destinations for human-readable household reminders, such as Gotify, ntfy, Telegram, Matrix, or email. Use placeholder examples in public docs and screenshots, for example `ntfy://ntfy.sh/family-topic` or `gotify://host.example/token`, not real tokens.
 
-External destinations are another place where household data is visible. Delivery depends on the destination platform and is not guaranteed. If Apprise is not installed in the backend image, Tribu keeps in-app and browser push notifications working and shows the destination provider as unavailable. Database backups can contain raw Apprise destination secrets under the app's existing backup model.
+Destination URLs are stored encrypted with a key derived from `NOTIFICATION_DESTINATION_SECRET_KEY` when set, otherwise `JWT_SECRET`. Keep that secret stable across upgrades and restores. Existing legacy plaintext rows are still readable so old installs can upgrade in place, but newly saved or updated destinations are encrypted.
+
+External destinations are another place where household data is visible. Delivery depends on the destination platform and is not guaranteed. If Apprise is not installed in the backend image, Tribu keeps in-app and browser push notifications working, allows admins to save destinations for later, and disables test sends until the provider is available.
+
+By default Tribu only allows destination URLs that resolve to globally routable addresses, and blocks unresolved hostnames plus loopback, link-local, private, shared, multicast, reserved, or unspecified addresses. The same guard is applied again while Apprise resolves the destination for delivery. This avoids using notification destinations as a server-side request path into the host or LAN. If a self-hosted Gotify, ntfy, Matrix, or SMTP server is intentionally private, allow it explicitly with `NOTIFICATION_DESTINATION_ALLOWED_HOSTS=gotify.lan,192.168.1.10` or, for fully trusted single-household deployments, `NOTIFICATION_DESTINATION_ALLOW_PRIVATE_HOSTS=true`. Prefer the host allowlist over the global switch.
 
 ## Phone Sync (CalDAV / CardDAV)
 

--- a/frontend/__tests__/components/NotificationCenter.test.js
+++ b/frontend/__tests__/components/NotificationCenter.test.js
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NotificationCenter from '../../components/NotificationCenter';
+import { buildMessages } from '../../lib/i18n';
+
+let mockAppState = {};
+
+jest.mock('../../lib/api', () => ({
+  apiMarkNotificationRead: jest.fn(),
+  apiMarkAllNotificationsRead: jest.fn(),
+  apiDeleteNotification: jest.fn(),
+}));
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+function baseState(overrides = {}) {
+  return {
+    messages: buildMessages('en'),
+    lang: 'en',
+    notifications: [],
+    setNotifications: jest.fn(),
+    unreadCount: 0,
+    setUnreadCount: jest.fn(),
+    loadNotifications: jest.fn(),
+    setActiveView: jest.fn(),
+    isAdmin: true,
+    isChild: false,
+    demoMode: false,
+    ...overrides,
+  };
+}
+
+describe('NotificationCenter external destination callout', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockAppState = baseState();
+  });
+
+  it('links admins from the notifications page to household notification destinations', () => {
+    const setActiveView = jest.fn();
+    mockAppState = baseState({ setActiveView });
+
+    render(<NotificationCenter />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure household notifications' }));
+
+    expect(sessionStorage.getItem('tribu_settings_tab')).toBe('notification_destinations');
+    expect(setActiveView).toHaveBeenCalledWith('settings');
+  });
+
+  it('does not show the destination callout to non-admins', () => {
+    mockAppState = baseState({ isAdmin: false });
+
+    render(<NotificationCenter />);
+
+    expect(screen.queryByRole('button', { name: 'Configure household notifications' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/NotificationDestinationsTab.test.js
+++ b/frontend/__tests__/components/NotificationDestinationsTab.test.js
@@ -100,6 +100,82 @@ describe('NotificationDestinationsTab', () => {
     render(<NotificationDestinationsTab />);
 
     expect(await screen.findByText('Apprise is not available on this server')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Add destination' })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Household Gotify' } });
+    fireEvent.change(screen.getByLabelText('Apprise URL'), { target: { value: 'gotify://host.example/placeholder-token' } });
+    expect(screen.getByRole('button', { name: 'Add destination' })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Add destination' }));
+    await waitFor(() => expect(api.apiCreateNotificationDestination).toHaveBeenCalledTimes(1));
+  });
+
+  it('disables test sends while the provider is unavailable', async () => {
+    api.apiGetNotificationDestinationProviderStatus.mockResolvedValue({ ok: true, data: { available: false } });
+    api.apiListNotificationDestinations.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 9,
+        name: 'Household Gotify',
+        provider: 'apprise',
+        url_redacted: 'gotify://[redacted]',
+        events: ['calendar.reminder'],
+        active: true,
+        respect_quiet_hours: true,
+        has_secret: true,
+        last_status: 'never',
+      }],
+    });
+
+    render(<NotificationDestinationsTab />);
+
+    expect(await screen.findByText('Household Gotify')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send test' })).toBeDisabled();
+  });
+
+  it('shows failed test notifications as errors instead of success toasts', async () => {
+    api.apiListNotificationDestinations.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 9,
+        name: 'Household Gotify',
+        provider: 'apprise',
+        url_redacted: 'gotify://[redacted]',
+        events: ['calendar.reminder'],
+        active: true,
+        respect_quiet_hours: true,
+        has_secret: true,
+        last_status: 'never',
+      }],
+    });
+    api.apiTestNotificationDestination.mockResolvedValue({ ok: true, data: { status: 'failed', error: 'send_failed' } });
+
+    render(<NotificationDestinationsTab />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Send test' }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Test notification failed'));
+    expect(toastSuccess).not.toHaveBeenCalledWith('Test notification failed');
+  });
+
+  it('asks for confirmation before deleting a destination', async () => {
+    api.apiListNotificationDestinations.mockResolvedValue({
+      ok: true,
+      data: [{
+        id: 9,
+        name: 'Household Gotify',
+        provider: 'apprise',
+        url_redacted: 'gotify://[redacted]',
+        events: ['calendar.reminder'],
+        active: true,
+        respect_quiet_hours: true,
+        has_secret: true,
+        last_status: 'never',
+      }],
+    });
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<NotificationDestinationsTab />);
+    fireEvent.click(await screen.findByLabelText('Delete Household Gotify'));
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete notification destination Household Gotify?');
+    expect(api.apiDeleteNotificationDestination).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/__tests__/components/SettingsNotificationDestinations.test.js
+++ b/frontend/__tests__/components/SettingsNotificationDestinations.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SettingsView from '../../components/settings';
 import { buildMessages } from '../../lib/i18n';
@@ -46,5 +46,19 @@ describe('Settings notification destinations visibility', () => {
       expect(screen.queryByRole('button', { name: 'Household notifications' })).not.toBeInTheDocument();
       unmount();
     }
+  });
+
+  it('resets the active tab when the current tab becomes hidden', () => {
+    mockAppState = baseState();
+    const { rerender } = render(<SettingsView />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Household notifications' }));
+    expect(screen.getByText('Notification destination panel')).toBeInTheDocument();
+
+    mockAppState = baseState({ isAdmin: false });
+    rerender(<SettingsView />);
+
+    expect(screen.queryByText('Notification destination panel')).not.toBeInTheDocument();
+    expect(screen.getByText('Account panel')).toBeInTheDocument();
   });
 });

--- a/frontend/components/NotificationCenter.js
+++ b/frontend/components/NotificationCenter.js
@@ -13,7 +13,7 @@ const TYPE_ICONS = {
 };
 
 export default function NotificationCenter({ onClose } = {}) {
-  const { messages, lang, notifications, setNotifications, unreadCount, setUnreadCount, loadNotifications, setActiveView } = useApp();
+  const { messages, lang, notifications, setNotifications, unreadCount, setUnreadCount, loadNotifications, setActiveView, isAdmin, isChild, demoMode } = useApp();
   const closeBtnRef = useRef(null);
 
   useEffect(() => {
@@ -58,6 +58,14 @@ export default function NotificationCenter({ onClose } = {}) {
       setActiveView(notif.link);
     }
   }
+
+  function handleConfigureHouseholdNotifications() {
+    if (typeof window !== 'undefined') sessionStorage.setItem('tribu_settings_tab', 'notification_destinations');
+    if (onClose) onClose();
+    setActiveView('settings');
+  }
+
+  const canManageHouseholdDestinations = !onClose && isAdmin && !isChild && !demoMode;
 
   // Group notifications by time period
   const groups = (() => {
@@ -112,6 +120,17 @@ export default function NotificationCenter({ onClose } = {}) {
               <CheckCheck size={16} /> {t(messages, 'notifications_mark_all_read')}
             </button>
           )}
+        </div>
+      )}
+
+      {canManageHouseholdDestinations && (
+        <div className="notif-empty notification-destination-callout">
+          <Bell size={24} className="notif-empty-icon" />
+          <p><strong>{t(messages, 'notifications_external_destinations_title')}</strong></p>
+          <p>{t(messages, 'notifications_external_destinations_help')}</p>
+          <button type="button" className="bento-empty-action" onClick={handleConfigureHouseholdNotifications}>
+            {t(messages, 'notifications_external_destinations_action')}
+          </button>
         </div>
       )}
 

--- a/frontend/components/settings/NotificationDestinationsTab.js
+++ b/frontend/components/settings/NotificationDestinationsTab.js
@@ -23,7 +23,7 @@ export default function NotificationDestinationsTab() {
   const { familyId, messages } = useApp();
   const { success: toastSuccess, error: toastError } = useToast();
   const [destinations, setDestinations] = useState([]);
-  const [providerStatus, setProviderStatus] = useState({ available: true });
+  const [providerStatus, setProviderStatus] = useState({ available: null });
   const [form, setForm] = useState(emptyForm);
   const [busy, setBusy] = useState(false);
 
@@ -36,6 +36,7 @@ export default function NotificationDestinationsTab() {
   const loadProviderStatus = useCallback(async () => {
     const res = await api.apiGetNotificationDestinationProviderStatus();
     if (res.ok) setProviderStatus(res.data || { available: false });
+    else setProviderStatus({ available: false });
   }, []);
 
   useEffect(() => { loadProviderStatus(); }, [loadProviderStatus]);
@@ -55,7 +56,7 @@ export default function NotificationDestinationsTab() {
 
   async function handleCreate(event) {
     event.preventDefault();
-    if (!familyId || !providerStatus.available) return;
+    if (!familyId) return;
     setBusy(true);
     try {
       const res = await api.apiCreateNotificationDestination({
@@ -84,6 +85,8 @@ export default function NotificationDestinationsTab() {
   }
 
   async function handleDelete(destination) {
+    const message = t(messages, 'notification_destinations_delete_confirm').replace('{name}', destination.name);
+    if (!window.confirm(message)) return;
     const res = await api.apiDeleteNotificationDestination(destination.id);
     if (res.ok) {
       toastSuccess(t(messages, 'notification_destinations_deleted'));
@@ -95,15 +98,16 @@ export default function NotificationDestinationsTab() {
     const res = await api.apiTestNotificationDestination(destination.id);
     if (res.ok) {
       const delivered = res.data?.status === 'delivered';
-      toastSuccess(t(messages, delivered ? 'notification_destinations_test_sent' : 'notification_destinations_test_failed'));
+      if (delivered) toastSuccess(t(messages, 'notification_destinations_test_sent'));
+      else toastError(t(messages, 'notification_destinations_test_failed'));
       await loadDestinations();
     } else {
       toastError(t(messages, 'notification_destinations_test_failed'));
     }
   }
 
-  const providerAvailable = providerStatus?.available !== false;
-  const canSubmit = providerAvailable && !busy && familyId && form.name.trim() && form.target_url_secret.trim() && form.events.length > 0;
+  const providerAvailable = providerStatus?.available === true;
+  const canSubmit = !busy && familyId && form.name.trim() && form.target_url_secret.trim() && form.events.length > 0;
 
   return (
     <div className="settings-grid">
@@ -204,7 +208,7 @@ export default function NotificationDestinationsTab() {
                   <button className="btn-ghost" onClick={() => handleToggle(destination)}>
                     {t(messages, destination.active ? 'notification_destinations_disable' : 'notification_destinations_enable')}
                   </button>
-                  <button className="btn-sm" onClick={() => handleTest(destination)}>{t(messages, 'notification_destinations_send_test')}</button>
+                  <button className="btn-sm" disabled={!providerAvailable || busy} onClick={() => handleTest(destination)}>{t(messages, 'notification_destinations_send_test')}</button>
                   <button
                     className="btn-ghost"
                     aria-label={t(messages, 'notification_destinations_delete_label').replace('{name}', destination.name)}

--- a/frontend/components/settings/index.js
+++ b/frontend/components/settings/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { User, Navigation, Bell, BellRing, Database, Key, Heart, Smartphone, ChevronRight, ArrowLeft, PlugZap } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { t } from '../../lib/i18n';
@@ -27,14 +27,25 @@ const TABS = [
 export default function SettingsView() {
   const { messages, isMobile, isChild, isAdmin, demoMode } = useApp();
   const visibleTabs = TABS.filter(tab => tab.visible({ isAdmin, isChild, demoMode }));
-  const [activeTab, setActiveTab] = useState(isMobile ? null : visibleTabs[0]?.key || 'account');
+  const [activeTab, setActiveTabState] = useState(() => {
+    if (isMobile) return null;
+    const requested = typeof window !== 'undefined' ? sessionStorage.getItem('tribu_settings_tab') : null;
+    return visibleTabs.some(tab => tab.key === requested) ? requested : visibleTabs[0]?.key || 'account';
+  });
+  const setActiveTab = useCallback((tabKey) => {
+    if (tabKey && typeof window !== 'undefined') sessionStorage.setItem('tribu_settings_tab', tabKey);
+    setActiveTabState(tabKey);
+  }, []);
 
-  // When switching from mobile to desktop, ensure a tab is selected
+  // Keep the selected tab valid as device layout and role visibility change.
   useEffect(() => {
-    if (!isMobile && activeTab === null) {
-      setActiveTab(visibleTabs[0]?.key || 'account');
+    const activeVisible = activeTab !== null && visibleTabs.some(tab => tab.key === activeTab);
+    if (isMobile) {
+      if (activeTab !== null && !activeVisible) setActiveTab(null);
+      return;
     }
-  }, [isMobile, activeTab, visibleTabs]);
+    if (!activeVisible) setActiveTab(visibleTabs[0]?.key || 'account');
+  }, [isMobile, activeTab, visibleTabs, setActiveTab]);
 
   const activeTabConfig = visibleTabs.find(tab => tab.key === activeTab);
   const ActiveComponent = activeTabConfig?.component;

--- a/frontend/i18n/core/bg.json
+++ b/frontend/i18n/core/bg.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/cs.json
+++ b/frontend/i18n/core/cs.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/da.json
+++ b/frontend/i18n/core/da.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Deaktivieren",
   "notification_destinations_enable": "Aktivieren",
   "notification_destinations_send_test": "Test senden",
-  "notification_destinations_delete_label": "{name} löschen"
+  "notification_destinations_delete_label": "{name} löschen",
+  "notification_destinations_delete_confirm": "Benachrichtigungsziel {name} löschen?",
+  "notifications_external_destinations_title": "Erinnerungen außerhalb von Tribu senden",
+  "notifications_external_destinations_help": "Admins können Gotify, ntfy, Telegram, Matrix oder E-Mail-Ziele für Haushaltserinnerungen hinzufügen.",
+  "notifications_external_destinations_action": "Haushaltsbenachrichtigungen konfigurieren"
 }

--- a/frontend/i18n/core/el.json
+++ b/frontend/i18n/core/el.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/es.json
+++ b/frontend/i18n/core/es.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/et.json
+++ b/frontend/i18n/core/et.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/fi.json
+++ b/frontend/i18n/core/fi.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/fr.json
+++ b/frontend/i18n/core/fr.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/ga.json
+++ b/frontend/i18n/core/ga.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/hr.json
+++ b/frontend/i18n/core/hr.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/hu.json
+++ b/frontend/i18n/core/hu.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/it.json
+++ b/frontend/i18n/core/it.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/lt.json
+++ b/frontend/i18n/core/lt.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/lv.json
+++ b/frontend/i18n/core/lv.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/nb.json
+++ b/frontend/i18n/core/nb.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/nl.json
+++ b/frontend/i18n/core/nl.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/pl.json
+++ b/frontend/i18n/core/pl.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/pt.json
+++ b/frontend/i18n/core/pt.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/ro.json
+++ b/frontend/i18n/core/ro.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/sk.json
+++ b/frontend/i18n/core/sk.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/sl.json
+++ b/frontend/i18n/core/sl.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }

--- a/frontend/i18n/core/sv.json
+++ b/frontend/i18n/core/sv.json
@@ -693,5 +693,9 @@
   "notification_destinations_disable": "Disable",
   "notification_destinations_enable": "Enable",
   "notification_destinations_send_test": "Send test",
-  "notification_destinations_delete_label": "Delete {name}"
+  "notification_destinations_delete_label": "Delete {name}",
+  "notification_destinations_delete_confirm": "Delete notification destination {name}?",
+  "notifications_external_destinations_title": "Send reminders outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
+  "notifications_external_destinations_action": "Configure household notifications"
 }


### PR DESCRIPTION
## Summary

- Encrypts saved external notification destination URLs while keeping existing plaintext rows readable for upgrades.
- Blocks private, unresolved, and otherwise non-global destination hosts by default, with explicit self-hosting allowlist controls for trusted private services.
- Rechecks destination resolution during delivery and keeps first-party notification delivery independent from external destination failures.
- Updates Settings and notification-center UX for destination setup, unavailable providers, test-send failures, and delete confirmation.
- Updates self-hosting documentation and the notification feature matrix.

## Validation

- Backend notification destination tests passed.
- Full backend test suite passed.
- Frontend unit tests passed.
- Production frontend build passed.
- Browser end-to-end suite passed.
- Locale key and placeholder parity passed.
- Whitespace diff check passed.

## Docs

- Repository docs updated in this PR.
- GitHub Wiki pages for Self-Hosting and Notifications were updated separately.
