### PR TITLE
Send shopping events to notification destinations

### DIFF
--- a/backend/app/core/notification_destinations.py
+++ b/backend/app/core/notification_destinations.py
@@ -21,7 +21,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app.core.clock import utcnow
 from app.database import SessionLocal
-from app.models import NotificationDestination, NotificationDestinationDelivery
+from app.models import Membership, NotificationDestination, NotificationDestinationDelivery, NotificationPreference
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,8 @@ ALLOWED_APPRISE_SCHEMES = {
 
 NETWORK_TARGET_SCHEMES = {"gotify", "gotifys", "ntfy", "ntfys", "matrix", "matrixs", "mailto", "mailtos", "smtp", "smtps"}
 REMINDER_EVENT_TYPES = {"calendar.reminder", "task.reminder", "birthday.reminder"}
+SHOPPING_EVENT_TYPES = {"shopping.list.changed", "shopping.item.changed"}
+DESTINATION_EVENT_TYPES = REMINDER_EVENT_TYPES | SHOPPING_EVENT_TYPES
 TEST_EVENT_TYPE = "notification.test"
 ENCRYPTED_TARGET_PREFIX = "enc:v1:"
 DEFAULT_CONNECT_TIMEOUT_SECONDS = 4.0
@@ -196,7 +198,7 @@ def _guard_apprise_egress_resolution():
 
 
 def clean_events(events: list[str], *, allow_test: bool = False) -> list[str]:
-    allowed = set(REMINDER_EVENT_TYPES)
+    allowed = set(DESTINATION_EVENT_TYPES)
     if allow_test:
         allowed.add(TEST_EVENT_TYPE)
     cleaned = sorted({event.strip() for event in (events or []) if event and event.strip()})
@@ -250,7 +252,7 @@ def provider_status() -> dict[str, Any]:
         "provider": "apprise",
         "available": is_provider_available(),
         "allowed_schemes": sorted(ALLOWED_APPRISE_SCHEMES),
-        "events": sorted(REMINDER_EVENT_TYPES),
+        "events": sorted(DESTINATION_EVENT_TYPES),
     }
 
 
@@ -411,6 +413,46 @@ def send_test_notification(destination_id: int) -> NotificationDestinationDelive
         db.close()
 
 
+def _in_quiet_hours(quiet_start: str | None, quiet_end: str | None, now: datetime) -> bool:
+    if not quiet_start or not quiet_end:
+        return False
+    try:
+        start_h, start_m = map(int, quiet_start.split(":"))
+        end_h, end_m = map(int, quiet_end.split(":"))
+    except (ValueError, AttributeError):
+        return False
+
+    current_minutes = now.hour * 60 + now.minute
+    start_minutes = start_h * 60 + start_m
+    end_minutes = end_h * 60 + end_m
+
+    if start_minutes <= end_minutes:
+        return start_minutes <= current_minutes < end_minutes
+    return current_minutes >= start_minutes or current_minutes < end_minutes
+
+
+def _family_destination_users(db, family_id: int, now: datetime) -> list[EligibleReminderUser]:
+    memberships = db.query(Membership).filter(Membership.family_id == family_id).all()
+    if not memberships:
+        return []
+    user_ids = [membership.user_id for membership in memberships]
+    prefs = {
+        pref.user_id: pref
+        for pref in db.query(NotificationPreference).filter(NotificationPreference.user_id.in_(user_ids)).all()
+    }
+    return [
+        EligibleReminderUser(
+            user_id=uid,
+            in_quiet_hours=_in_quiet_hours(
+                prefs[uid].quiet_start if uid in prefs else None,
+                prefs[uid].quiet_end if uid in prefs else None,
+                now,
+            ),
+        )
+        for uid in user_ids
+    ]
+
+
 def dispatch_family_notification(
     *,
     family_id: int,
@@ -421,9 +463,11 @@ def dispatch_family_notification(
     source_type: str,
     source_id: int,
     trigger_key: str,
-    eligible_users: list[EligibleReminderUser],
+    eligible_users: list[EligibleReminderUser] | None = None,
 ) -> list[NotificationDestinationDelivery]:
-    if event_type not in REMINDER_EVENT_TYPES or not eligible_users:
+    if event_type not in DESTINATION_EVENT_TYPES:
+        return []
+    if event_type in REMINDER_EVENT_TYPES and not eligible_users:
         return []
 
     payload = {
@@ -444,13 +488,16 @@ def dispatch_family_notification(
             .filter(NotificationDestination.family_id == family_id)
             .all()
         )
+        quiet_hour_users = eligible_users
+        if quiet_hour_users is None:
+            quiet_hour_users = _family_destination_users(db, family_id, utcnow())
         deliveries: list[NotificationDestinationDelivery] = []
         for destination in destinations:
             if not destination.active:
                 continue
             if event_type not in (destination.events or []):
                 continue
-            if destination.respect_quiet_hours and not any(not user.in_quiet_hours for user in eligible_users):
+            if destination.respect_quiet_hours and quiet_hour_users and not any(not user.in_quiet_hours for user in quiet_hour_users):
                 _mark_destination(destination, status="quiet_hours", now=utcnow(), error="quiet_hours")
                 db.commit()
                 continue

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -1,8 +1,9 @@
-
-from app.core.utils import utcnow
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+
+from app.core.utils import utcnow
 
 from app.core.deps import current_user, ensure_adult, ensure_family_membership
 from app.core.activity import record_activity
@@ -17,6 +18,7 @@ from app.core.ws_broadcast import (
     broadcast_list_created,
     broadcast_list_deleted,
 )
+from app.core.notification_destinations import dispatch_family_notification
 from app.core.webhooks import dispatch_webhook_event
 from app.schemas import (
     AUTH_RESPONSES,
@@ -41,6 +43,7 @@ from app.core.errors import (
 )
 
 router = APIRouter(prefix="/shopping", tags=["shopping"], responses={**AUTH_RESPONSES})
+logger = logging.getLogger(__name__)
 
 
 def _clean_optional_text(value: str | None) -> str | None:
@@ -84,6 +87,35 @@ def _list_response(sl: ShoppingList) -> ShoppingListResponse:
         item_count=total,
         checked_count=checked,
     )
+
+
+def _dispatch_shopping_destination_event(
+    *,
+    family_id: int,
+    event_type: str,
+    title: str,
+    body: str,
+    link: str,
+    source_type: str,
+    source_id: int,
+    action: str,
+) -> None:
+    try:
+        dispatch_family_notification(
+            family_id=family_id,
+            event_type=event_type,
+            title=title,
+            body=body,
+            link=link,
+            source_type=source_type,
+            source_id=source_id,
+            trigger_key=f"{source_type}:{source_id}:{action}:{utcnow().isoformat()}",
+            eligible_users=None,
+        )
+    except Exception:
+        # External destinations must never block the saved shopping action.
+        logger.warning("Shopping notification destination dispatch failed")
+        return
 
 
 def _template_response(template: ShoppingTemplate) -> ShoppingTemplateResponse:
@@ -258,6 +290,17 @@ def apply_template(
     for item in created_items:
         db.refresh(item)
         broadcast_item_added(sl.id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
+    if created_items:
+        _dispatch_shopping_destination_event(
+            family_id=sl.family_id,
+            event_type="shopping.item.changed",
+            title="Shopping items added",
+            body=f'{user.display_name or "Someone"} added {len(created_items)} items from "{template.name}" to "{sl.name}".',
+            link=f"/shopping?list={sl.id}",
+            source_type="shopping_list",
+            source_id=sl.id,
+            action="template_applied",
+        )
 
     return ShoppingTemplateApplyResponse(
         template_id=template.id,
@@ -331,6 +374,16 @@ def create_list(
         event_type="shopping.list.created",
         data={"list_id": sl.id, "name": sl.name, "created_by_user_id": user.id},
     )
+    _dispatch_shopping_destination_event(
+        family_id=sl.family_id,
+        event_type="shopping.list.changed",
+        title="Shopping list created",
+        body=f'{user.display_name or "Someone"} created shopping list "{sl.name}".',
+        link=f"/shopping?list={sl.id}",
+        source_type="shopping_list",
+        source_id=sl.id,
+        action="created",
+    )
     return resp
 
 
@@ -352,9 +405,20 @@ def delete_list(
         raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
     family_id = sl.family_id
     ensure_adult(db, user.id, family_id)
+    list_name = sl.name
     db.delete(sl)
     db.commit()
     broadcast_list_deleted(family_id, list_id)
+    _dispatch_shopping_destination_event(
+        family_id=family_id,
+        event_type="shopping.list.changed",
+        title="Shopping list deleted",
+        body=f'{user.display_name or "Someone"} deleted shopping list "{list_name}".',
+        link="/shopping",
+        source_type="shopping_list",
+        source_id=list_id,
+        action="deleted",
+    )
     return {"status": "deleted", "list_id": list_id}
 
 
@@ -437,6 +501,16 @@ def add_item(
             event_type="shopping.item.updated",
             data={"list_id": list_id, "item_id": checked_match.id, "name": checked_match.name, "checked": checked_match.checked},
         )
+        _dispatch_shopping_destination_event(
+            family_id=sl.family_id,
+            event_type="shopping.item.changed",
+            title="Shopping item restored",
+            body=f'{user.display_name or "Someone"} restored "{checked_match.name}" on "{sl.name}".',
+            link=f"/shopping?list={list_id}",
+            source_type="shopping_item",
+            source_id=checked_match.id,
+            action="restored",
+        )
         return checked_match
 
     item = ShoppingItem(
@@ -468,6 +542,16 @@ def add_item(
         family_id=sl.family_id,
         event_type="shopping.item.created",
         data={"list_id": list_id, "item_id": item.id, "name": item.name, "checked": item.checked},
+    )
+    _dispatch_shopping_destination_event(
+        family_id=sl.family_id,
+        event_type="shopping.item.changed",
+        title="Shopping item added",
+        body=f'{user.display_name or "Someone"} added "{item.name}" to "{sl.name}".',
+        link=f"/shopping?list={list_id}",
+        source_type="shopping_item",
+        source_id=item.id,
+        action="created",
     )
     return item
 
@@ -529,6 +613,22 @@ def update_item(
         event_type="shopping.item.updated",
         data={"list_id": item.list_id, "item_id": item.id, "name": item.name, "checked": item.checked},
     )
+    if payload.checked is True:
+        item_action = "checked"
+    elif payload.checked is False:
+        item_action = "unchecked"
+    else:
+        item_action = "updated"
+    _dispatch_shopping_destination_event(
+        family_id=sl.family_id,
+        event_type="shopping.item.changed",
+        title="Shopping item updated",
+        body=f'{user.display_name or "Someone"} {item_action} "{item.name}" on "{sl.name}".',
+        link=f"/shopping?list={item.list_id}",
+        source_type="shopping_item",
+        source_id=item.id,
+        action=item_action,
+    )
     return item
 
 
@@ -551,9 +651,20 @@ def delete_item(
     sl = db.query(ShoppingList).filter(ShoppingList.id == item.list_id).first()
     ensure_adult(db, user.id, sl.family_id)
     list_id = item.list_id
+    item_name = item.name
     db.delete(item)
     db.commit()
     broadcast_item_deleted(list_id, item_id)
+    _dispatch_shopping_destination_event(
+        family_id=sl.family_id,
+        event_type="shopping.item.changed",
+        title="Shopping item deleted",
+        body=f'{user.display_name or "Someone"} deleted "{item_name}" from "{sl.name}".',
+        link=f"/shopping?list={list_id}",
+        source_type="shopping_item",
+        source_id=item_id,
+        action="deleted",
+    )
     return {"status": "deleted", "item_id": item_id}
 
 

--- a/backend/tests/test_notification_destinations.py
+++ b/backend/tests/test_notification_destinations.py
@@ -25,6 +25,10 @@ from app.models import (
     NotificationDestinationDelivery,
     NotificationPreference,
     PersonalAccessToken,
+    ShoppingItem,
+    ShoppingList,
+    ShoppingTemplate,
+    ShoppingTemplateItem,
     User,
 )
 from app.security import PAT_PREFIX, hash_password
@@ -552,6 +556,345 @@ def test_scheduler_dispatches_once_across_users_and_retries(monkeypatch):
         assert len(deliveries) == 1
         assert deliveries[0].status == "delivered"
         assert deliveries[0].attempts == 1
+    finally:
+        db.close()
+
+
+def test_provider_status_and_crud_accept_shopping_event_destinations():
+    token, family_id, _ = _seed_member()
+
+    status = client.get("/notification-destinations/provider/status", headers=_auth(token))
+    assert status.status_code == 200
+    assert "shopping.list.changed" in status.json()["events"]
+    assert "shopping.item.changed" in status.json()["events"]
+
+    created = client.post(
+        "/notification-destinations",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Shopping channel",
+            "target_url_secret": "mailto://shopping@example.com",
+            "events": ["shopping.list.changed", "shopping.item.changed"],
+        },
+    )
+    assert created.status_code == 200, created.json()
+    assert created.json()["events"] == ["shopping.item.changed", "shopping.list.changed"]
+
+    invalid = client.post(
+        "/notification-destinations",
+        headers=_auth(token),
+        json={
+            "family_id": family_id,
+            "name": "Audit channel",
+            "target_url_secret": "mailto://audit@example.com",
+            "events": ["audit.log.created"],
+        },
+    )
+    assert invalid.status_code == 422
+
+
+def test_shopping_list_destination_delivery_runs_after_saved_change(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,shopping:read,shopping:write")
+    db = TestSession()
+    try:
+        db.add(_destination(family_id, user_id, target_url_secret="mailto://shopping@example.com", events=["shopping.list.changed"]))
+        db.commit()
+    finally:
+        db.close()
+
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+
+    def fake_send(_url, payload):
+        check_db = TestSession()
+        try:
+            saved = check_db.get(ShoppingList, payload["source_id"])
+            assert saved is not None
+            assert saved.name == "Groceries"
+        finally:
+            check_db.close()
+        calls.append(payload)
+        return True
+
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", fake_send)
+
+    resp = client.post(
+        "/shopping/lists",
+        headers=_auth(token),
+        json={"family_id": family_id, "name": "Groceries"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert len(calls) == 1
+    assert calls[0]["event_type"] == "shopping.list.changed"
+    assert calls[0]["source_type"] == "shopping_list"
+    assert calls[0]["title"] == "Shopping list created"
+    assert calls[0]["link"] == f"/shopping?list={resp.json()['id']}"
+
+    db = TestSession()
+    try:
+        deliveries = db.query(NotificationDestinationDelivery).all()
+        assert len(deliveries) == 1
+        assert deliveries[0].status == "delivered"
+    finally:
+        db.close()
+
+
+def test_shopping_item_destination_failure_is_isolated_and_filters_destinations(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,shopping:read,shopping:write")
+    created_list = client.post(
+        "/shopping/lists",
+        headers=_auth(token),
+        json={"family_id": family_id, "name": "Errands"},
+    )
+    assert created_list.status_code == 200, created_list.json()
+    list_id = created_list.json()["id"]
+
+    db = TestSession()
+    try:
+        db.add_all([
+            _destination(family_id, user_id, name="Matching", target_url_secret="mailto://shopping@example.com", events=["shopping.item.changed"]),
+            _destination(family_id, user_id, name="Inactive", active=False, target_url_secret="mailto://inactive@example.com", events=["shopping.item.changed"]),
+            _destination(family_id, user_id, name="Reminder only", target_url_secret="mailto://reminder@example.com", events=["calendar.reminder"]),
+        ])
+        db.commit()
+    finally:
+        db.close()
+
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+
+    def failing_send(_url, payload):
+        calls.append(payload)
+        raise RuntimeError("destination down")
+
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", failing_send)
+
+    resp = client.post(
+        f"/shopping/lists/{list_id}/items",
+        headers=_auth(token),
+        json={"name": "Milk"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert len(calls) == 1
+    assert calls[0]["event_type"] == "shopping.item.changed"
+    assert calls[0]["source_type"] == "shopping_item"
+    assert calls[0]["title"] == "Shopping item added"
+
+    db = TestSession()
+    try:
+        saved_item = db.get(ShoppingItem, resp.json()["id"])
+        assert saved_item is not None
+        assert saved_item.name == "Milk"
+        deliveries = db.query(NotificationDestinationDelivery).all()
+        assert len(deliveries) == 1
+        assert deliveries[0].status == "failed"
+        assert deliveries[0].last_error == "send_failed"
+    finally:
+        db.close()
+
+
+def test_shopping_item_destination_update_actions_include_unchecked(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,shopping:read,shopping:write")
+    created_list = client.post(
+        "/shopping/lists",
+        headers=_auth(token),
+        json={"family_id": family_id, "name": "Market"},
+    )
+    assert created_list.status_code == 200, created_list.json()
+    list_id = created_list.json()["id"]
+
+    db = TestSession()
+    try:
+        db.add(_destination(family_id, user_id, target_url_secret="mailto://items@example.com", events=["shopping.item.changed"]))
+        db.commit()
+    finally:
+        db.close()
+
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", lambda _url, payload: calls.append(payload) or True)
+
+    created_item = client.post(
+        f"/shopping/lists/{list_id}/items",
+        headers=_auth(token),
+        json={"name": "Apples"},
+    )
+    assert created_item.status_code == 200, created_item.json()
+    item_id = created_item.json()["id"]
+
+    checked = client.patch(f"/shopping/items/{item_id}", headers=_auth(token), json={"checked": True})
+    assert checked.status_code == 200, checked.json()
+
+    unchecked = client.patch(f"/shopping/items/{item_id}", headers=_auth(token), json={"checked": False})
+    assert unchecked.status_code == 200, unchecked.json()
+
+    assert [call["trigger_key"].split(":")[2] for call in calls] == ["created", "checked", "unchecked"]
+    assert calls[-1]["body"] == 'User admin unchecked "Apples" on "Market".'
+
+
+def test_shopping_template_apply_sends_item_destination_after_items_are_saved(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,shopping:read,shopping:write")
+    created_list = client.post(
+        "/shopping/lists",
+        headers=_auth(token),
+        json={"family_id": family_id, "name": "Weekly shop"},
+    )
+    assert created_list.status_code == 200, created_list.json()
+    list_id = created_list.json()["id"]
+
+    db = TestSession()
+    try:
+        template = ShoppingTemplate(family_id=family_id, name="Breakfast", created_by_user_id=user_id)
+        db.add(template)
+        db.flush()
+        db.add_all([
+            ShoppingTemplateItem(template_id=template.id, name="Milk", position=0),
+            ShoppingTemplateItem(template_id=template.id, name="Oats", position=1),
+        ])
+        db.add(_destination(family_id, user_id, target_url_secret="mailto://template@example.com", events=["shopping.item.changed"]))
+        db.commit()
+        template_id = template.id
+    finally:
+        db.close()
+
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+
+    def fake_send(_url, payload):
+        check_db = TestSession()
+        try:
+            saved_items = check_db.query(ShoppingItem).filter(ShoppingItem.list_id == list_id).all()
+            assert {item.name for item in saved_items} == {"Milk", "Oats"}
+        finally:
+            check_db.close()
+        calls.append(payload)
+        return True
+
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", fake_send)
+
+    applied = client.post(
+        f"/shopping/templates/{template_id}/apply",
+        headers=_auth(token),
+        json={"list_id": list_id},
+    )
+
+    assert applied.status_code == 200, applied.json()
+    assert applied.json()["added_count"] == 2
+    assert len(calls) == 1
+    assert calls[0]["event_type"] == "shopping.item.changed"
+    assert calls[0]["source_type"] == "shopping_list"
+    assert calls[0]["source_id"] == list_id
+    assert calls[0]["title"] == "Shopping items added"
+    assert "2 items" in calls[0]["body"]
+
+
+def test_shopping_destination_respects_household_quiet_hours(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,shopping:read,shopping:write")
+    _, _, other_user_id = _seed_member(family_id=family_id, suffix="quiet-member")
+    now = datetime(2026, 5, 10, 1, 30, 0)
+
+    db = TestSession()
+    try:
+        db.add_all([
+            NotificationPreference(user_id=user_id, reminders_enabled=True, reminder_minutes=30, quiet_start="22:00", quiet_end="06:00"),
+            NotificationPreference(user_id=other_user_id, reminders_enabled=True, reminder_minutes=30, quiet_start="22:00", quiet_end="06:00"),
+            _destination(
+                family_id,
+                user_id,
+                name="Quiet shopping channel",
+                target_url_secret="mailto://quiet@example.com",
+                events=["shopping.list.changed"],
+                respect_quiet_hours=True,
+            ),
+        ])
+        db.commit()
+    finally:
+        db.close()
+
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "utcnow", lambda: now)
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", lambda _url, payload: calls.append(payload) or True)
+
+    resp = client.post(
+        "/shopping/lists",
+        headers=_auth(token),
+        json={"family_id": family_id, "name": "Quiet groceries"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert calls == []
+
+    db = TestSession()
+    try:
+        saved = db.get(ShoppingList, resp.json()["id"])
+        assert saved is not None
+        destination = db.query(NotificationDestination).filter(NotificationDestination.name == "Quiet shopping channel").one()
+        assert destination.last_status == "quiet_hours"
+        assert destination.last_error == "quiet_hours"
+        assert db.query(NotificationDestinationDelivery).count() == 0
+    finally:
+        db.close()
+
+
+def test_shopping_destination_sends_when_any_household_member_is_awake(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,shopping:read,shopping:write")
+    _, _, other_user_id = _seed_member(family_id=family_id, suffix="awake-member")
+    now = datetime(2026, 5, 10, 22, 30, 0)
+
+    db = TestSession()
+    try:
+        db.add_all([
+            NotificationPreference(user_id=user_id, reminders_enabled=True, reminder_minutes=30, quiet_start="22:00", quiet_end="23:00"),
+            NotificationPreference(user_id=other_user_id, reminders_enabled=True, reminder_minutes=30, quiet_start="23:00", quiet_end="06:00"),
+            _destination(
+                family_id,
+                user_id,
+                name="Awake shopping channel",
+                target_url_secret="mailto://awake@example.com",
+                events=["shopping.list.changed"],
+                respect_quiet_hours=True,
+            ),
+        ])
+        db.commit()
+    finally:
+        db.close()
+
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "utcnow", lambda: now)
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", lambda _url, payload: calls.append(payload) or True)
+
+    resp = client.post(
+        "/shopping/lists",
+        headers=_auth(token),
+        json={"family_id": family_id, "name": "Awake groceries"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert len(calls) == 1
+    assert calls[0]["event_type"] == "shopping.list.changed"
+
+    db = TestSession()
+    try:
+        destination = db.query(NotificationDestination).filter(NotificationDestination.name == "Awake shopping channel").one()
+        assert destination.last_status == "delivered"
+        assert db.query(NotificationDestinationDelivery).count() == 1
     finally:
         db.close()
 

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -18,7 +18,7 @@ This page gives visitors and contributors a quick view of what Tribu ships today
 | Templates | Repeatable household plans | Reusable task and routine templates. |
 | Gifts | Gift planning | Gift ideas and planning around family dates. |
 | Rewards | Family motivation | Token economy, reward catalog, earning rules, and progress. |
-| Notifications | In-app, browser push, and external reminder destinations | Household activity, overdue tasks, upcoming events, and Apprise-backed human reminder channels with encrypted destination URLs and private-host guardrails. |
+| Notifications | In-app, browser push, and external destinations | Household activity, overdue tasks, upcoming events, and Apprise-backed human channels for reminders plus opt-in shopping activity with encrypted destination URLs and private-host guardrails. |
 | Activity | Household timeline | Recent changes and quick context. |
 | Search | Global search | Fast lookup across core household data. |
 | Shared Home Display | Read-only household screen | Pairable device tokens for kitchen tablets, hallway screens, and wall displays. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -47,11 +47,11 @@ See [Self-Hosting: Push Notifications](https://github.com/itsDNNS/tribu/wiki/Sel
 
 ## Household Notification Destinations (Optional)
 
-Admins can add Apprise-backed destinations for human-readable household reminders, such as Gotify, ntfy, Telegram, Matrix, or email. Use placeholder examples in public docs and screenshots, for example `ntfy://ntfy.sh/family-topic` or `gotify://host.example/token`, not real tokens.
+Admins can add Apprise-backed destinations for human-readable household reminders and opt-in shopping activity, such as Gotify, ntfy, Telegram, Matrix, or email. Use placeholder examples in public docs and screenshots, for example `ntfy://ntfy.sh/family-topic` or `gotify://host.example/token`, not real tokens.
 
 Destination URLs are stored encrypted with a key derived from `NOTIFICATION_DESTINATION_SECRET_KEY` when set, otherwise `JWT_SECRET`. Keep that secret stable across upgrades and restores. Existing legacy plaintext rows are still readable so old installs can upgrade in place, but newly saved or updated destinations are encrypted.
 
-External destinations are another place where household data is visible. Delivery depends on the destination platform and is not guaranteed. If Apprise is not installed in the backend image, Tribu keeps in-app and browser push notifications working, allows admins to save destinations for later, and disables test sends until the provider is available.
+External destinations are another place where household data is visible. Reminder events can include calendar, task, and birthday reminder details. Shopping events are opt-in and can include list names, item names, and action context. Delivery depends on the destination platform and is not guaranteed. If Apprise is not installed in the backend image, Tribu keeps in-app and browser push notifications working, allows admins to save destinations for later, and disables test sends until the provider is available.
 
 By default Tribu only allows destination URLs that resolve to globally routable addresses, and blocks unresolved hostnames plus loopback, link-local, private, shared, multicast, reserved, or unspecified addresses. The same guard is applied again while Apprise resolves the destination for delivery. This avoids using notification destinations as a server-side request path into the host or LAN. If a self-hosted Gotify, ntfy, Matrix, or SMTP server is intentionally private, allow it explicitly with `NOTIFICATION_DESTINATION_ALLOWED_HOSTS=gotify.lan,192.168.1.10` or, for fully trusted single-household deployments, `NOTIFICATION_DESTINATION_ALLOW_PRIVATE_HOSTS=true`. Prefer the host allowlist over the global switch.
 

--- a/frontend/__tests__/components/NotificationDestinationsTab.test.js
+++ b/frontend/__tests__/components/NotificationDestinationsTab.test.js
@@ -36,7 +36,7 @@ describe('NotificationDestinationsTab', () => {
         name: 'Kitchen ntfy',
         provider: 'apprise',
         url_redacted: 'ntfy://[redacted]',
-        events: ['calendar.reminder', 'task.reminder'],
+        events: ['calendar.reminder', 'task.reminder', 'shopping.item.changed'],
         active: true,
         respect_quiet_hours: true,
         has_secret: true,
@@ -51,6 +51,7 @@ describe('NotificationDestinationsTab', () => {
     expect(screen.getByText(/Destination URLs may contain passwords or tokens/)).toBeInTheDocument();
     expect(screen.queryByText(/placeholder-token/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/placeholder-topic/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Shopping item changes/).length).toBeGreaterThan(0);
   });
 
   it('creates a destination and sends safe test notifications', async () => {
@@ -58,6 +59,8 @@ describe('NotificationDestinationsTab', () => {
 
     fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Household Gotify' } });
     fireEvent.change(screen.getByLabelText('Apprise URL'), { target: { value: 'gotify://host.example/placeholder-token' } });
+    expect(screen.getByLabelText('Shopping list changes')).not.toBeChecked();
+    fireEvent.click(screen.getByLabelText('Shopping item changes'));
     fireEvent.click(screen.getByRole('button', { name: 'Add destination' }));
 
     await waitFor(() => expect(api.apiCreateNotificationDestination).toHaveBeenCalledTimes(1));
@@ -65,8 +68,9 @@ describe('NotificationDestinationsTab', () => {
       family_id: 1,
       name: 'Household Gotify',
       target_url_secret: 'gotify://host.example/placeholder-token',
-      events: expect.arrayContaining(['calendar.reminder']),
+      events: expect.arrayContaining(['calendar.reminder', 'shopping.item.changed']),
     }));
+    expect(api.apiCreateNotificationDestination.mock.calls[0][0].events).not.toContain('shopping.list.changed');
     expect(toastSuccess).toHaveBeenCalledWith('Notification destination saved');
 
     api.apiListNotificationDestinations.mockResolvedValue({

--- a/frontend/components/settings/NotificationDestinationsTab.js
+++ b/frontend/components/settings/NotificationDestinationsTab.js
@@ -9,6 +9,8 @@ const DESTINATION_EVENTS = [
   ['calendar.reminder', 'notification_destinations_event_calendar'],
   ['task.reminder', 'notification_destinations_event_task'],
   ['birthday.reminder', 'notification_destinations_event_birthday'],
+  ['shopping.list.changed', 'notification_destinations_event_shopping_list'],
+  ['shopping.item.changed', 'notification_destinations_event_shopping_item'],
 ];
 
 const emptyForm = {

--- a/frontend/i18n/core/bg.json
+++ b/frontend/i18n/core/bg.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Типове събития",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Изпращайте напомняния и покупки извън Tribu",
+  "notifications_external_destinations_help": "Администраторите могат да добавят Gotify, ntfy, Telegram, Matrix или имейл дестинации за домашни напомняния и избрана активност при пазаруване.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Промени в списъците за пазаруване",
+  "notification_destinations_event_shopping_item": "Промени в артикулите за пазаруване"
 }

--- a/frontend/i18n/core/cs.json
+++ b/frontend/i18n/core/cs.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Typy událostí",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Posílejte připomínky a nákupy mimo Tribu",
+  "notifications_external_destinations_help": "Administrátoři mohou přidat cíle Gotify, ntfy, Telegram, Matrix nebo e-mail pro domácí připomínky a vybranou nákupní aktivitu.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Změny nákupních seznamů",
+  "notification_destinations_event_shopping_item": "Změny nákupních položek"
 }

--- a/frontend/i18n/core/da.json
+++ b/frontend/i18n/core/da.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Hændelsestyper",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Send påmindelser og indkøb uden for Tribu",
+  "notifications_external_destinations_help": "Administratorer kan tilføje Gotify-, ntfy-, Telegram-, Matrix- eller maildestinationer til husstandens påmindelser og valgt indkøbsaktivitet.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Ændringer i indkøbslister",
+  "notification_destinations_event_shopping_item": "Ændringer i indkøbsvarer"
 }

--- a/frontend/i18n/core/de.json
+++ b/frontend/i18n/core/de.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Küchen-ntfy",
   "notification_destinations_url": "Apprise-URL",
   "notification_destinations_examples": "Beispiele: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Nutze in Doku und Screenshots Platzhalter statt echter Secrets.",
-  "notification_destinations_events": "Erinnerungstypen",
+  "notification_destinations_events": "Ereignistypen",
   "notification_destinations_event_calendar": "Kalendererinnerungen",
   "notification_destinations_event_task": "Aufgabenerinnerungen",
   "notification_destinations_event_birthday": "Geburtstagserinnerungen",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Test senden",
   "notification_destinations_delete_label": "{name} löschen",
   "notification_destinations_delete_confirm": "Benachrichtigungsziel {name} löschen?",
-  "notifications_external_destinations_title": "Erinnerungen außerhalb von Tribu senden",
-  "notifications_external_destinations_help": "Admins können Gotify, ntfy, Telegram, Matrix oder E-Mail-Ziele für Haushaltserinnerungen hinzufügen.",
-  "notifications_external_destinations_action": "Haushaltsbenachrichtigungen konfigurieren"
+  "notifications_external_destinations_title": "Erinnerungen und Einkäufe außerhalb von Tribu senden",
+  "notifications_external_destinations_help": "Admins können Gotify-, ntfy-, Telegram-, Matrix- oder E-Mail-Ziele für Haushaltserinnerungen und ausgewählte Einkaufsaktivität hinzufügen.",
+  "notifications_external_destinations_action": "Haushaltsbenachrichtigungen konfigurieren",
+  "notification_destinations_event_shopping_list": "Änderungen an Einkaufslisten",
+  "notification_destinations_event_shopping_item": "Änderungen an Einkaufsartikeln"
 }

--- a/frontend/i18n/core/el.json
+++ b/frontend/i18n/core/el.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Τύποι συμβάντων",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Στείλτε υπενθυμίσεις και αγορές εκτός Tribu",
+  "notifications_external_destinations_help": "Οι διαχειριστές μπορούν να προσθέσουν προορισμούς Gotify, ntfy, Telegram, Matrix ή email για υπενθυμίσεις νοικοκυριού και επιλεγμένη δραστηριότητα αγορών.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Αλλαγές λιστών αγορών",
+  "notification_destinations_event_shopping_item": "Αλλαγές ειδών αγορών"
 }

--- a/frontend/i18n/core/en.json
+++ b/frontend/i18n/core/en.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Event types",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Send reminders and shopping activity outside Tribu",
+  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders and selected shopping activity.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Shopping list changes",
+  "notification_destinations_event_shopping_item": "Shopping item changes"
 }

--- a/frontend/i18n/core/es.json
+++ b/frontend/i18n/core/es.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Tipos de eventos",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Enviar recordatorios y compras fuera de Tribu",
+  "notifications_external_destinations_help": "Los administradores pueden añadir destinos Gotify, ntfy, Telegram, Matrix o correo para recordatorios del hogar y actividad de compras seleccionada.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Cambios en listas de compras",
+  "notification_destinations_event_shopping_item": "Cambios en artículos de compras"
 }

--- a/frontend/i18n/core/et.json
+++ b/frontend/i18n/core/et.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Sündmuste tüübid",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Saada meeldetuletusi ja ostutegevust väljaspool Tribut",
+  "notifications_external_destinations_help": "Administraatorid saavad lisada Gotify, ntfy, Telegrami, Matrixi või e-posti sihtkohti majapidamise meeldetuletuste ja valitud ostutegevuse jaoks.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Ostunimekirjade muudatused",
+  "notification_destinations_event_shopping_item": "Ostukaupade muudatused"
 }

--- a/frontend/i18n/core/fi.json
+++ b/frontend/i18n/core/fi.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Tapahtumatyypit",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Lähetä muistutuksia ja ostostapahtumia Tribun ulkopuolelle",
+  "notifications_external_destinations_help": "Ylläpitäjät voivat lisätä Gotify-, ntfy-, Telegram-, Matrix- tai sähköpostikohteita kotitalouden muistutuksille ja valitulle ostostoiminnalle.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Ostoslistojen muutokset",
+  "notification_destinations_event_shopping_item": "Ostosnimikkeiden muutokset"
 }

--- a/frontend/i18n/core/fr.json
+++ b/frontend/i18n/core/fr.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Types d’événements",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Envoyer rappels et courses hors de Tribu",
+  "notifications_external_destinations_help": "Les administrateurs peuvent ajouter des destinations Gotify, ntfy, Telegram, Matrix ou e-mail pour les rappels du foyer et certaines activités de courses.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Modifications des listes de courses",
+  "notification_destinations_event_shopping_item": "Modifications des articles de courses"
 }

--- a/frontend/i18n/core/ga.json
+++ b/frontend/i18n/core/ga.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Cineálacha imeachtaí",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Seol meabhrúcháin agus siopadóireacht lasmuigh de Tribu",
+  "notifications_external_destinations_help": "Is féidir le riarthóirí cinn scríbe Gotify, ntfy, Telegram, Matrix nó ríomhphoist a chur leis do mheabhrúcháin teaghlaigh agus do ghníomhaíocht siopadóireachta roghnaithe.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Athruithe ar liostaí siopadóireachta",
+  "notification_destinations_event_shopping_item": "Athruithe ar mhíreanna siopadóireachta"
 }

--- a/frontend/i18n/core/hr.json
+++ b/frontend/i18n/core/hr.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Vrste događaja",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Šaljite podsjetnike i kupnju izvan Tribua",
+  "notifications_external_destinations_help": "Administratori mogu dodati Gotify, ntfy, Telegram, Matrix ili e-mail odredišta za podsjetnike kućanstva i odabranu aktivnost kupnje.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Promjene popisa za kupnju",
+  "notification_destinations_event_shopping_item": "Promjene stavki za kupnju"
 }

--- a/frontend/i18n/core/hu.json
+++ b/frontend/i18n/core/hu.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Eseménytípusok",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Emlékeztetők és bevásárlások küldése Tribun kívül",
+  "notifications_external_destinations_help": "Az adminok Gotify-, ntfy-, Telegram-, Matrix- vagy e-mail célokat adhatnak hozzá háztartási emlékeztetőkhöz és kiválasztott bevásárlási aktivitáshoz.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Bevásárlólisták változásai",
+  "notification_destinations_event_shopping_item": "Bevásárlótételek változásai"
 }

--- a/frontend/i18n/core/it.json
+++ b/frontend/i18n/core/it.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Tipi di evento",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Invia promemoria e spesa fuori da Tribu",
+  "notifications_external_destinations_help": "Gli amministratori possono aggiungere destinazioni Gotify, ntfy, Telegram, Matrix o email per promemoria domestici e attività della spesa selezionate.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Modifiche alle liste della spesa",
+  "notification_destinations_event_shopping_item": "Modifiche agli articoli della spesa"
 }

--- a/frontend/i18n/core/lt.json
+++ b/frontend/i18n/core/lt.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Įvykių tipai",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Siųskite priminimus ir pirkinius už Tribu ribų",
+  "notifications_external_destinations_help": "Administratoriai gali pridėti Gotify, ntfy, Telegram, Matrix arba el. pašto paskirties vietas namų priminimams ir pasirinktai pirkinių veiklai.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Pirkinių sąrašų pakeitimai",
+  "notification_destinations_event_shopping_item": "Pirkinių prekių pakeitimai"
 }

--- a/frontend/i18n/core/lv.json
+++ b/frontend/i18n/core/lv.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Notikumu veidi",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Sūtiet atgādinājumus un iepirkšanos ārpus Tribu",
+  "notifications_external_destinations_help": "Administratori var pievienot Gotify, ntfy, Telegram, Matrix vai e-pasta galamērķus mājsaimniecības atgādinājumiem un izvēlētai iepirkšanās aktivitātei.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Iepirkumu sarakstu izmaiņas",
+  "notification_destinations_event_shopping_item": "Iepirkumu preču izmaiņas"
 }

--- a/frontend/i18n/core/nb.json
+++ b/frontend/i18n/core/nb.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Hendelsestyper",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Send påminnelser og handling utenfor Tribu",
+  "notifications_external_destinations_help": "Administratorer kan legge til Gotify-, ntfy-, Telegram-, Matrix- eller e-postmål for husstandens påminnelser og valgt handleaktivitet.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Endringer i handlelister",
+  "notification_destinations_event_shopping_item": "Endringer i handlevarer"
 }

--- a/frontend/i18n/core/nl.json
+++ b/frontend/i18n/core/nl.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Gebeurtenistypen",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Stuur herinneringen en boodschappen buiten Tribu",
+  "notifications_external_destinations_help": "Beheerders kunnen Gotify-, ntfy-, Telegram-, Matrix- of e-mailbestemmingen toevoegen voor huishoudelijke herinneringen en geselecteerde boodschappenactiviteit.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Wijzigingen in boodschappenlijsten",
+  "notification_destinations_event_shopping_item": "Wijzigingen in boodschappenitems"
 }

--- a/frontend/i18n/core/pl.json
+++ b/frontend/i18n/core/pl.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Typy zdarzeń",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Wysyłaj przypomnienia i zakupy poza Tribu",
+  "notifications_external_destinations_help": "Administratorzy mogą dodać miejsca docelowe Gotify, ntfy, Telegram, Matrix lub e-mail dla przypomnień domowych i wybranej aktywności zakupowej.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Zmiany list zakupów",
+  "notification_destinations_event_shopping_item": "Zmiany pozycji zakupów"
 }

--- a/frontend/i18n/core/pt.json
+++ b/frontend/i18n/core/pt.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Tipos de evento",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Enviar lembretes e compras fora do Tribu",
+  "notifications_external_destinations_help": "Administradores podem adicionar destinos Gotify, ntfy, Telegram, Matrix ou e-mail para lembretes da casa e atividade de compras selecionada.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Alterações em listas de compras",
+  "notification_destinations_event_shopping_item": "Alterações em itens de compras"
 }

--- a/frontend/i18n/core/ro.json
+++ b/frontend/i18n/core/ro.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Tipuri de evenimente",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Trimite mementouri și cumpărături în afara Tribu",
+  "notifications_external_destinations_help": "Administratorii pot adăuga destinații Gotify, ntfy, Telegram, Matrix sau e-mail pentru mementouri ale gospodăriei și activitate de cumpărături selectată.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Modificări ale listelor de cumpărături",
+  "notification_destinations_event_shopping_item": "Modificări ale articolelor de cumpărături"
 }

--- a/frontend/i18n/core/sk.json
+++ b/frontend/i18n/core/sk.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Typy udalostí",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Posielajte pripomienky a nákupy mimo Tribu",
+  "notifications_external_destinations_help": "Administrátori môžu pridať ciele Gotify, ntfy, Telegram, Matrix alebo e-mail pre domáce pripomienky a vybranú nákupnú aktivitu.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Zmeny nákupných zoznamov",
+  "notification_destinations_event_shopping_item": "Zmeny nákupných položiek"
 }

--- a/frontend/i18n/core/sl.json
+++ b/frontend/i18n/core/sl.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Vrste dogodkov",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Pošiljajte opomnike in nakupe zunaj Tribu",
+  "notifications_external_destinations_help": "Skrbniki lahko dodajo cilje Gotify, ntfy, Telegram, Matrix ali e-pošto za gospodinjske opomnike in izbrano nakupovalno dejavnost.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Spremembe nakupovalnih seznamov",
+  "notification_destinations_event_shopping_item": "Spremembe nakupovalnih izdelkov"
 }

--- a/frontend/i18n/core/sv.json
+++ b/frontend/i18n/core/sv.json
@@ -672,7 +672,7 @@
   "notification_destinations_name_placeholder": "Kitchen ntfy",
   "notification_destinations_url": "Apprise URL",
   "notification_destinations_examples": "Examples: ntfy://ntfy.sh/family-topic, gotify://host.example/token, tgram://bot-token/chat-id. Use placeholders in docs and never paste shared secrets into screenshots.",
-  "notification_destinations_events": "Reminder types",
+  "notification_destinations_events": "Händelsetyper",
   "notification_destinations_event_calendar": "Calendar reminders",
   "notification_destinations_event_task": "Task reminders",
   "notification_destinations_event_birthday": "Birthday reminders",
@@ -695,7 +695,9 @@
   "notification_destinations_send_test": "Send test",
   "notification_destinations_delete_label": "Delete {name}",
   "notification_destinations_delete_confirm": "Delete notification destination {name}?",
-  "notifications_external_destinations_title": "Send reminders outside Tribu",
-  "notifications_external_destinations_help": "Admins can add Gotify, ntfy, Telegram, Matrix, or email destinations for household reminders.",
-  "notifications_external_destinations_action": "Configure household notifications"
+  "notifications_external_destinations_title": "Skicka påminnelser och inköp utanför Tribu",
+  "notifications_external_destinations_help": "Administratörer kan lägga till Gotify-, ntfy-, Telegram-, Matrix- eller e-postmål för hushållets påminnelser och vald inköpsaktivitet.",
+  "notifications_external_destinations_action": "Configure household notifications",
+  "notification_destinations_event_shopping_list": "Ändringar i inköpslistor",
+  "notification_destinations_event_shopping_item": "Ändringar i inköpsvaror"
 }


### PR DESCRIPTION
## Summary
- Adds opt-in shopping list and shopping item events for household notification destinations.
- Sends shopping destination deliveries only after the shopping change has been saved, with best-effort failure isolation.
- Updates Settings labels, locale packs, and public docs for the new shopping destination choices.

## Validation
- Backend notification destination coverage passes.
- Full backend test suite passes.
- Frontend component tests pass.
- i18n pack validation passes across supported locales.
- Full Playwright suite passes locally: 108 passed, 2 skipped.

Closes #347
