### PR TITLE
Move dashboard search into header

### DIFF
--- a/frontend/__tests__/components/AppShellMobileNav.test.js
+++ b/frontend/__tests__/components/AppShellMobileNav.test.js
@@ -13,7 +13,9 @@ jest.mock('../../contexts/AppContext', () => ({
 
 jest.mock('../../lib/announce', () => ({ announce: jest.fn() }));
 
-jest.mock('../../components/DashboardView', () => function MockDashboard() { return <div>Dashboard view</div>; });
+jest.mock('../../components/DashboardView', () => function MockDashboard({ onOpenSearch }) {
+  return <button type="button" onClick={onOpenSearch}>Dashboard search trigger</button>;
+});
 jest.mock('../../components/ActivityView', () => function MockActivity() { return <div>Activity view</div>; });
 jest.mock('../../components/calendar', () => function MockCalendar() { return <div>Calendar view</div>; });
 jest.mock('../../components/ContactsView', () => function MockContacts() { return <div>Contacts view</div>; });
@@ -31,7 +33,9 @@ jest.mock('../../components/NotificationCenter', () => function MockNotification
 jest.mock('../../components/ForcePasswordChange', () => function MockForcePasswordChange() { return <div>Force password change</div>; });
 jest.mock('../../components/OnboardingWizard', () => function MockOnboarding() { return <div>Onboarding</div>; });
 jest.mock('../../components/MemberAvatar', () => function MockMemberAvatar() { return <div data-testid="member-avatar" />; });
-jest.mock('../../components/SearchOverlay', () => function MockSearchOverlay() { return null; });
+jest.mock('../../components/SearchOverlay', () => function MockSearchOverlay({ open }) {
+  return open ? <div role="dialog" aria-label="Search">Search overlay</div> : null;
+});
 
 const messages = {
   dashboard: 'Dashboard',
@@ -153,6 +157,22 @@ describe('AppShell mobile bottom navigation', () => {
     const css = fs.readFileSync(path.join(process.cwd(), 'styles', 'globals.css'), 'utf8');
 
     expect(css).toMatch(/\.bottom-nav-item \{[^}]*min-height: 44px;[^}]*min-width: 44px;/);
+  });
+
+  it('moves desktop dashboard search out of the sidebar and wires the dashboard trigger to global search', () => {
+    mockAppState = baseState({ isMobile: false, activeView: 'dashboard' });
+    const { container } = render(<AppShell />);
+
+    expect(container.querySelector('.sidebar-search-btn')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Dashboard search trigger' }));
+    expect(screen.getByRole('dialog', { name: 'Search' })).toBeInTheDocument();
+  });
+
+  it('keeps desktop sidebar search available outside the dashboard', () => {
+    mockAppState = baseState({ isMobile: false, activeView: 'calendar' });
+    const { container } = render(<AppShell />);
+
+    expect(container.querySelector('.sidebar-search-btn')).toBeInTheDocument();
   });
 
   it('groups desktop navigation around household jobs and keeps system items separate', () => {

--- a/frontend/__tests__/components/DashboardHero.test.js
+++ b/frontend/__tests__/components/DashboardHero.test.js
@@ -53,6 +53,7 @@ const messages = {
   'module.dashboard.today_status_shopping': 'Shopping open',
   'module.dashboard.today_status_birthdays': 'Birthdays soon',
   'module.dashboard.today_status_label': 'Today status',
+  'search.placeholder': 'Search tasks, shopping, events...',
   'module.dashboard.quick_my_tasks': 'My tasks',
   'module.dashboard.quick_rewards': 'Rewards',
   'module.dashboard.context_chips_label': 'Family at a glance',
@@ -230,6 +231,20 @@ describe('DashboardView hero', () => {
   it('does not render the icon-only header quick action buttons anymore', () => {
     const { container } = render(<DashboardView />);
     expect(container.querySelectorAll('.dashboard-header-actions .btn-icon')).toHaveLength(0);
+  });
+
+  it('moves global search into the dashboard header and removes the duplicated date chip', () => {
+    const onOpenSearch = jest.fn();
+    const { container } = render(<DashboardView onOpenSearch={onOpenSearch} />);
+
+    const headerActions = container.querySelector('.dashboard-header-actions');
+    expect(headerActions).toBeInTheDocument();
+    expect(headerActions.querySelector('.view-date')).not.toBeInTheDocument();
+
+    const searchButton = within(headerActions).getByRole('button', { name: /Search tasks, shopping, events/i });
+    expect(searchButton).toHaveClass('dashboard-search-btn');
+    fireEvent.click(searchButton);
+    expect(onOpenSearch).toHaveBeenCalledTimes(1);
   });
 
   it('renders child-safe quick action pills without duplicated header summary chips', () => {

--- a/frontend/components/AppShell.js
+++ b/frontend/components/AppShell.js
@@ -241,11 +241,13 @@ export default function AppShell() {
         </div>
 
         <div className="sidebar-content">
-          <button className="sidebar-search-btn" onClick={() => setSearchOpen(true)}>
-            <Search size={14} />
-            {!collapsed && <span>{t(messages, 'search.placeholder')}</span>}
-            {!collapsed && <kbd className="sidebar-search-kbd">⌘K</kbd>}
-          </button>
+          {activeView !== 'dashboard' && (
+            <button className="sidebar-search-btn" onClick={() => setSearchOpen(true)}>
+              <Search size={14} />
+              {!collapsed && <span>{t(messages, 'search.placeholder')}</span>}
+              {!collapsed && <kbd className="sidebar-search-kbd">⌘K</kbd>}
+            </button>
+          )}
           {!collapsed && currentFamily && (
             <div className="family-switcher">
               <span style={{ fontSize: '0.85rem', fontWeight: 500 }}>{currentFamily.family_name}</span>
@@ -366,7 +368,7 @@ export default function AppShell() {
         )}
 
         <div className="view-enter">
-          {loading ? <DashboardSkeleton /> : me?.must_change_password ? <ForcePasswordChange /> : !me?.has_completed_onboarding ? <OnboardingWizard /> : <ActiveComponent />}
+          {loading ? <DashboardSkeleton /> : me?.must_change_password ? <ForcePasswordChange /> : !me?.has_completed_onboarding ? <OnboardingWizard /> : <ActiveComponent onOpenSearch={() => setSearchOpen(true)} />}
         </div>
       </main>
 

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { CalendarClock, ListChecks, Cake, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer, Settings2, ArrowUp, ArrowDown, RotateCcw, MapPin } from 'lucide-react';
+import { CalendarClock, ListChecks, Cake, Calendar, CheckCircle, CheckSquare, UserPlus, Circle, ShoppingCart, Utensils, Sparkles, Printer, Settings2, ArrowUp, ArrowDown, RotateCcw, MapPin, Search } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
@@ -275,7 +275,7 @@ function ActivationPanel({ steps, completedCount, totalCount, messages, onDismis
   );
 }
 
-export default function DashboardView() {
+export default function DashboardView({ onOpenSearch } = {}) {
   const { summary, me, members, tasks, events, shoppingLists, quickCaptureInbox, familyId, families, setActiveView, messages, lang, timeFormat, isChild, isAdmin, demoMode, loadQuickCaptureInbox, loadTasks, loadShoppingLists, loadActivity } = useApp();
   const todayIso = useMemo(() => todayIsoDate(), []);
   const [mealsTodayCount, setMealsTodayCount] = useState(0);
@@ -513,7 +513,18 @@ export default function DashboardView() {
             <p className="today-command-family">{todayStr}</p>
           </div>
           <div className="dashboard-header-actions">
-            <div className="view-date">{todayStr}</div>
+            {typeof onOpenSearch === 'function' && (
+              <button
+                type="button"
+                className="dashboard-search-btn"
+                onClick={onOpenSearch}
+                aria-label={t(messages, 'search.placeholder')}
+              >
+                <Search size={16} aria-hidden="true" />
+                <span className="dashboard-search-placeholder">{t(messages, 'search.placeholder')}</span>
+                <kbd className="dashboard-search-kbd">⌘K</kbd>
+              </button>
+            )}
             <button type="button" className="dashboard-layout-toggle" onClick={() => setLayoutEditing((current) => !current)}>
               <Settings2 size={15} aria-hidden="true" />
               <span>{t(messages, 'module.dashboard.customize_layout')}</span>

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -39,6 +39,34 @@ test.describe('Dashboard', () => {
     await expect(page.getByRole('region', { name: 'Open tasks' })).toBeVisible();
   });
 
+  test('moves search into the dashboard header and removes the duplicate date chip', async ({ authedPage: page }) => {
+    await expect(page.getByRole('group', { name: 'Quick actions' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.dashboard-header-actions .view-date')).toHaveCount(0);
+    await expect(page.locator('.sidebar-search-btn')).toHaveCount(0);
+
+    const dashboardSearch = page.locator('.dashboard-header-actions .dashboard-search-btn');
+    await expect(dashboardSearch).toBeVisible();
+    await dashboardSearch.click();
+    await expect(page.locator('.search-overlay')).toBeVisible();
+    await expect(page.getByPlaceholder(/Search/i)).toBeFocused();
+  });
+
+  test('keeps dashboard header search usable on narrow desktop widths', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 1024, height: 720 });
+    await expect(page.getByRole('group', { name: 'Quick actions' })).toBeVisible({ timeout: 10000 });
+
+    const header = page.locator('.today-command-header');
+    const dashboardSearch = header.locator('.dashboard-search-btn');
+    await expect(dashboardSearch).toBeVisible();
+
+    const headerBox = await header.boundingBox();
+    const searchBox = await dashboardSearch.boundingBox();
+    expect(headerBox).not.toBeNull();
+    expect(searchBox).not.toBeNull();
+    expect(searchBox.x + searchBox.width).toBeLessThanOrEqual(headerBox.x + headerBox.width + 1);
+    expect(searchBox.width).toBeGreaterThanOrEqual(280);
+  });
+
   test('quick-action pills navigate to correct views', async ({ authedPage: page }) => {
     const quickActions = page.getByRole('group', { name: 'Quick actions' });
     await quickActions.waitFor({ timeout: 10000 });

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -217,6 +217,7 @@
   box-shadow: 0 8px 24px -4px rgba(124, 58, 237, 0.25);
 }
 
+[data-theme="light"] .dashboard-search-btn,
 [data-theme="light"] .view-date {
   background: rgba(0, 0, 0, 0.03);
   border: 1px solid rgba(0, 0, 0, 0.06);
@@ -790,7 +791,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .view-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-xl); gap: var(--space-md); }
 .dashboard-today-page { display: grid; gap: var(--space-lg); }
 .today-command-center { display: grid; gap: var(--space-lg); padding: clamp(18px, 2.7vw, 30px) 0 var(--space-sm); margin-bottom: var(--space-md); border: 0; border-radius: 0; background: transparent; box-shadow: none; }
-.today-command-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-lg); }
+.today-command-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-lg); flex-wrap: wrap; }
+.today-command-header > div:first-child { min-width: 0; flex: 1 1 360px; }
 .today-command-kicker { color: var(--amethyst); font-size: 0.72rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
 .view-title.today-command-title { font-size: clamp(1.85rem, 3vw, 2.45rem); line-height: 1.08; font-weight: 500; color: var(--text-primary); }
 .view-title.today-command-title span:first-of-type { font-weight: 850; }
@@ -834,7 +836,12 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 .view-title { font-size: 1.65rem; font-weight: 700; letter-spacing: -0.02em; }
 .view-subtitle { color: var(--text-secondary); font-size: 0.88rem; margin-top: 2px; }
 .view-date { font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; color: var(--text-secondary); background: rgba(255,255,255,0.03); padding: 8px 14px; border-radius: var(--radius-sm); border: 1px solid var(--glass-border); }
-.dashboard-header-actions { display: flex; align-items: center; gap: var(--space-sm); }
+.dashboard-header-actions { display: flex; align-items: center; justify-content: flex-end; gap: var(--space-sm); flex: 1 1 440px; min-width: min(100%, 360px); flex-wrap: wrap; }
+.dashboard-search-btn { flex: 1 1 320px; min-width: min(100%, 320px); max-width: 520px; min-height: 40px; display: inline-flex; align-items: center; gap: 10px; padding: 9px 12px; border: 1px solid var(--glass-border); border-radius: var(--radius-sm); background: rgba(255,255,255,0.04); color: var(--text-secondary); font: inherit; font-size: 0.84rem; cursor: pointer; box-shadow: var(--shadow-sm); }
+.dashboard-search-btn:hover { background: var(--surface-raised); border-color: rgba(139, 94, 159, 0.26); color: var(--text-primary); }
+.dashboard-search-btn:focus-visible { outline: none; border-color: var(--amethyst); box-shadow: 0 0 0 3px var(--amethyst-glow); color: var(--text-primary); }
+.dashboard-search-placeholder { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left; }
+.dashboard-search-kbd { flex-shrink: 0; font-size: 0.65rem; opacity: 0.72; background: var(--void-surface); border: 1px solid var(--glass-border); padding: 2px 5px; border-radius: 4px; }
 .dashboard-layout-toggle, .dashboard-layout-reset { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: 38px; border: 1px solid var(--glass-border); border-radius: var(--radius-pill); padding: 8px 13px; background: rgba(255,255,255,0.03); color: var(--text-primary); font: inherit; font-size: 0.82rem; font-weight: 600; cursor: pointer; transition: background 0.2s, border-color 0.2s; }
 .dashboard-layout-toggle:hover, .dashboard-layout-reset:hover { background: rgba(255,255,255,0.06); border-color: rgba(120, 130, 180, 0.28); }
 .dashboard-layout-panel { margin: calc(-1 * var(--space-sm)) 0 var(--space-md); padding: var(--space-md); border: 1px solid var(--glass-border); border-radius: var(--radius-lg); background: rgba(255,255,255,0.025); }
@@ -1981,7 +1988,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
   .dashboard-module-shell[data-dashboard-module="quick_capture"] { grid-column: span 1; }
   .daily-loop-list { grid-template-columns: 1fr; }
   .daily-loop-item { grid-template-columns: auto 1fr; }
-  .dashboard-header-actions { flex-wrap: wrap; }
+  .dashboard-header-actions { width: 100%; flex-wrap: wrap; }
+  .dashboard-search-btn { flex: 1 1 240px; min-width: 0; max-width: none; }
   .view-header { flex-direction: column; align-items: flex-start; }
   .tasks-toolbar { flex-direction: column; align-items: flex-start; }
   .tasks-count { margin-left: 0; }


### PR DESCRIPTION
## Summary
- remove the duplicate dashboard header date chip from the right-side action area
- move the global search entry point into that header space on the dashboard, while keeping sidebar search on non-dashboard views
- add unit and Playwright coverage for the new search placement, including a 1024px narrow-desktop regression

## Verification
- git diff --check
- frontend Jest: 55 suites, 370 tests passed
- frontend Next build
- targeted Playwright Desktop Chrome dashboard header search: 2 passed
- full Playwright: collected 116 tests, 114 passed, 2 skipped on Desktop Chrome + Mobile Chrome
- visual screenshot smoke: duplicate right date chip gone, dashboard header search visible, sidebar search hidden on dashboard