### PR TITLE
fix: tighten mobile dashboard spacing

### DIFF
--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -67,6 +67,37 @@ test.describe('Dashboard', () => {
     expect(searchBox.width).toBeGreaterThanOrEqual(280);
   });
 
+  test('keeps mobile dashboard header and cards tightly stacked', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 485, height: 873 });
+    await expect(page.getByRole('group', { name: 'Quick actions' })).toBeVisible({ timeout: 10000 });
+
+    const dateLine = page.locator('.today-command-family');
+    const dashboardSearch = page.locator('.dashboard-search-btn');
+    const layoutToggle = page.locator('.dashboard-layout-toggle');
+    const nextUp = page.locator('.next-up-card');
+    const statusCard = page.locator('.today-status-card');
+
+    const boxes = await Promise.all([
+      dateLine.boundingBox(),
+      dashboardSearch.boundingBox(),
+      layoutToggle.boundingBox(),
+      nextUp.boundingBox(),
+      statusCard.boundingBox(),
+    ]);
+    for (const box of boxes) expect(box).not.toBeNull();
+
+    const [dateBox, searchBox, layoutBox, nextUpBox, statusBox] = boxes;
+    const firstActionTop = Math.min(searchBox.y, layoutBox.y);
+    const lastActionBottom = Math.max(searchBox.y + searchBox.height, layoutBox.y + layoutBox.height);
+    const dateToActionsGap = firstActionTop - (dateBox.y + dateBox.height);
+    const actionsToNextUpGap = nextUpBox.y - lastActionBottom;
+    const nextUpToStatusGap = statusBox.y - (nextUpBox.y + nextUpBox.height);
+
+    expect(dateToActionsGap).toBeLessThanOrEqual(32);
+    expect(actionsToNextUpGap).toBeLessThanOrEqual(32);
+    expect(nextUpToStatusGap).toBeLessThanOrEqual(32);
+  });
+
   test('quick-action pills navigate to correct views', async ({ authedPage: page }) => {
     const quickActions = page.getByRole('group', { name: 'Quick actions' });
     await quickActions.waitFor({ timeout: 10000 });

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -869,6 +869,8 @@ body { font-family: 'Outfit', sans-serif; background: var(--void); color: var(--
 @media (max-width: 960px) {
   .today-command-grid { grid-template-columns: 1fr; }
   .today-command-header { flex-direction: column; align-items: stretch; }
+  .today-command-header > div:first-child,
+  .dashboard-header-actions { flex: 0 1 auto; min-width: 0; }
   .today-status-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }
 


### PR DESCRIPTION
## Summary
- Fixes excessive empty space in the mobile dashboard header area.
- Keeps the greeting, search controls, and first dashboard cards tightly stacked on narrow screens.
- Adds mobile browser regression coverage for the spacing contract.

## Validation
- npm test -- --runTestsByPath __tests__/components/DashboardHero.test.js __tests__/components/AppShellMobileNav.test.js --runInBand
- npm run build
- BASE_URL=http://127.0.0.1:3301 npx playwright test e2e/tests/dashboard.spec.js --project="Desktop Chrome" --project="Mobile Chrome"
- BASE_URL=http://127.0.0.1:3301 npx playwright test
- Mobile browser smoke screenshot verified after the CSS fix
