### PR TITLE
chore: slim Docker build context

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -6,3 +6,9 @@ tests
 *.md
 .venv
 .pytest_cache
+test-*.db
+.ruff_cache/
+coverage/
+htmlcov/
+start-dev.sh
+radicale-data/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,13 +8,17 @@ ENV APP_VERSION=${APP_VERSION}
 ENV APP_BUILD_NUMBER=${APP_BUILD_NUMBER}
 ENV APP_GIT_SHA=${APP_GIT_SHA}
 ENV APP_BUILD_DATE=${APP_BUILD_DATE}
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PIP_NO_COMPILE=1
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client gosu && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --no-compile -r requirements.txt \
+    && find /usr/local/lib/python*/site-packages -type d -name __pycache__ -prune -exec rm -rf {} + \
+    && find /usr/local/lib/python*/site-packages -type d \( -name tests -o -name test \) -prune -exec rm -rf {} +
 
 COPY alembic.ini .
 COPY alembic ./alembic

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -4,3 +4,10 @@ node_modules
 .git
 *.md
 .eslintrc*
+__tests__/
+e2e/
+coverage/
+playwright-report/
+test-results/
+jest.config.js
+playwright.config.js

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # refuses to run if package.json and package-lock.json disagree. This
 # pins the audit posture of the build to whatever was committed.
 COPY package.json package-lock.json ./
-RUN npm ci --no-audit --no-fund --include=dev
+RUN npm ci --no-audit --no-fund --omit=dev
 
 
 FROM node:22-alpine AS builder
@@ -32,7 +32,9 @@ ENV NEXT_PUBLIC_APP_BUILD_DATE=$NEXT_PUBLIC_APP_BUILD_DATE
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN npm run build
+RUN npm run build \
+    && cp -a .next/standalone /tmp/standalone \
+    && rm -rf /tmp/standalone/node_modules/@img /tmp/standalone/node_modules/sharp
 
 
 FROM node:22-alpine AS runner
@@ -52,7 +54,7 @@ RUN addgroup -S tribu && adduser -S tribu -G tribu
 # copied alongside it because Next's standalone server expects them
 # at fixed paths.
 COPY --from=builder --chown=tribu:tribu /app/public ./public
-COPY --from=builder --chown=tribu:tribu /app/.next/standalone ./
+COPY --from=builder --chown=tribu:tribu /tmp/standalone ./
 COPY --from=builder --chown=tribu:tribu /app/.next/static ./.next/static
 
 USER tribu


### PR DESCRIPTION
## Summary
- Reduces backend and frontend Docker build contexts by ignoring local test and report artifacts.
- Keeps frontend Docker builds on production dependencies only.
- Removes unused native image packages from the Next standalone runtime copy.

## Validation
- `git diff --check`
- `npm ci --no-audit --no-fund --omit=dev`
- `npm run build`
- Standalone smoke check for `/` and `/display`

Note: Docker is not installed on the local verification host, so this was validated through the production-dependencies Next build and standalone runtime smoke path.