### PR TITLE
Fix shopping destination coverage gaps

### DIFF
--- a/backend/app/core/shopping_notifications.py
+++ b/backend/app/core/shopping_notifications.py
@@ -1,0 +1,39 @@
+"""Shared shopping notification destination dispatch helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.clock import utcnow
+from app.core.notification_destinations import dispatch_family_notification
+
+logger = logging.getLogger(__name__)
+
+
+def dispatch_shopping_destination_event(
+    *,
+    family_id: int,
+    event_type: str,
+    title: str,
+    body: str,
+    link: str,
+    source_type: str,
+    source_id: int,
+    action: str,
+) -> None:
+    """Send a shopping destination event without blocking the saved action."""
+
+    try:
+        dispatch_family_notification(
+            family_id=family_id,
+            event_type=event_type,
+            title=title,
+            body=body,
+            link=link,
+            source_type=source_type,
+            source_id=source_id,
+            trigger_key=f"{source_type}:{source_id}:{action}:{utcnow().isoformat()}",
+            eligible_users=None,
+        )
+    except Exception:
+        logger.warning("Shopping notification destination dispatch failed")

--- a/backend/app/modules/household_templates_router.py
+++ b/backend/app/modules/household_templates_router.py
@@ -8,6 +8,7 @@ from app.core.activity import record_activity
 from app.core.deps import current_user, ensure_adult
 from app.core.errors import error_detail, SHOPPING_LIST_NOT_FOUND
 from app.core.scopes import require_scope
+from app.core.shopping_notifications import dispatch_shopping_destination_event
 from app.database import get_db
 from app.models import HouseholdTemplate, ShoppingItem, ShoppingList, Task, User
 from app.schemas import (
@@ -146,19 +147,19 @@ def _resolve_shopping_list(
     user_id: int,
     shopping_items: list[dict[str, Any]],
     payload: HouseholdTemplateApplyRequest,
-) -> ShoppingList | None:
+) -> tuple[ShoppingList | None, bool]:
     if payload.shopping_list_id is not None:
         shopping_list = db.query(ShoppingList).filter(ShoppingList.id == payload.shopping_list_id).first()
         if not shopping_list or shopping_list.family_id != family_id:
             raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
-        return shopping_list if shopping_items else None
+        return (shopping_list, False) if shopping_items else (None, False)
     if not shopping_items:
-        return None
+        return None, False
     name = (payload.shopping_list_name or "Template groceries").strip()
     shopping_list = ShoppingList(family_id=family_id, name=name, created_by_user_id=user_id)
     db.add(shopping_list)
     db.flush()
-    return shopping_list
+    return shopping_list, True
 
 
 def _apply_template(
@@ -186,7 +187,7 @@ def _apply_template(
         db.add(task)
         created_tasks.append(task)
 
-    shopping_list = _resolve_shopping_list(
+    shopping_list, shopping_list_created = _resolve_shopping_list(
         db,
         family_id=family_id,
         user_id=user.id,
@@ -229,6 +230,28 @@ def _apply_template(
         db.refresh(item)
     if shopping_list is not None:
         db.refresh(shopping_list)
+        if shopping_list_created:
+            dispatch_shopping_destination_event(
+                family_id=family_id,
+                event_type="shopping.list.changed",
+                title="Shopping list created",
+                body=f'{user.display_name or "Someone"} created shopping list "{shopping_list.name}" from a household template.',
+                link=f"/shopping?list={shopping_list.id}",
+                source_type="shopping_list",
+                source_id=shopping_list.id,
+                action="household_template_list_created",
+            )
+        if created_shopping_items:
+            dispatch_shopping_destination_event(
+                family_id=family_id,
+                event_type="shopping.item.changed",
+                title="Shopping items added",
+                body=f'{user.display_name or "Someone"} added {len(created_shopping_items)} items from a household template to "{shopping_list.name}".',
+                link=f"/shopping?list={shopping_list.id}",
+                source_type="shopping_list",
+                source_id=shopping_list.id,
+                action="household_template_added",
+            )
     return HouseholdTemplateApplyResponse(
         template_id=template_id,
         created_task_count=len(created_tasks),

--- a/backend/app/modules/meal_plans_router.py
+++ b/backend/app/modules/meal_plans_router.py
@@ -27,6 +27,7 @@ from app.core.errors import (
     error_detail,
 )
 from app.core.scopes import require_scope
+from app.core.shopping_notifications import dispatch_shopping_destination_event
 from app.core.ws_broadcast import broadcast_item_added
 from app.database import get_db
 from app.models import MealPlan, Membership, ShoppingItem, ShoppingList, User
@@ -473,6 +474,17 @@ def add_week_ingredients_to_shopping(
             shopping_list.id,
             ShoppingItemResponse.model_validate(item).model_dump(mode="json"),
         )
+    if created:
+        dispatch_shopping_destination_event(
+            family_id=payload.family_id,
+            event_type="shopping.item.changed",
+            title="Meal plan ingredients added",
+            body=f'{user.display_name or "Someone"} added {len(created)} ingredients from the meal plan week to "{shopping_list.name}".',
+            link=f"/shopping?list={shopping_list.id}",
+            source_type="shopping_list",
+            source_id=shopping_list.id,
+            action="meal_plan_week_added",
+        )
     return MealPlanAddToShoppingResponse(added_count=len(created))
 
 
@@ -543,5 +555,16 @@ def add_ingredients_to_shopping(
         broadcast_item_added(
             shopping_list.id,
             ShoppingItemResponse.model_validate(item).model_dump(mode="json"),
+        )
+    if created:
+        dispatch_shopping_destination_event(
+            family_id=plan.family_id,
+            event_type="shopping.item.changed",
+            title="Meal ingredients added",
+            body=f'{user.display_name or "Someone"} added {len(created)} ingredients from "{plan.meal_name}" to "{shopping_list.name}".',
+            link=f"/shopping?list={shopping_list.id}",
+            source_type="shopping_list",
+            source_id=shopping_list.id,
+            action="meal_plan_added",
         )
     return MealPlanAddToShoppingResponse(added_count=len(created))

--- a/backend/app/modules/quick_capture_router.py
+++ b/backend/app/modules/quick_capture_router.py
@@ -7,6 +7,7 @@ from app.core.activity import record_activity
 from app.core.deps import current_user, ensure_adult
 from app.core.errors import error_detail
 from app.core.scopes import require_scope
+from app.core.shopping_notifications import dispatch_shopping_destination_event
 from app.core.webhooks import dispatch_webhook_event
 from app.database import get_db
 from app.models import QuickCaptureItem, ShoppingItem, ShoppingList, Task, User
@@ -44,7 +45,7 @@ def _shopping_item_response(item: ShoppingItem) -> ShoppingItemResponse:
     return ShoppingItemResponse.model_validate(item)
 
 
-def _get_or_create_quick_list(db: Session, family_id: int, user_id: int) -> ShoppingList:
+def _get_or_create_quick_list(db: Session, family_id: int, user_id: int) -> tuple[ShoppingList, bool]:
     shopping_list = (
         db.query(ShoppingList)
         .filter(ShoppingList.family_id == family_id, ShoppingList.name == QUICK_CAPTURE_SHOPPING_LIST_NAME)
@@ -52,7 +53,7 @@ def _get_or_create_quick_list(db: Session, family_id: int, user_id: int) -> Shop
         .first()
     )
     if shopping_list:
-        return shopping_list
+        return shopping_list, False
     shopping_list = ShoppingList(
         family_id=family_id,
         name=QUICK_CAPTURE_SHOPPING_LIST_NAME,
@@ -60,7 +61,7 @@ def _get_or_create_quick_list(db: Session, family_id: int, user_id: int) -> Shop
     )
     db.add(shopping_list)
     db.flush()
-    return shopping_list
+    return shopping_list, True
 
 
 def _create_task(db: Session, *, family_id: int, user: User, text: str) -> Task:
@@ -87,8 +88,8 @@ def _create_task(db: Session, *, family_id: int, user: User, text: str) -> Task:
     return task
 
 
-def _create_shopping_item(db: Session, *, family_id: int, user: User, text: str) -> ShoppingItem:
-    shopping_list = _get_or_create_quick_list(db, family_id, user.id)
+def _create_shopping_item(db: Session, *, family_id: int, user: User, text: str) -> tuple[ShoppingItem, ShoppingList, bool]:
+    shopping_list, shopping_list_created = _get_or_create_quick_list(db, family_id, user.id)
     item = ShoppingItem(
         list_id=shopping_list.id,
         name=text,
@@ -108,13 +109,44 @@ def _create_shopping_item(db: Session, *, family_id: int, user: User, text: str)
         verb="added",
         object_kind="to shopping",
     )
-    return item
+    return item, shopping_list, shopping_list_created
 
 
 def _created_payload(destination: QuickCaptureDestination, created_item: Task | ShoppingItem) -> QuickCaptureResponse:
     if destination == QuickCaptureDestination.task:
         return QuickCaptureResponse(destination=destination, created_item=_task_response(created_item))
     return QuickCaptureResponse(destination=destination, created_item=_shopping_item_response(created_item))
+
+
+def _dispatch_quick_capture_shopping_events(
+    *,
+    family_id: int,
+    user: User,
+    shopping_list: ShoppingList,
+    item: ShoppingItem,
+    shopping_list_created: bool,
+) -> None:
+    if shopping_list_created:
+        dispatch_shopping_destination_event(
+            family_id=family_id,
+            event_type="shopping.list.changed",
+            title="Shopping list created",
+            body=f'{user.display_name or "Someone"} created shopping list "{shopping_list.name}" from quick capture.',
+            link=f"/shopping?list={shopping_list.id}",
+            source_type="shopping_list",
+            source_id=shopping_list.id,
+            action="quick_capture_list_created",
+        )
+    dispatch_shopping_destination_event(
+        family_id=family_id,
+        event_type="shopping.item.changed",
+        title="Shopping item added",
+        body=f'{user.display_name or "Someone"} added "{item.name}" to "{shopping_list.name}" from quick capture.',
+        link=f"/shopping?list={shopping_list.id}",
+        source_type="shopping_item",
+        source_id=item.id,
+        action="quick_capture_added",
+    )
 
 
 @router.post(
@@ -145,14 +177,22 @@ def create_quick_capture(
         return _created_payload(payload.destination, task)
 
     if payload.destination == QuickCaptureDestination.shopping:
-        item = _create_shopping_item(db, family_id=payload.family_id, user=user, text=text)
+        item, shopping_list, shopping_list_created = _create_shopping_item(db, family_id=payload.family_id, user=user, text=text)
         db.commit()
         db.refresh(item)
+        db.refresh(shopping_list)
         dispatch_webhook_event(
             db,
             family_id=payload.family_id,
             event_type="shopping.item.created",
             data={"list_id": item.list_id, "item_id": item.id, "name": item.name, "source": "quick_capture"},
+        )
+        _dispatch_quick_capture_shopping_events(
+            family_id=payload.family_id,
+            user=user,
+            shopping_list=shopping_list,
+            item=item,
+            shopping_list_created=shopping_list_created,
         )
         return _created_payload(payload.destination, item)
 
@@ -229,10 +269,12 @@ def convert_quick_capture_item(
     if payload.destination == QuickCaptureDestination.inbox:
         raise HTTPException(status_code=400, detail=error_detail("INVALID_QUICK_CAPTURE_DESTINATION"))
 
+    shopping_list = None
+    shopping_list_created = False
     if payload.destination == QuickCaptureDestination.task:
         created = _create_task(db, family_id=item.family_id, user=user, text=item.text)
     else:
-        created = _create_shopping_item(db, family_id=item.family_id, user=user, text=item.text)
+        created, shopping_list, shopping_list_created = _create_shopping_item(db, family_id=item.family_id, user=user, text=item.text)
 
     item.status = "converted"
     item.converted_to = payload.destination.value
@@ -240,6 +282,15 @@ def convert_quick_capture_item(
     db.commit()
     db.refresh(item)
     db.refresh(created)
+    if payload.destination == QuickCaptureDestination.shopping and shopping_list is not None:
+        db.refresh(shopping_list)
+        _dispatch_quick_capture_shopping_events(
+            family_id=item.family_id,
+            user=user,
+            shopping_list=shopping_list,
+            item=created,
+            shopping_list_created=shopping_list_created,
+        )
     return QuickCaptureConvertResponse(
         status=item.status,
         converted_to=payload.destination,

--- a/backend/app/modules/recipes_router.py
+++ b/backend/app/modules/recipes_router.py
@@ -20,6 +20,7 @@ from app.core.errors import (
     error_detail,
 )
 from app.core.scopes import require_scope
+from app.core.shopping_notifications import dispatch_shopping_destination_event
 from app.core.ws_broadcast import broadcast_item_added
 from app.database import get_db
 from app.models import Membership, Recipe, ShoppingItem, ShoppingList, User
@@ -374,5 +375,16 @@ def add_recipe_ingredients_to_shopping(
         broadcast_item_added(
             shopping_list.id,
             ShoppingItemResponse.model_validate(item).model_dump(mode="json"),
+        )
+    if created:
+        dispatch_shopping_destination_event(
+            family_id=recipe.family_id,
+            event_type="shopping.item.changed",
+            title="Recipe ingredients added",
+            body=f'{user.display_name or "Someone"} added {len(created)} ingredients from "{recipe.title}" to "{shopping_list.name}".',
+            link=f"/shopping?list={shopping_list.id}",
+            source_type="shopping_list",
+            source_id=shopping_list.id,
+            action="recipe_added",
         )
     return RecipeAddToShoppingResponse(added_count=len(created))

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -1,5 +1,3 @@
-import logging
-
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -18,7 +16,7 @@ from app.core.ws_broadcast import (
     broadcast_list_created,
     broadcast_list_deleted,
 )
-from app.core.notification_destinations import dispatch_family_notification
+from app.core.shopping_notifications import dispatch_shopping_destination_event
 from app.core.webhooks import dispatch_webhook_event
 from app.schemas import (
     AUTH_RESPONSES,
@@ -43,7 +41,6 @@ from app.core.errors import (
 )
 
 router = APIRouter(prefix="/shopping", tags=["shopping"], responses={**AUTH_RESPONSES})
-logger = logging.getLogger(__name__)
 
 
 def _clean_optional_text(value: str | None) -> str | None:
@@ -87,35 +84,6 @@ def _list_response(sl: ShoppingList) -> ShoppingListResponse:
         item_count=total,
         checked_count=checked,
     )
-
-
-def _dispatch_shopping_destination_event(
-    *,
-    family_id: int,
-    event_type: str,
-    title: str,
-    body: str,
-    link: str,
-    source_type: str,
-    source_id: int,
-    action: str,
-) -> None:
-    try:
-        dispatch_family_notification(
-            family_id=family_id,
-            event_type=event_type,
-            title=title,
-            body=body,
-            link=link,
-            source_type=source_type,
-            source_id=source_id,
-            trigger_key=f"{source_type}:{source_id}:{action}:{utcnow().isoformat()}",
-            eligible_users=None,
-        )
-    except Exception:
-        # External destinations must never block the saved shopping action.
-        logger.warning("Shopping notification destination dispatch failed")
-        return
 
 
 def _template_response(template: ShoppingTemplate) -> ShoppingTemplateResponse:
@@ -291,7 +259,7 @@ def apply_template(
         db.refresh(item)
         broadcast_item_added(sl.id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
     if created_items:
-        _dispatch_shopping_destination_event(
+        dispatch_shopping_destination_event(
             family_id=sl.family_id,
             event_type="shopping.item.changed",
             title="Shopping items added",
@@ -374,7 +342,7 @@ def create_list(
         event_type="shopping.list.created",
         data={"list_id": sl.id, "name": sl.name, "created_by_user_id": user.id},
     )
-    _dispatch_shopping_destination_event(
+    dispatch_shopping_destination_event(
         family_id=sl.family_id,
         event_type="shopping.list.changed",
         title="Shopping list created",
@@ -409,7 +377,7 @@ def delete_list(
     db.delete(sl)
     db.commit()
     broadcast_list_deleted(family_id, list_id)
-    _dispatch_shopping_destination_event(
+    dispatch_shopping_destination_event(
         family_id=family_id,
         event_type="shopping.list.changed",
         title="Shopping list deleted",
@@ -501,7 +469,7 @@ def add_item(
             event_type="shopping.item.updated",
             data={"list_id": list_id, "item_id": checked_match.id, "name": checked_match.name, "checked": checked_match.checked},
         )
-        _dispatch_shopping_destination_event(
+        dispatch_shopping_destination_event(
             family_id=sl.family_id,
             event_type="shopping.item.changed",
             title="Shopping item restored",
@@ -543,7 +511,7 @@ def add_item(
         event_type="shopping.item.created",
         data={"list_id": list_id, "item_id": item.id, "name": item.name, "checked": item.checked},
     )
-    _dispatch_shopping_destination_event(
+    dispatch_shopping_destination_event(
         family_id=sl.family_id,
         event_type="shopping.item.changed",
         title="Shopping item added",
@@ -619,7 +587,7 @@ def update_item(
         item_action = "unchecked"
     else:
         item_action = "updated"
-    _dispatch_shopping_destination_event(
+    dispatch_shopping_destination_event(
         family_id=sl.family_id,
         event_type="shopping.item.changed",
         title="Shopping item updated",
@@ -655,7 +623,7 @@ def delete_item(
     db.delete(item)
     db.commit()
     broadcast_item_deleted(list_id, item_id)
-    _dispatch_shopping_destination_event(
+    dispatch_shopping_destination_event(
         family_id=sl.family_id,
         event_type="shopping.item.changed",
         title="Shopping item deleted",
@@ -691,4 +659,15 @@ def clear_checked(
     ).delete(synchronize_session="fetch")
     db.commit()
     broadcast_items_cleared(list_id, deleted)
+    if deleted:
+        dispatch_shopping_destination_event(
+            family_id=sl.family_id,
+            event_type="shopping.item.changed",
+            title="Shopping items cleared",
+            body=f'{user.display_name or "Someone"} cleared {deleted} checked items from "{sl.name}".',
+            link=f"/shopping?list={list_id}",
+            source_type="shopping_list",
+            source_id=list_id,
+            action="clear_checked",
+        )
     return {"status": "ok", "deleted_count": deleted}

--- a/backend/tests/test_notification_destinations.py
+++ b/backend/tests/test_notification_destinations.py
@@ -6,7 +6,7 @@ import hashlib
 import logging
 import socket
 import types
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -23,8 +23,12 @@ from app.models import (
     Membership,
     NotificationDestination,
     NotificationDestinationDelivery,
+    HouseholdTemplate,
+    MealPlan,
     NotificationPreference,
     PersonalAccessToken,
+    QuickCaptureItem,
+    Recipe,
     ShoppingItem,
     ShoppingList,
     ShoppingTemplate,
@@ -136,6 +140,42 @@ def _destination(family_id: int, user_id: int, **overrides) -> NotificationDesti
     }
     data.update(overrides)
     return NotificationDestination(**data)
+
+
+def _capture_destination_calls(monkeypatch) -> list[dict]:
+    from app.core import notification_destinations as destinations_core
+
+    calls = []
+    monkeypatch.setattr(destinations_core, "is_provider_available", lambda: True)
+    monkeypatch.setattr(destinations_core, "_send_with_apprise", lambda _url, payload: calls.append(payload) or True)
+    return calls
+
+
+def _seed_shopping_destination(family_id: int, user_id: int) -> None:
+    db = TestSession()
+    try:
+        db.add(
+            _destination(
+                family_id,
+                user_id,
+                target_url_secret="mailto://shopping-coverage@example.com",
+                events=["shopping.list.changed", "shopping.item.changed"],
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _seed_shopping_list(family_id: int, user_id: int, name: str = "Coverage list") -> int:
+    db = TestSession()
+    try:
+        shopping_list = ShoppingList(family_id=family_id, name=name, created_by_user_id=user_id)
+        db.add(shopping_list)
+        db.commit()
+        return shopping_list.id
+    finally:
+        db.close()
 
 
 def test_admin_crud_redacts_secret_and_audits_safe_metadata():
@@ -797,6 +837,186 @@ def test_shopping_template_apply_sends_item_destination_after_items_are_saved(mo
     assert calls[0]["source_id"] == list_id
     assert calls[0]["title"] == "Shopping items added"
     assert "2 items" in calls[0]["body"]
+
+
+def test_recipe_add_to_shopping_sends_item_destination(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,recipes:write")
+    list_id = _seed_shopping_list(family_id, user_id, "Recipe list")
+    _seed_shopping_destination(family_id, user_id)
+    db = TestSession()
+    try:
+        recipe = Recipe(
+            family_id=family_id,
+            title="Pancakes",
+            ingredients=[{"name": "Flour", "amount": 250, "unit": "g"}, {"name": "Milk", "amount": 1, "unit": "l"}],
+            created_by_user_id=user_id,
+        )
+        db.add(recipe)
+        db.commit()
+        recipe_id = recipe.id
+    finally:
+        db.close()
+
+    calls = _capture_destination_calls(monkeypatch)
+    resp = client.post(
+        f"/recipes/{recipe_id}/add-to-shopping",
+        headers=_auth(token),
+        json={"shopping_list_id": list_id, "ingredient_names": ["Flour", "Milk"]},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["added_count"] == 2
+    assert [call["event_type"] for call in calls] == ["shopping.item.changed"]
+    assert calls[0]["source_type"] == "shopping_list"
+    assert calls[0]["source_id"] == list_id
+    assert calls[0]["trigger_key"].split(":")[2] == "recipe_added"
+    assert "2 ingredients" in calls[0]["body"]
+
+
+def test_meal_plan_add_to_shopping_sends_single_and_week_item_destinations(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,meal_plans:write")
+    list_id = _seed_shopping_list(family_id, user_id, "Meal plan list")
+    _seed_shopping_destination(family_id, user_id)
+    db = TestSession()
+    try:
+        single = MealPlan(
+            family_id=family_id,
+            plan_date=date(2026, 5, 11),
+            slot="noon",
+            meal_name="Soup",
+            ingredients=[{"name": "Carrot", "amount": 2, "unit": "pcs"}],
+            created_by_user_id=user_id,
+        )
+        weekly = MealPlan(
+            family_id=family_id,
+            plan_date=date(2026, 5, 12),
+            slot="evening",
+            meal_name="Pasta",
+            ingredients=[{"name": "Pasta", "amount": 500, "unit": "g"}],
+            created_by_user_id=user_id,
+        )
+        db.add_all([single, weekly])
+        db.commit()
+        single_id = single.id
+    finally:
+        db.close()
+
+    calls = _capture_destination_calls(monkeypatch)
+    single_resp = client.post(
+        f"/meal-plans/{single_id}/add-to-shopping",
+        headers=_auth(token),
+        json={"shopping_list_id": list_id},
+    )
+    week_resp = client.post(
+        "/meal-plans/week/add-to-shopping",
+        headers=_auth(token),
+        json={"family_id": family_id, "week_start": "2026-05-11", "shopping_list_id": list_id},
+    )
+
+    assert single_resp.status_code == 200, single_resp.json()
+    assert week_resp.status_code == 200, week_resp.json()
+    assert [call["event_type"] for call in calls] == ["shopping.item.changed", "shopping.item.changed"]
+    assert [call["trigger_key"].split(":")[2] for call in calls] == ["meal_plan_added", "meal_plan_week_added"]
+    assert calls[0]["source_id"] == list_id
+    assert calls[1]["source_id"] == list_id
+
+
+def test_household_template_apply_sends_list_and_item_destinations(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,household_templates:write")
+    _seed_shopping_destination(family_id, user_id)
+    db = TestSession()
+    try:
+        template = HouseholdTemplate(
+            family_id=family_id,
+            name="Party prep",
+            task_items=[],
+            shopping_items=[{"name": "Juice boxes", "spec": "12", "category": "Drinks"}],
+            created_by_user_id=user_id,
+        )
+        db.add(template)
+        db.commit()
+        template_id = template.id
+    finally:
+        db.close()
+
+    calls = _capture_destination_calls(monkeypatch)
+    resp = client.post(
+        f"/household-templates/{template_id}/apply",
+        headers=_auth(token),
+        json={"target_date": "2026-05-11", "shopping_list_name": "Party shop"},
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["created_shopping_count"] == 1
+    assert [call["event_type"] for call in calls] == ["shopping.list.changed", "shopping.item.changed"]
+    assert [call["trigger_key"].split(":")[2] for call in calls] == ["household_template_list_created", "household_template_added"]
+    assert calls[0]["source_id"] == resp.json()["shopping_list_id"]
+    assert calls[1]["source_id"] == resp.json()["shopping_list_id"]
+
+
+def test_quick_capture_shopping_routes_send_destinations(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,quick_capture:write")
+    _seed_shopping_destination(family_id, user_id)
+    db = TestSession()
+    try:
+        inbox = QuickCaptureItem(family_id=family_id, text="Dish soap", created_by_user_id=user_id)
+        db.add(inbox)
+        db.commit()
+        inbox_id = inbox.id
+    finally:
+        db.close()
+
+    calls = _capture_destination_calls(monkeypatch)
+    direct = client.post(
+        "/quick-capture",
+        headers=_auth(token),
+        json={"family_id": family_id, "text": "Bananas", "destination": "shopping"},
+    )
+    converted = client.post(
+        f"/quick-capture/inbox/{inbox_id}/convert",
+        headers=_auth(token),
+        json={"destination": "shopping"},
+    )
+
+    assert direct.status_code == 200, direct.json()
+    assert converted.status_code == 200, converted.json()
+    assert [call["event_type"] for call in calls] == [
+        "shopping.list.changed",
+        "shopping.item.changed",
+        "shopping.item.changed",
+    ]
+    assert [call["trigger_key"].split(":")[2] for call in calls] == [
+        "quick_capture_list_created",
+        "quick_capture_added",
+        "quick_capture_added",
+    ]
+
+
+def test_clear_checked_shopping_items_sends_item_destination(monkeypatch):
+    token, family_id, user_id = _seed_member(scopes="admin:read,admin:write,shopping:write")
+    list_id = _seed_shopping_list(family_id, user_id, "Checked list")
+    _seed_shopping_destination(family_id, user_id)
+    db = TestSession()
+    try:
+        db.add_all([
+            ShoppingItem(list_id=list_id, name="Done one", checked=True, added_by_user_id=user_id),
+            ShoppingItem(list_id=list_id, name="Done two", checked=True, added_by_user_id=user_id),
+            ShoppingItem(list_id=list_id, name="Keep", checked=False, added_by_user_id=user_id),
+        ])
+        db.commit()
+    finally:
+        db.close()
+
+    calls = _capture_destination_calls(monkeypatch)
+    resp = client.delete(f"/shopping/lists/{list_id}/checked", headers=_auth(token))
+
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["deleted_count"] == 2
+    assert [call["event_type"] for call in calls] == ["shopping.item.changed"]
+    assert calls[0]["source_type"] == "shopping_list"
+    assert calls[0]["source_id"] == list_id
+    assert calls[0]["trigger_key"].split(":")[2] == "clear_checked"
+    assert "cleared 2 checked items" in calls[0]["body"]
 
 
 def test_shopping_destination_respects_household_quiet_hours(monkeypatch):


### PR DESCRIPTION
## Summary
- Dispatch shopping destination events from recipe, meal-plan, household-template, and quick-capture flows that add shopping lists or items
- Keep destination failures isolated so the saved shopping action still completes
- Add regression coverage for the indirect shopping entry points and clear-checked behavior

## Validation
- `DATABASE_URL=sqlite:////tmp/tribu-test-full.db JWT_SECRET=test-secret PYTHONPATH=backend backend/.venv/bin/pytest backend/tests -q`
- `BASE_URL=http://127.0.0.1:3210 npm run e2e`
- `git diff --check`
