### PR TITLE
fix(auth): preserve exact OIDC issuer

### DIFF
--- a/backend/app/core/oidc.py
+++ b/backend/app/core/oidc.py
@@ -223,7 +223,7 @@ def save_config(
     set_setting(db, KEY_ENABLED, "true" if enabled else "false")
     set_setting(db, KEY_PRESET, preset)
     set_setting(db, KEY_BUTTON_LABEL, button_label)
-    set_setting(db, KEY_ISSUER, issuer.rstrip("/"))
+    set_setting(db, KEY_ISSUER, issuer.strip())
     set_setting(db, KEY_CLIENT_ID, client_id)
     if client_secret is not None:
         set_setting(db, KEY_CLIENT_SECRET, client_secret)
@@ -428,7 +428,11 @@ def _fetch_json(url: str, timeout: float = 5.0) -> dict:
 
 
 def _discovery_url(issuer: str) -> str:
-    base = issuer.rstrip("/")
+    # Only normalize for URL concatenation. The configured issuer
+    # itself is an OIDC identity string and must stay exact for
+    # discovery issuer checks, ID-token `iss` validation, and identity
+    # linking. Authentik commonly includes a trailing slash there.
+    base = issuer.strip().rstrip("/")
     return f"{base}/.well-known/openid-configuration"
 
 
@@ -440,7 +444,7 @@ def fetch_discovery(issuer: str, *, force: bool = False) -> Discovery:
     fields the login flow actually reads; the full JSON is kept as
     ``.raw`` for tests and for admin diagnostics.
     """
-    issuer = issuer.rstrip("/")
+    issuer = issuer.strip()
     now = time.monotonic()
     if not force:
         cached = _discovery_cache.get(issuer)
@@ -466,12 +470,11 @@ def fetch_discovery(issuer: str, *, force: bool = False) -> Discovery:
             f"Discovery document missing required fields: {', '.join(missing)}"
         )
 
-    # Some IdPs issue discovery at a slightly different URL than the
-    # issuer claim (trailing slash mismatch). We require the claim
-    # itself to match the configured issuer after stripping trailing
-    # slashes to protect against mix-up / phishing via a rogue
-    # discovery endpoint.
-    claimed = str(data["issuer"]).rstrip("/")
+    # The issuer is an exact OIDC identity string. A trailing slash
+    # mismatch is significant because the same value is later passed
+    # to ID-token `iss` validation. Do not normalize it away here, or
+    # the admin discovery test can pass while the real callback fails.
+    claimed = str(data["issuer"])
     if claimed != issuer:
         raise DiscoveryError(
             f"Issuer mismatch: configured {issuer!r}, document says {claimed!r}"
@@ -498,7 +501,7 @@ def invalidate_discovery_cache(issuer: Optional[str] = None) -> None:
     if issuer is None:
         _discovery_cache.clear()
     else:
-        _discovery_cache.pop(issuer.rstrip("/"), None)
+        _discovery_cache.pop(issuer.strip(), None)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_oidc_admin.py
+++ b/backend/tests/test_oidc_admin.py
@@ -233,7 +233,7 @@ def test_put_config_partial_update():
         json={
             "enabled": True,
             "preset": "authentik",
-            "issuer": "https://auth.example.com/application/o/tribu",
+            "issuer": "https://auth.example.com/application/o/tribu/",
             "client_id": "tribu",
             "client_secret": "s3cr3t",
             "scopes": "openid profile email",
@@ -260,7 +260,7 @@ def test_put_config_partial_update():
     body = resp.json()
     assert body["button_label"] == "Sign in with home IdP"
     assert body["client_secret_set"] is True
-    assert body["issuer"] == "https://auth.example.com/application/o/tribu"
+    assert body["issuer"] == "https://auth.example.com/application/o/tribu/"
 
 
 def test_put_clears_secret_on_empty_string():

--- a/backend/tests/test_oidc_config.py
+++ b/backend/tests/test_oidc_config.py
@@ -89,12 +89,13 @@ class TestConfigRoundTrip:
         assert cfg.is_ready() is False
 
     def test_save_and_reload(self, db):
+        issuer = "https://auth.example.com/application/o/tribu/"
         oidc_core.save_config(
             db,
             enabled=True,
             preset="authentik",
             button_label="Sign in with Home IdP",
-            issuer="https://auth.example.com/application/o/tribu",
+            issuer=issuer,
             client_id="tribu-client",
             client_secret="topsecret",
             scopes="openid profile email",
@@ -107,8 +108,10 @@ class TestConfigRoundTrip:
         assert cfg.enabled is True
         assert cfg.preset == "authentik"
         assert cfg.button_label == "Sign in with Home IdP"
-        # Trailing slash stripped on save so URL concat stays predictable
-        assert cfg.issuer == "https://auth.example.com/application/o/tribu"
+        # The issuer is an OIDC identity string, not just a URL prefix.
+        # Authentik normally includes the trailing slash in both discovery
+        # and ID-token `iss`, so saving must preserve it exactly.
+        assert cfg.issuer == issuer
         assert cfg.client_id == "tribu-client"
         assert cfg.client_secret == "topsecret"
         assert cfg.allow_signup is True
@@ -311,10 +314,32 @@ class TestDiscovery:
         assert disc.token_endpoint.endswith("/token")
         assert disc.jwks_uri.endswith("/jwks")
 
-    def test_trailing_slash_normalised(self):
-        with patch.object(oidc_core, "_fetch_json", return_value=_valid_doc()):
-            disc = oidc_core.fetch_discovery("https://idp.example.com/", force=True)
-        assert disc.issuer == "https://idp.example.com"
+    def test_trailing_slash_preserved_for_authentik_issuer(self):
+        issuer = "https://idp.example.com/application/o/tribu/"
+        fetched_urls: list[str] = []
+
+        def fake_fetch(url, timeout=5.0):
+            fetched_urls.append(url)
+            return _valid_doc(issuer)
+
+        with patch.object(oidc_core, "_fetch_json", side_effect=fake_fetch):
+            disc = oidc_core.fetch_discovery(issuer, force=True)
+
+        assert disc.issuer == issuer
+        assert fetched_urls == [
+            "https://idp.example.com/application/o/tribu/.well-known/openid-configuration"
+        ]
+
+    def test_trailing_slash_mismatch_raises(self):
+        with patch.object(
+            oidc_core,
+            "_fetch_json",
+            return_value=_valid_doc("https://idp.example.com/application/o/tribu/"),
+        ):
+            with pytest.raises(oidc_core.DiscoveryError):
+                oidc_core.fetch_discovery(
+                    "https://idp.example.com/application/o/tribu", force=True
+                )
 
     def test_missing_required_field_raises(self):
         bad = _valid_doc()


### PR DESCRIPTION
## Summary
- Preserve OIDC issuer values exactly after whitespace trimming so Authentik issuers with trailing slashes keep matching discovery and ID-token `iss` values.
- Keep slash normalization limited to the discovery URL path construction.
- Add regression coverage for exact issuer storage, discovery URL generation, and trailing-slash mismatch rejection.

Closes #360

## Validation
- `pytest backend/tests/test_oidc_config.py::TestConfigRoundTrip::test_save_and_reload backend/tests/test_oidc_config.py::TestDiscovery::test_trailing_slash_preserved_for_authentik_issuer backend/tests/test_oidc_config.py::TestDiscovery::test_trailing_slash_mismatch_raises backend/tests/test_oidc_admin.py::test_put_config_partial_update -q`
- `pytest backend/tests/test_oidc_config.py backend/tests/test_oidc_admin.py -q`
- `pytest backend/tests -q`
- `npm test -- --runTestsByPath __tests__/components/SsoSection.test.js --runInBand`
- `BACKEND_PORT=8210 FRONTEND_PORT=3310 TRIBU_E2E_DB=/tmp/tribu-issue-360-e2e.db DAV_STORAGE_FOLDER=/tmp/tribu-issue-360-e2e-dav ./scripts/e2e-local.sh frontend/e2e/tests/admin.spec.js`
- `git diff --check`
