### PR TITLE
Add mobile bearer login endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,11 +66,11 @@ from app.core.scheduler import configure_backup_schedule, start_notification_job
 from app.core import ws_broadcast
 from app.schemas import (
     AUTH_RESPONSES, CONFLICT_RESPONSE, ErrorResponse,
-    ChangePasswordRequest, DeleteAccountRequest, LeaveFamilyRequest, LoginRequest, MeResponse, ProfileImageUpdate, RegisterRequest,
+    ChangePasswordRequest, DeleteAccountRequest, LeaveFamilyRequest, LoginRequest, MeResponse, MobileLoginResponse, ProfileImageUpdate, RegisterRequest,
 )
 from app.core import cache
 from app.core.utils import get_setting, utcnow
-from app.security import hash_password, verify_password
+from app.security import JWT_EXPIRE_HOURS, create_access_token, hash_password, verify_password
 from app.core.config import REFRESH_COOKIE_NAME, VERSION
 
 logger = logging.getLogger(__name__)
@@ -396,6 +396,35 @@ def login(request: Request, payload: LoginRequest, db: Session = Depends(get_db)
     issue_session_cookies(response, db, user)
     db.commit()
     return response
+
+
+@app.post(
+    "/auth/mobile-login",
+    tags=["auth"],
+    summary="Mobile login",
+    description=(
+        "Authenticate a native mobile client with email and password. "
+        "Returns a bearer token for Authorization header use instead of browser cookies. "
+        "Rate limited to 20 requests per minute. No authentication required."
+    ),
+    response_model=MobileLoginResponse,
+    responses={401: {"model": ErrorResponse, "description": "Invalid credentials"}},
+    response_description="Mobile login successful",
+)
+@limiter.limit("20/minute")
+def mobile_login(request: Request, payload: LoginRequest, db: Session = Depends(get_db)):
+    if oidc_core.password_login_disabled(db):
+        raise HTTPException(status_code=403, detail=error_detail(PASSWORD_LOGIN_DISABLED))
+
+    user = db.query(User).filter(User.email == payload.email.lower()).first()
+    if not user or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(status_code=401, detail=error_detail(INVALID_CREDENTIALS))
+
+    return MobileLoginResponse(
+        access_token=create_access_token(user_id=user.id, email=user.email),
+        expires_in_hours=JWT_EXPIRE_HOURS,
+        must_change_password=user.must_change_password,
+    )
 
 
 @app.post(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -80,6 +80,14 @@ class LoginRequest(BaseModel):
     })
 
 
+class MobileLoginResponse(BaseModel):
+    """Bearer token response for native mobile clients."""
+    access_token: str = Field(..., description="JWT bearer token for Authorization header use")
+    token_type: str = Field("bearer", description="Token type")
+    expires_in_hours: int = Field(..., description="Configured access token lifetime in hours")
+    must_change_password: bool = Field(False, description="True if user must change their temporary password")
+
+
 class MeResponse(BaseModel):
     """Current authenticated user profile."""
     user_id: int = Field(..., description="User ID")

--- a/backend/tests/test_mobile_auth.py
+++ b/backend/tests/test_mobile_auth.py
@@ -1,0 +1,106 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import Family, Membership, User
+from app.security import hash_password
+
+
+engine = create_engine(
+    "sqlite:///./test-mobile-auth.db",
+    connect_args={"check_same_thread": False},
+)
+TestSession = sessionmaker(bind=engine)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, _):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+def setup_function():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def _override():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+
+
+def teardown_function():
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def _seed_user():
+    db = TestSession()
+    try:
+        user = User(
+            email="mobile-login@example.com",
+            password_hash=hash_password("Secure1Pass"),
+            display_name="Mobile Login",
+            must_change_password=True,
+            has_completed_onboarding=True,
+        )
+        db.add(user)
+        db.flush()
+        family = Family(name="Mobile Family")
+        db.add(family)
+        db.flush()
+        db.add(
+            Membership(
+                user_id=user.id, family_id=family.id, role="admin", is_adult=True
+            )
+        )
+        db.commit()
+        return family.id
+    finally:
+        db.close()
+
+
+def test_mobile_login_returns_bearer_token_usable_for_authenticated_routes():
+    _seed_user()
+
+    login = client.post(
+        "/auth/mobile-login",
+        json={"email": "mobile-login@example.com", "password": "Secure1Pass"},
+    )
+
+    assert login.status_code == 200, login.json()
+    data = login.json()
+    assert data["token_type"] == "bearer"
+    assert data["access_token"]
+    assert data["expires_in_hours"] > 0
+    assert data["must_change_password"] is True
+    assert "set-cookie" not in {
+        key.lower(): value for key, value in login.headers.items()
+    }
+
+    me = client.get(
+        "/auth/me", headers={"Authorization": f"Bearer {data['access_token']}"}
+    )
+    assert me.status_code == 200, me.json()
+    assert me.json()["email"] == "mobile-login@example.com"
+
+
+def test_mobile_login_rejects_invalid_credentials():
+    _seed_user()
+
+    login = client.post(
+        "/auth/mobile-login",
+        json={"email": "mobile-login@example.com", "password": "WrongPass1"},
+    )
+
+    assert login.status_code == 401


### PR DESCRIPTION
## Summary
- Add a native-client login endpoint that returns a bearer token instead of setting browser cookies.
- Add the mobile login response schema.
- Cover successful bearer login and invalid credentials with backend tests.

## Validation
- Backend tests pass locally.
- Changed backend files pass the lint gate with the existing startup import pattern respected.
- GitHub checks are green, including CodeQL and E2E.