### PR TITLE
fix(calendar): align date numbers with event icons

### DIFF
--- a/frontend/__tests__/components/CalendarViewBirthdayIndicators.test.js
+++ b/frontend/__tests__/components/CalendarViewBirthdayIndicators.test.js
@@ -130,4 +130,21 @@ describe('CalendarView birthday month indicators', () => {
     expect(eventDay.querySelector('.calendar-day-icon-indicator')).toHaveTextContent('⚽');
     expect(eventDay.querySelector('.calendar-day-dot')).not.toBeInTheDocument();
   });
+
+  it('reserves the indicator row for days without events so date numbers stay aligned', () => {
+    mockUseCalendar.mockReturnValue(baseCalendar([
+      emptyCell(),
+      monthCell(4, [{ id: 77, title: 'Soccer training', color: '#16a34a', icon: 'soccer' }]),
+      monthCell(5, []),
+    ]));
+
+    render(<CalendarView />);
+
+    const iconDay = screen.getByRole('button', { name: /May 4, 1 event: Soccer training/i });
+    const plainDay = screen.getByRole('button', { name: /^May 5$/i });
+
+    expect(iconDay.querySelector('.calendar-day-dots')).toBeInTheDocument();
+    expect(plainDay.querySelector('.calendar-day-dots')).toBeInTheDocument();
+    expect(plainDay.querySelector('.calendar-day-dots')).toBeEmptyDOMElement();
+  });
 });

--- a/frontend/components/calendar/index.js
+++ b/frontend/components/calendar/index.js
@@ -168,29 +168,27 @@ export default function CalendarView() {
                     {!c.empty && (
                       <>
                         <span className="calendar-day-num">{c.day}</span>
-                        {(birthdayCount > 0 || regularEventCount > 0) && (
-                          <div className="calendar-day-dots" aria-hidden="true">
-                            {birthdayCount > 0 && (
-                              <div className="calendar-day-birthday-indicator" title={formatCountLabel(birthdayCount, 'birthday', 'birthdays')}>
-                                <Cake size={11} strokeWidth={2.4} aria-hidden="true" />
+                        <div className="calendar-day-dots" aria-hidden="true">
+                          {birthdayCount > 0 && (
+                            <div className="calendar-day-birthday-indicator" title={formatCountLabel(birthdayCount, 'birthday', 'birthdays')}>
+                              <Cake size={11} strokeWidth={2.4} aria-hidden="true" />
+                            </div>
+                          )}
+                          {regularEvents.slice(0, birthdayCount > 0 ? 2 : 3).map((ev, di) => {
+                            const eventIcon = getCalendarEventIcon(ev.icon);
+                            return eventIcon ? (
+                              <div
+                                key={ev.id || di}
+                                className="calendar-day-icon-indicator"
+                                title={eventIcon.label}
+                              >
+                                {eventIcon.emoji}
                               </div>
-                            )}
-                            {regularEvents.slice(0, birthdayCount > 0 ? 2 : 3).map((ev, di) => {
-                              const eventIcon = getCalendarEventIcon(ev.icon);
-                              return eventIcon ? (
-                                <div
-                                  key={ev.id || di}
-                                  className="calendar-day-icon-indicator"
-                                  title={eventIcon.label}
-                                >
-                                  {eventIcon.emoji}
-                                </div>
-                              ) : (
-                                <div key={ev.id || di} className="calendar-day-dot" style={{ background: ev.color || getMemberColor(null, di) }} />
-                              );
-                            })}
-                          </div>
-                        )}
+                            ) : (
+                              <div key={ev.id || di} className="calendar-day-dot" style={{ background: ev.color || getMemberColor(null, di) }} />
+                            );
+                          })}
+                        </div>
                       </>
                     )}
                   </button>

--- a/frontend/e2e/tests/calendar.spec.js
+++ b/frontend/e2e/tests/calendar.spec.js
@@ -41,6 +41,54 @@ test.describe('Calendar', () => {
     );
   });
 
+  test('month date numbers stay aligned with and without event icons', async ({ authedPage: page, apiCtx }) => {
+    const familyId = await getFamilyId(apiCtx);
+    const now = new Date();
+    const candidateDays = [21, 22, 23, 24, 25, 26, 27].filter((day) => {
+      const iconDate = new Date(now.getFullYear(), now.getMonth(), day, 9, 0, 0);
+      const plainDate = new Date(now.getFullYear(), now.getMonth(), day + 1, 9, 0, 0);
+      return plainDate.getMonth() === now.getMonth() && iconDate.getDay() !== 0 && iconDate.getDay() !== 6;
+    });
+
+    await navigateTo(page, 'Calendar');
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+
+    let iconDayNumber;
+    let plainDayNumber;
+    for (const day of candidateDays) {
+      const iconCandidate = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${day}$`) }) }).first();
+      const plainCandidate = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${day + 1}$`) }) }).first();
+      if (await iconCandidate.locator('.calendar-day-dots > *').count() === 0 && await plainCandidate.locator('.calendar-day-dots > *').count() === 0) {
+        iconDayNumber = day;
+        plainDayNumber = day + 1;
+        break;
+      }
+    }
+    expect(iconDayNumber).toBeDefined();
+    expect(plainDayNumber).toBeDefined();
+
+    const iconDate = new Date(now.getFullYear(), now.getMonth(), iconDayNumber, 9, 0, 0);
+    await seedCalendarEvent(apiCtx, familyId, {
+      title: 'Alignment Soccer',
+      starts_at: iconDate.toISOString(),
+      icon: 'soccer',
+    });
+
+    await page.reload();
+    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+
+    const iconDay = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${iconDayNumber}$`) }) }).first();
+    const plainDay = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${plainDayNumber}$`) }) }).first();
+    await expect(iconDay.locator('.calendar-day-icon-indicator').first()).toBeVisible({ timeout: 10000 });
+    await expect(plainDay.locator('.calendar-day-dots > *')).toHaveCount(0);
+
+    const iconBox = await iconDay.locator('.calendar-day-num').boundingBox();
+    const plainBox = await plainDay.locator('.calendar-day-num').boundingBox();
+    expect(iconBox).not.toBeNull();
+    expect(plainBox).not.toBeNull();
+    expect(Math.abs(iconBox.y - plainBox.y)).toBeLessThanOrEqual(0.5);
+  });
+
   test('desktop event form gives date-time fields enough room for time entry', async ({ authedPage: page }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await navigateTo(page, 'Calendar');

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1027,7 +1027,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .calendar-day.empty { opacity: 0.25; cursor: default; }
 .calendar-day.other-month { opacity: 0.3; }
 .calendar-day-num { font-size: 0.88rem; font-weight: 500; font-family: 'JetBrains Mono', monospace; }
-.calendar-day-dots { display: flex; align-items: center; gap: 3px; min-height: 11px; }
+.calendar-day-dots { display: flex; align-items: center; justify-content: center; gap: 3px; height: 14px; }
 .calendar-day-dot { width: 5px; height: 5px; border-radius: 50%; }
 .calendar-day-icon-indicator { width: 14px; height: 14px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; font-size: 10px; line-height: 1; background: var(--bg-muted); flex: 0 0 auto; }
 .calendar-day-birthday-indicator { width: 13px; height: 13px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; color: #f43f5e; background: color-mix(in srgb, #f43f5e 12%, transparent); flex: 0 0 auto; }


### PR DESCRIPTION
## Bug Description

Calendar date numbers were vertically offset when a day had an event icon. Days without indicators stayed lower, so dates in the same week did not share one baseline.

Closes #353

## Root Cause

The calendar only rendered the indicator row when a day had birthdays or events. Cells without indicators had less content height, which changed the visual position of the date number.

## Fix

- Always reserve the month-cell indicator row for non-empty calendar days.
- Match the reserved row height to the event icon size.
- Keep the indicator row hidden from assistive technology so the existing day button label remains the accessible source of event information.
- Add component and browser coverage for date-number alignment with and without icons.

## How to Verify

1. Open the calendar month view.
2. Compare a date with an event icon to a neighboring date without any indicator.
3. Confirm both date numbers sit on the same vertical baseline and the icon appears below the number.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Browser verification of the fix on desktop and mobile

## Risk Assessment

Low. The change is limited to calendar month cell markup, one CSS rule, and regression coverage for the affected layout.
