### PR TITLE
Align dashboard hero with mockup

### DIFF
--- a/frontend/__tests__/components/DashboardHero.test.js
+++ b/frontend/__tests__/components/DashboardHero.test.js
@@ -45,6 +45,7 @@ const messages = {
   'module.dashboard.today_command_center': 'Today command center',
   'module.dashboard.today_kicker': 'Today at home',
   'module.dashboard.next_up_title': 'Next up',
+  'module.dashboard.next_up_cta': 'View today',
   'module.dashboard.next_up_empty': 'Nothing else scheduled',
   'module.dashboard.next_up_empty_hint': 'Use quick capture to park anything the family should remember.',
   'module.dashboard.today_status_events': 'Events today',
@@ -148,8 +149,15 @@ describe('DashboardView hero', () => {
     expect(nextUp).toHaveTextContent('School run');
     expect(nextUp).toHaveTextContent('Main gate');
     expect(nextUp).toHaveTextContent('08:15');
+    expect(nextUp.querySelector('.next-up-time-chip')).toHaveTextContent('08:15');
+    expect(nextUp.querySelector('.next-up-visual')).toBeInTheDocument();
+    expect(nextUp.querySelector('.next-up-cta')).toHaveTextContent('View today');
 
     const statusGroup = within(commandCenter).getByRole('group', { name: 'Today status' });
+    expect(statusGroup).toHaveClass('today-status-card');
+    expect(within(statusGroup).getByText('Today status')).toBeVisible();
+    expect(statusGroup.querySelectorAll('.today-status-item')).toHaveLength(4);
+    expect(statusGroup.querySelectorAll('.today-status-icon')).toHaveLength(4);
     expect(within(statusGroup).getByTestId('today-status-events')).toHaveTextContent('2');
     expect(within(statusGroup).getByTestId('today-status-tasks')).toHaveTextContent('2');
     expect(within(statusGroup).getByTestId('today-status-shopping')).toHaveTextContent('5');

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { CalendarClock, ListChecks, Cake, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer, Settings2, ArrowUp, ArrowDown, RotateCcw, Clock3, MapPin } from 'lucide-react';
+import { CalendarClock, ListChecks, Cake, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer, Settings2, ArrowUp, ArrowDown, RotateCcw, MapPin } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
@@ -97,9 +97,12 @@ function formatEventTime(value, locale, timeFormat) {
   return date.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: timeFormat === '12h' });
 }
 
-function TodayStatusItem({ label, value, testId }) {
+function TodayStatusItem({ label, value, testId, icon: Icon, tone }) {
   return (
-    <div className="today-status-item">
+    <div className={`today-status-item today-status-item-${tone}`}>
+      <span className="today-status-icon" aria-hidden="true">
+        <Icon size={20} strokeWidth={2.1} />
+      </span>
       <span className="today-status-value" data-testid={testId}>{value}</span>
       <span className="today-status-label">{label}</span>
     </div>
@@ -122,13 +125,21 @@ function NextUpCard({ event, locale, lang, timeFormat, messages, members, setAct
       <div className="next-up-eyebrow">{t(messages, 'module.dashboard.next_up_title')}</div>
       {event ? (
         <button type="button" className="next-up-button" onClick={goToEvent}>
-          <span className="next-up-time"><Clock3 size={16} aria-hidden="true" /> {formatEventTime(event.starts_at, locale, timeFormat)}</span>
-          <span className="next-up-title">{event.title}</span>
-          <span className="next-up-meta">
-            <span>{prettyDate(event.starts_at, lang, timeFormat)}</span>
-            {event.location && <span><MapPin size={14} aria-hidden="true" /> {event.location}</span>}
-            {assignedMember && <span>{assignedMember.display_name}</span>}
+          <span className="next-up-time-chip">
+            <span>{formatEventTime(event.starts_at, locale, timeFormat)}</span>
           </span>
+          <span className="next-up-details">
+            <span className="next-up-title">{event.title}</span>
+            <span className="next-up-meta">
+              {assignedMember && <span>{assignedMember.display_name}</span>}
+              {event.location && <span><MapPin size={14} aria-hidden="true" /> {event.location}</span>}
+              <span>{prettyDate(event.starts_at, lang, timeFormat)}</span>
+            </span>
+          </span>
+          <span className="next-up-visual" aria-hidden="true">
+            <span className="next-up-visual-orb"><CalendarClock size={34} /></span>
+          </span>
+          <span className="next-up-cta">{t(messages, 'module.dashboard.next_up_cta')} <span aria-hidden="true">›</span></span>
         </button>
       ) : (
         <div className="next-up-clear">
@@ -487,6 +498,8 @@ export default function DashboardView() {
     : DEFAULT_DASHBOARD_LAYOUT;
   const orderedDashboardLayout = normalizeDashboardLayout(dashboardLayout, availableDashboardModules);
   const moduleOrder = (moduleKey) => orderedDashboardLayout.indexOf(moduleKey);
+  const heroName = me?.display_name || currentFamily?.family_name || 'User';
+  const heroFamilyName = currentFamily?.family_name && currentFamily.family_name !== heroName ? currentFamily.family_name : null;
 
   return (
     <div className="dashboard-today-page">
@@ -494,8 +507,10 @@ export default function DashboardView() {
         <div className="today-command-header">
           <div>
             <div className="today-command-kicker">{t(messages, 'module.dashboard.today_kicker')}</div>
-            <h1 className="view-title">{getGreeting(messages)}, {me?.display_name || 'User'}</h1>
-            {currentFamily && <p className="today-command-family">{currentFamily.family_name}</p>}
+            <h1 className="view-title today-command-title">
+              {getGreeting(messages)}, <span>{heroName}</span>{heroFamilyName && <span className="today-command-family-inline"> · {heroFamilyName}</span>} <span className="today-command-wave" aria-hidden="true">👋</span>
+            </h1>
+            <p className="today-command-family">{todayStr}</p>
           </div>
           <div className="dashboard-header-actions">
             <div className="view-date">{todayStr}</div>
@@ -517,11 +532,14 @@ export default function DashboardView() {
             setActiveView={setActiveView}
             isChild={isChild}
           />
-          <div className="today-status-grid" role="group" aria-label={t(messages, 'module.dashboard.today_status_label')}>
-            <TodayStatusItem label={t(messages, 'module.dashboard.today_status_events')} value={todayEventCount} testId="today-status-events" />
-            <TodayStatusItem label={t(messages, 'module.dashboard.today_status_tasks')} value={openTaskCount} testId="today-status-tasks" />
-            <TodayStatusItem label={t(messages, 'module.dashboard.today_status_shopping')} value={shoppingOpenCount} testId="today-status-shopping" />
-            <TodayStatusItem label={t(messages, 'module.dashboard.today_status_birthdays')} value={birthdaySoonCount} testId="today-status-birthdays" />
+          <div className="today-status-card" role="group" aria-label={t(messages, 'module.dashboard.today_status_label')}>
+            <div className="today-status-heading">{t(messages, 'module.dashboard.today_status_label')}</div>
+            <div className="today-status-grid">
+              <TodayStatusItem icon={Calendar} tone="events" label={t(messages, 'module.dashboard.today_status_events')} value={todayEventCount} testId="today-status-events" />
+              <TodayStatusItem icon={CheckCircle} tone="tasks" label={t(messages, 'module.dashboard.today_status_tasks')} value={openTaskCount} testId="today-status-tasks" />
+              <TodayStatusItem icon={ShoppingCart} tone="shopping" label={t(messages, 'module.dashboard.today_status_shopping')} value={shoppingOpenCount} testId="today-status-shopping" />
+              <TodayStatusItem icon={Cake} tone="birthdays" label={t(messages, 'module.dashboard.today_status_birthdays')} value={birthdaySoonCount} testId="today-status-birthdays" />
+            </div>
           </div>
         </div>
 

--- a/frontend/i18n/modules/dashboard/bg.json
+++ b/frontend/i18n/modules/dashboard/bg.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Отворени задачи",
   "module.dashboard.module_birthdays": "Рождени дни",
   "module.dashboard.module_activity": "Скорошна дейност",
-  "module.dashboard.module_rewards": "Награди"
+  "module.dashboard.module_rewards": "Награди",
+  "module.dashboard.next_up_cta": "Вижте днес"
 }

--- a/frontend/i18n/modules/dashboard/cs.json
+++ b/frontend/i18n/modules/dashboard/cs.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Otevřené úkoly",
   "module.dashboard.module_birthdays": "narozeniny",
   "module.dashboard.module_activity": "Nedávná aktivita",
-  "module.dashboard.module_rewards": "Odměny"
+  "module.dashboard.module_rewards": "Odměny",
+  "module.dashboard.next_up_cta": "Zobrazit dnešek"
 }

--- a/frontend/i18n/modules/dashboard/da.json
+++ b/frontend/i18n/modules/dashboard/da.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Åbne opgaver",
   "module.dashboard.module_birthdays": "Fødselsdage",
   "module.dashboard.module_activity": "Seneste aktivitet",
-  "module.dashboard.module_rewards": "Belønninger"
+  "module.dashboard.module_rewards": "Belønninger",
+  "module.dashboard.next_up_cta": "Se i dag"
 }

--- a/frontend/i18n/modules/dashboard/de.json
+++ b/frontend/i18n/modules/dashboard/de.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Offene Aufgaben",
   "module.dashboard.module_birthdays": "Geburtstage",
   "module.dashboard.module_activity": "Letzte Aktivitäten",
-  "module.dashboard.module_rewards": "Rewards"
+  "module.dashboard.module_rewards": "Rewards",
+  "module.dashboard.next_up_cta": "Heute ansehen"
 }

--- a/frontend/i18n/modules/dashboard/el.json
+++ b/frontend/i18n/modules/dashboard/el.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Ανοίξτε τις εργασίες",
   "module.dashboard.module_birthdays": "Γενέθλια",
   "module.dashboard.module_activity": "Πρόσφατη δραστηριότητα",
-  "module.dashboard.module_rewards": "Ανταμοιβές"
+  "module.dashboard.module_rewards": "Ανταμοιβές",
+  "module.dashboard.next_up_cta": "Δείτε σήμερα"
 }

--- a/frontend/i18n/modules/dashboard/en.json
+++ b/frontend/i18n/modules/dashboard/en.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Open tasks",
   "module.dashboard.module_birthdays": "Birthdays",
   "module.dashboard.module_activity": "Recent activity",
-  "module.dashboard.module_rewards": "Rewards"
+  "module.dashboard.module_rewards": "Rewards",
+  "module.dashboard.next_up_cta": "View today"
 }

--- a/frontend/i18n/modules/dashboard/es.json
+++ b/frontend/i18n/modules/dashboard/es.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Tareas abiertas",
   "module.dashboard.module_birthdays": "Cumpleaños",
   "module.dashboard.module_activity": "Actividad reciente",
-  "module.dashboard.module_rewards": "Recompensas"
+  "module.dashboard.module_rewards": "Recompensas",
+  "module.dashboard.next_up_cta": "Ver hoy"
 }

--- a/frontend/i18n/modules/dashboard/et.json
+++ b/frontend/i18n/modules/dashboard/et.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Avatud ülesanded",
   "module.dashboard.module_birthdays": "Sünnipäevad",
   "module.dashboard.module_activity": "Hiljutine tegevus",
-  "module.dashboard.module_rewards": "Preemiad"
+  "module.dashboard.module_rewards": "Preemiad",
+  "module.dashboard.next_up_cta": "Vaata tänast"
 }

--- a/frontend/i18n/modules/dashboard/fi.json
+++ b/frontend/i18n/modules/dashboard/fi.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Avoimet tehtävät",
   "module.dashboard.module_birthdays": "Syntymäpäivät",
   "module.dashboard.module_activity": "Viimeaikainen toiminta",
-  "module.dashboard.module_rewards": "Palkinnot"
+  "module.dashboard.module_rewards": "Palkinnot",
+  "module.dashboard.next_up_cta": "Näytä tämä päivä"
 }

--- a/frontend/i18n/modules/dashboard/fr.json
+++ b/frontend/i18n/modules/dashboard/fr.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Tâches ouvertes",
   "module.dashboard.module_birthdays": "Anniversaires",
   "module.dashboard.module_activity": "Activité récente",
-  "module.dashboard.module_rewards": "Récompenses"
+  "module.dashboard.module_rewards": "Récompenses",
+  "module.dashboard.next_up_cta": "Voir aujourd’hui"
 }

--- a/frontend/i18n/modules/dashboard/ga.json
+++ b/frontend/i18n/modules/dashboard/ga.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Tascanna a oscailt",
   "module.dashboard.module_birthdays": "Breithlaethanta",
   "module.dashboard.module_activity": "Gníomhaíocht le déanaí",
-  "module.dashboard.module_rewards": "luach saothair"
+  "module.dashboard.module_rewards": "luach saothair",
+  "module.dashboard.next_up_cta": "Féach ar inniu"
 }

--- a/frontend/i18n/modules/dashboard/hr.json
+++ b/frontend/i18n/modules/dashboard/hr.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Otvoreni zadaci",
   "module.dashboard.module_birthdays": "rođendani",
   "module.dashboard.module_activity": "Nedavna aktivnost",
-  "module.dashboard.module_rewards": "Nagrade"
+  "module.dashboard.module_rewards": "Nagrade",
+  "module.dashboard.next_up_cta": "Pogledaj danas"
 }

--- a/frontend/i18n/modules/dashboard/hu.json
+++ b/frontend/i18n/modules/dashboard/hu.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Nyitott feladatok",
   "module.dashboard.module_birthdays": "Születésnapok",
   "module.dashboard.module_activity": "Legutóbbi tevékenység",
-  "module.dashboard.module_rewards": "Jutalmak"
+  "module.dashboard.module_rewards": "Jutalmak",
+  "module.dashboard.next_up_cta": "Mai nap megtekintése"
 }

--- a/frontend/i18n/modules/dashboard/it.json
+++ b/frontend/i18n/modules/dashboard/it.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Attività aperte",
   "module.dashboard.module_birthdays": "Compleanni",
   "module.dashboard.module_activity": "Attività recente",
-  "module.dashboard.module_rewards": "Premi"
+  "module.dashboard.module_rewards": "Premi",
+  "module.dashboard.next_up_cta": "Vedi oggi"
 }

--- a/frontend/i18n/modules/dashboard/lt.json
+++ b/frontend/i18n/modules/dashboard/lt.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Atviros užduotys",
   "module.dashboard.module_birthdays": "Gimtadieniai",
   "module.dashboard.module_activity": "Naujausia veikla",
-  "module.dashboard.module_rewards": "Apdovanojimai"
+  "module.dashboard.module_rewards": "Apdovanojimai",
+  "module.dashboard.next_up_cta": "Peržiūrėti šiandieną"
 }

--- a/frontend/i18n/modules/dashboard/lv.json
+++ b/frontend/i18n/modules/dashboard/lv.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Atvērtie uzdevumi",
   "module.dashboard.module_birthdays": "Dzimšanas dienas",
   "module.dashboard.module_activity": "Pēdējā darbība",
-  "module.dashboard.module_rewards": "Atlīdzības"
+  "module.dashboard.module_rewards": "Atlīdzības",
+  "module.dashboard.next_up_cta": "Skatīt šodienu"
 }

--- a/frontend/i18n/modules/dashboard/nb.json
+++ b/frontend/i18n/modules/dashboard/nb.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Åpne oppgaver",
   "module.dashboard.module_birthdays": "Bursdager",
   "module.dashboard.module_activity": "Nylig aktivitet",
-  "module.dashboard.module_rewards": "Belønninger"
+  "module.dashboard.module_rewards": "Belønninger",
+  "module.dashboard.next_up_cta": "Se i dag"
 }

--- a/frontend/i18n/modules/dashboard/nl.json
+++ b/frontend/i18n/modules/dashboard/nl.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Openstaande taken",
   "module.dashboard.module_birthdays": "Verjaardagen",
   "module.dashboard.module_activity": "Recente activiteit",
-  "module.dashboard.module_rewards": "Beloningen"
+  "module.dashboard.module_rewards": "Beloningen",
+  "module.dashboard.next_up_cta": "Vandaag bekijken"
 }

--- a/frontend/i18n/modules/dashboard/pl.json
+++ b/frontend/i18n/modules/dashboard/pl.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Otwarte zadania",
   "module.dashboard.module_birthdays": "Urodziny",
   "module.dashboard.module_activity": "Ostatnia aktywność",
-  "module.dashboard.module_rewards": "Nagrody"
+  "module.dashboard.module_rewards": "Nagrody",
+  "module.dashboard.next_up_cta": "Zobacz dziś"
 }

--- a/frontend/i18n/modules/dashboard/pt.json
+++ b/frontend/i18n/modules/dashboard/pt.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Tarefas abertas",
   "module.dashboard.module_birthdays": "Aniversários",
   "module.dashboard.module_activity": "Atividade recente",
-  "module.dashboard.module_rewards": "Recompensas"
+  "module.dashboard.module_rewards": "Recompensas",
+  "module.dashboard.next_up_cta": "Ver hoje"
 }

--- a/frontend/i18n/modules/dashboard/ro.json
+++ b/frontend/i18n/modules/dashboard/ro.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Deschide sarcini",
   "module.dashboard.module_birthdays": "Zile de naștere",
   "module.dashboard.module_activity": "Activitate recentă",
-  "module.dashboard.module_rewards": "Recompense"
+  "module.dashboard.module_rewards": "Recompense",
+  "module.dashboard.next_up_cta": "Vezi azi"
 }

--- a/frontend/i18n/modules/dashboard/sk.json
+++ b/frontend/i18n/modules/dashboard/sk.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Otvorené úlohy",
   "module.dashboard.module_birthdays": "narodeniny",
   "module.dashboard.module_activity": "Nedávna aktivita",
-  "module.dashboard.module_rewards": "Odmeny"
+  "module.dashboard.module_rewards": "Odmeny",
+  "module.dashboard.next_up_cta": "Zobraziť dnešok"
 }

--- a/frontend/i18n/modules/dashboard/sl.json
+++ b/frontend/i18n/modules/dashboard/sl.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Odprte naloge",
   "module.dashboard.module_birthdays": "Rojstni dnevi",
   "module.dashboard.module_activity": "Nedavna dejavnost",
-  "module.dashboard.module_rewards": "Nagrade"
+  "module.dashboard.module_rewards": "Nagrade",
+  "module.dashboard.next_up_cta": "Prikaži danes"
 }

--- a/frontend/i18n/modules/dashboard/sv.json
+++ b/frontend/i18n/modules/dashboard/sv.json
@@ -113,5 +113,6 @@
   "module.dashboard.module_tasks": "Öppna uppgifter",
   "module.dashboard.module_birthdays": "Födelsedagar",
   "module.dashboard.module_activity": "Senaste aktiviteten",
-  "module.dashboard.module_rewards": "Belöningar"
+  "module.dashboard.module_rewards": "Belöningar",
+  "module.dashboard.next_up_cta": "Visa idag"
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -789,26 +789,47 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .main-content { margin-left: var(--sidebar-width); padding: var(--space-xl); min-height: 100vh; width: calc(100% - var(--sidebar-width)); position: relative; z-index: 2; transition: margin-left 0.25s ease, width 0.25s ease; }
 .view-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-xl); gap: var(--space-md); }
 .dashboard-today-page { display: grid; gap: var(--space-lg); }
-.today-command-center { display: grid; gap: var(--space-lg); padding: var(--space-lg); margin-bottom: var(--space-md); border: 1px solid var(--glass-border); border-radius: var(--radius-xl); background: linear-gradient(135deg, var(--surface-raised), var(--void-surface)); box-shadow: var(--shadow-soft); }
+.today-command-center { display: grid; gap: var(--space-lg); padding: clamp(18px, 2.7vw, 30px) 0 var(--space-sm); margin-bottom: var(--space-md); border: 0; border-radius: 0; background: transparent; box-shadow: none; }
 .today-command-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-lg); }
-.today-command-kicker { color: var(--amethyst); font-size: 0.74rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 5px; }
-.today-command-family { margin: 4px 0 0; color: var(--text-secondary); font-size: 0.9rem; }
-.today-command-grid { display: grid; grid-template-columns: minmax(280px, 1.15fr) minmax(280px, 0.85fr); gap: var(--space-md); align-items: stretch; }
-.next-up-card { border: 1px solid rgba(139, 94, 159, 0.18); border-radius: var(--radius-lg); background: rgba(139, 94, 159, 0.08); padding: var(--space-md); min-height: 160px; }
-.next-up-eyebrow { color: var(--text-muted); font-size: 0.72rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: var(--space-sm); }
-.next-up-button { width: 100%; min-height: 120px; display: grid; align-content: center; gap: 9px; text-align: left; border: 0; background: transparent; color: var(--text-primary); padding: 0; font: inherit; cursor: pointer; }
+.today-command-kicker { color: var(--amethyst); font-size: 0.72rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+.view-title.today-command-title { font-size: clamp(1.85rem, 3vw, 2.45rem); line-height: 1.08; font-weight: 500; color: var(--text-primary); }
+.view-title.today-command-title span:first-of-type { font-weight: 850; }
+.today-command-wave { display: inline-block; margin-left: 2px; font-size: 0.8em; transform: translateY(-1px); }
+.today-command-family-inline { color: var(--text-muted); font-weight: 700; }
+.today-command-family { margin: 8px 0 0; color: var(--text-secondary); font-size: 0.92rem; }
+.today-command-grid { display: grid; grid-template-columns: minmax(320px, 0.95fr) minmax(380px, 1.35fr); gap: var(--space-md); align-items: stretch; }
+.next-up-card { position: relative; overflow: hidden; border: 1px solid rgba(139, 94, 159, 0.26); border-radius: 20px; background: linear-gradient(135deg, rgba(139, 94, 159, 0.16), rgba(32, 38, 56, 0.9)); padding: 16px; min-height: 148px; box-shadow: 0 18px 45px rgba(8, 11, 20, 0.32); }
+.next-up-card::after { content: ''; position: absolute; right: -28px; bottom: -36px; width: 138px; height: 138px; border-radius: 999px; background: radial-gradient(circle, rgba(139, 94, 159, 0.14), rgba(139, 94, 159, 0)); pointer-events: none; }
+.next-up-eyebrow { position: relative; z-index: 1; color: var(--text-primary); font-size: 0.84rem; font-weight: 800; letter-spacing: 0; text-transform: none; margin-bottom: 12px; }
+.next-up-button { position: relative; z-index: 1; width: 100%; min-height: 102px; display: grid; grid-template-columns: minmax(74px, auto) minmax(0, 1fr) auto; grid-template-rows: 1fr auto; column-gap: 16px; row-gap: 12px; align-items: center; text-align: left; border: 0; background: transparent; color: var(--text-primary); padding: 0; font: inherit; cursor: pointer; }
 .next-up-button:focus-visible, .next-up-empty-action:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--amethyst-glow); border-radius: var(--radius-md); }
-.next-up-time { display: inline-flex; align-items: center; gap: 7px; width: fit-content; color: var(--amethyst); font-weight: 800; font-size: 0.92rem; }
-.next-up-title { display: block; color: var(--text-primary); font-size: 1.35rem; font-weight: 800; line-height: 1.12; letter-spacing: -0.02em; }
-.next-up-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 9px 12px; color: var(--text-secondary); font-size: 0.86rem; }
+.next-up-time-chip { min-width: 76px; min-height: 56px; display: inline-flex; align-items: center; justify-content: center; border-radius: 14px; background: rgba(255, 255, 255, 0.08); color: var(--text-primary); font-weight: 850; font-size: 0.98rem; box-shadow: inset 0 0 0 1px rgba(197, 203, 224, 0.12); }
+.next-up-details { display: grid; gap: 7px; min-width: 0; }
+.next-up-title { display: block; color: var(--text-primary); font-size: 1rem; font-weight: 850; line-height: 1.18; letter-spacing: -0.015em; }
+.next-up-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 5px 10px; color: var(--text-secondary); font-size: 0.82rem; }
 .next-up-meta span { display: inline-flex; align-items: center; gap: 4px; }
-.next-up-clear { display: grid; align-content: center; min-height: 120px; gap: 8px; color: var(--text-secondary); }
+.next-up-visual { align-self: center; justify-self: end; display: inline-flex; align-items: center; justify-content: center; width: 76px; height: 76px; }
+.next-up-visual-orb { display: inline-flex; align-items: center; justify-content: center; width: 62px; height: 62px; border-radius: 999px; color: var(--amethyst); background: linear-gradient(135deg, rgba(255,255,255,0.12), rgba(139, 94, 159, 0.18)); box-shadow: 0 12px 28px rgba(8, 11, 20, 0.28); transform: rotate(-8deg); }
+.next-up-cta { grid-column: 1 / span 2; justify-self: start; display: inline-flex; align-items: center; gap: 6px; min-height: 36px; padding: 8px 15px; border-radius: var(--radius-pill); background: var(--amethyst); color: #fff; font-size: 0.82rem; font-weight: 800; box-shadow: 0 10px 22px rgba(139, 94, 159, 0.24); }
+.next-up-clear { display: grid; align-content: center; min-height: 112px; gap: 8px; color: var(--text-secondary); }
 .next-up-clear p { margin: 0; max-width: 34rem; }
 .next-up-empty-action { justify-self: start; min-height: 38px; border: 1px solid var(--glass-border); border-radius: var(--radius-pill); background: var(--surface-raised); color: var(--text-primary); padding: 8px 13px; font: inherit; font-size: 0.83rem; font-weight: 700; cursor: pointer; }
-.today-status-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-sm); }
-.today-status-item { min-height: 76px; display: grid; align-content: center; gap: 4px; padding: var(--space-md); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); background: var(--surface-soft); }
-.today-status-value { color: var(--text-primary); font-size: 1.45rem; line-height: 1; font-weight: 800; font-family: 'JetBrains Mono', monospace; }
-.today-status-label { color: var(--text-secondary); font-size: 0.78rem; font-weight: 700; }
+.today-status-card { border: 1px solid var(--glass-border); border-radius: 20px; background: rgba(255, 255, 255, 0.045); padding: 17px 18px; min-height: 148px; box-shadow: 0 18px 44px rgba(8, 11, 20, 0.3); backdrop-filter: blur(14px); }
+.today-status-heading { color: var(--text-primary); font-size: 0.9rem; font-weight: 850; margin-bottom: 16px; }
+.today-status-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: clamp(10px, 2vw, 18px); align-items: start; }
+.today-status-item { min-height: 86px; display: grid; justify-items: center; align-content: start; gap: 6px; padding: 0; border: 0; border-radius: 0; background: transparent; text-align: center; }
+.today-status-icon { display: inline-flex; align-items: center; justify-content: center; width: 38px; height: 38px; border-radius: 13px; color: var(--amethyst); background: rgba(139, 94, 159, 0.11); }
+.today-status-item-tasks .today-status-icon { color: #5f8a4c; background: rgba(95, 138, 76, 0.14); }
+.today-status-item-shopping .today-status-icon { color: #b97826; background: rgba(185, 120, 38, 0.13); }
+.today-status-item-birthdays .today-status-icon { color: #c46d3b; background: rgba(196, 109, 59, 0.13); }
+.today-status-value { color: var(--text-primary); font-size: 1.26rem; line-height: 1; font-weight: 850; font-family: 'JetBrains Mono', monospace; margin-top: 3px; }
+.today-status-label { color: var(--text-secondary); font-size: 0.76rem; font-weight: 700; line-height: 1.2; }
+
+
+[data-theme="light"] .next-up-card { background: linear-gradient(135deg, rgba(248, 241, 251, 0.96), rgba(255, 248, 244, 0.9)); box-shadow: 0 18px 45px rgba(71, 45, 95, 0.08); }
+[data-theme="light"] .next-up-time-chip { background: rgba(255, 255, 255, 0.78); box-shadow: inset 0 0 0 1px rgba(139, 94, 159, 0.08); }
+[data-theme="light"] .next-up-visual-orb { background: linear-gradient(135deg, rgba(255,255,255,0.92), rgba(235, 224, 243, 0.75)); box-shadow: 0 12px 28px rgba(71, 45, 95, 0.16); }
+[data-theme="light"] .today-status-card { border-color: rgba(120, 130, 180, 0.16); background: rgba(255, 255, 255, 0.86); box-shadow: 0 18px 44px rgba(47, 35, 62, 0.08); }
 
 .view-title { font-size: 1.65rem; font-weight: 700; letter-spacing: -0.02em; }
 .view-subtitle { color: var(--text-secondary); font-size: 0.88rem; margin-top: 2px; }
@@ -841,6 +862,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 @media (max-width: 960px) {
   .today-command-grid { grid-template-columns: 1fr; }
   .today-command-header { flex-direction: column; align-items: stretch; }
+  .today-status-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }
 
 @media (max-width: 768px) {
@@ -1933,9 +1955,16 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 
 @media (max-width: 768px) {
 
-  .today-command-center { padding: var(--space-md); border-radius: var(--radius-lg); }
-  .today-status-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .next-up-title { font-size: 1.15rem; }
+  .today-command-center { padding: var(--space-md) 0; border-radius: var(--radius-lg); }
+  .view-title.today-command-title { font-size: 1.75rem; }
+  .today-status-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); row-gap: var(--space-md); }
+  .next-up-button { grid-template-columns: 1fr auto; }
+  .next-up-time-chip { justify-self: start; min-height: 46px; }
+  .next-up-details { grid-column: 1 / -1; }
+  .next-up-visual { grid-column: 2; grid-row: 1; width: 58px; height: 58px; }
+  .next-up-visual-orb { width: 48px; height: 48px; }
+  .next-up-cta { grid-column: 1 / -1; }
+  .next-up-title { font-size: 1.05rem; }
   .sidebar { position: fixed; left: 0; top: 0; width: 260px; min-width: 260px; transform: translateX(-100%); transition: transform 0.3s var(--ease-out-expo); z-index: 60; padding-top: env(safe-area-inset-top); }
   .sidebar.mobile-open { transform: translateX(0); background: var(--void-surface); }
   .main-content { margin-left: 0; width: 100%; padding: var(--space-md); padding-bottom: calc(100px + env(safe-area-inset-bottom)); }


### PR DESCRIPTION
## Summary
- Reworks the dashboard hero into the planned open Today command center layout
- Adds the richer Next up card with a time chip, visual accent, and localized CTA
- Rebuilds Today status as one horizontal card with icon-backed counts while keeping the user greeting visible

## Validation
- `npm test -- --runInBand`
- `npm run build`
- dashboard locale parity and fallback scan
- full Playwright suite: 110 passed, 2 skipped across Desktop Chrome and Mobile Chrome
