### PR TITLE
Fix session refresh timestamp handling

### DIFF
--- a/backend/app/core/auth_sessions.py
+++ b/backend/app/core/auth_sessions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import Literal
+from datetime import datetime, timedelta
+from typing import Literal, cast
 
 from fastapi import Response
 from sqlalchemy.orm import Session
@@ -13,7 +13,7 @@ from app.core.config import (
     REFRESH_COOKIE_MAX_AGE,
     REFRESH_COOKIE_NAME,
 )
-from app.core.utils import utcnow
+from app.core.clock import to_utc_naive, utcnow
 from app.models import User, UserSession
 from app.security import (
     create_access_token,
@@ -78,7 +78,7 @@ def rotate_refresh_token(db: Session, refresh_token: str) -> tuple[RefreshRotati
     if session.revoked_at is not None:
         return "invalid", None, None
     now = utcnow()
-    if session.expires_at <= now:
+    if to_utc_naive(cast(datetime, session.expires_at)) <= now:
         session.revoked_at = now
         db.commit()
         return "invalid", None, None

--- a/backend/app/core/clock.py
+++ b/backend/app/core/clock.py
@@ -9,6 +9,19 @@ def utcnow() -> datetime:
     return datetime.now(UTC).replace(tzinfo=None)
 
 
+def to_utc_naive(value: datetime) -> datetime:
+    """Normalize a datetime to Tribu's naive UTC storage convention.
+
+    Most audit/session fields are stored as naive UTC values, but production
+    PostgreSQL drivers can return ``timezone=True`` columns as aware UTC
+    datetimes. Normalizing before comparisons keeps SQLite and Postgres
+    behavior aligned without changing local wall-clock calendar semantics.
+    """
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value
+    return value.astimezone(UTC).replace(tzinfo=None)
+
+
 @lru_cache(maxsize=8)
 def app_timezone(name: str | None = None) -> ZoneInfo:
     timezone_name = (name or os.getenv("TZ") or "UTC").strip() or "UTC"

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,8 +1,8 @@
 from datetime import UTC, date, datetime
 import jwt
 
-from app.core.utils import utcnow
-from typing import Optional
+from app.core.clock import to_utc_naive, utcnow
+from typing import Optional, cast
 
 from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -81,7 +81,8 @@ def _resolve_user(request: Request, token_str: str, db: Session) -> User:
         pat = _find_pat(db, token_str)
         if not pat:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=error_detail(INVALID_TOKEN))
-        if pat.expires_at and pat.expires_at < utcnow():
+        expires_at = cast(datetime | None, pat.expires_at)
+        if expires_at is not None and to_utc_naive(expires_at) < utcnow():
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=error_detail(TOKEN_EXPIRED))
         if not verify_pat(token_str, pat.token_hash):
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=error_detail(INVALID_TOKEN))

--- a/backend/app/dav/auth_plugin.py
+++ b/backend/app/dav/auth_plugin.py
@@ -12,12 +12,13 @@ storage plugin in the next phases.
 """
 from __future__ import annotations
 
-from typing import Optional
+from datetime import datetime
+from typing import Optional, cast
 
 from radicale.auth import BaseAuth
 from radicale.log import logger
 
-from app.core.clock import utcnow
+from app.core.clock import to_utc_naive, utcnow
 from app.core.scopes import has_scope, parse_scopes
 from app.database import SessionLocal
 from app.models import PersonalAccessToken, User
@@ -71,7 +72,8 @@ class Auth(BaseAuth):
             )
             if pat is None:
                 return ""
-            if pat.expires_at is not None and pat.expires_at < utcnow():
+            expires_at = cast(datetime | None, pat.expires_at)
+            if expires_at is not None and to_utc_naive(expires_at) < utcnow():
                 _record_dav_failure(pat, "token_expired")
                 db.commit()
                 return ""

--- a/backend/tests/test_session_persistence.py
+++ b/backend/tests/test_session_persistence.py
@@ -1,14 +1,18 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
 import jwt
+from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
+from app.core.auth_sessions import issue_refresh_session, rotate_refresh_token
+from app.core.deps import _resolve_user
 from app.database import Base, get_db
 from app.main import app
-from app.models import Family, Membership, User, UserSession
-from app.security import JWT_ALG, JWT_SECRET, hash_password
+from app.models import Family, Membership, PersonalAccessToken, User, UserSession
+from app.security import JWT_ALG, JWT_SECRET, generate_pat, hash_password
 
 engine = create_engine(
     "sqlite:///./test-session-persistence.db",
@@ -77,6 +81,70 @@ def _expired_access_token(user_id: int) -> str:
         JWT_SECRET,
         algorithm=JWT_ALG,
     )
+
+
+def test_rotate_refresh_token_accepts_aware_postgres_expiry_timestamp():
+    user_id = _seed_user()
+    db = TestSession()
+    try:
+        user = db.query(User).filter(User.id == user_id).one()
+        refresh_token = issue_refresh_session(db, user)
+        session = db.query(UserSession).filter(UserSession.user_id == user_id).one()
+        setattr(session, "expires_at", datetime.now(timezone.utc) + timedelta(days=1))
+
+        result, refreshed_user, next_token = rotate_refresh_token(db, refresh_token)
+
+        assert result == "ok"
+        assert refreshed_user is not None
+        assert getattr(refreshed_user, "id") == user_id
+        assert next_token is not None
+    finally:
+        db.close()
+
+
+def test_expired_refresh_token_with_aware_postgres_timestamp_is_invalid():
+    user_id = _seed_user()
+    db = TestSession()
+    try:
+        user = db.query(User).filter(User.id == user_id).one()
+        refresh_token = issue_refresh_session(db, user)
+        session = db.query(UserSession).filter(UserSession.user_id == user_id).one()
+        setattr(session, "expires_at", datetime.now(timezone.utc) - timedelta(minutes=1))
+
+        result, refreshed_user, next_token = rotate_refresh_token(db, refresh_token)
+
+        assert result == "invalid"
+        assert refreshed_user is None
+        assert next_token is None
+        assert getattr(session, "revoked_at") is not None
+    finally:
+        db.close()
+
+
+def test_expired_pat_with_aware_timestamp_returns_unauthorized():
+    user_id = _seed_user()
+    token, token_hash, token_lookup = generate_pat()
+    db = TestSession()
+    try:
+        db.add(
+            PersonalAccessToken(
+                user_id=user_id,
+                name="expired-aware-pat",
+                token_hash=token_hash,
+                token_lookup=token_lookup,
+                scopes="profile:read",
+                expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+            )
+        )
+        db.flush()
+        request = Request({"type": "http", "headers": []})
+
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_user(request, token, db)
+
+        assert exc_info.value.status_code == 401
+    finally:
+        db.close()
 
 
 def test_login_issues_refresh_cookie_and_refreshes_expired_access_cookie():

--- a/frontend/__tests__/lib/api.test.js
+++ b/frontend/__tests__/lib/api.test.js
@@ -168,6 +168,23 @@ describe('Auth API', () => {
     expect(global.fetch.mock.calls[1][1].credentials).toBe('include');
   });
 
+  it('retries once after a stale refresh failure in case another context refreshed cookies', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) })
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'invalid' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ email: 'session@example.com' }) });
+
+    const result = await apiGetMe();
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ email: 'session@example.com' });
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual([
+      '/api/auth/me',
+      '/api/auth/refresh',
+      '/api/auth/me',
+    ]);
+  });
+
   it('apiUpdateProfileImage sends PATCH', async () => {
     await apiUpdateProfileImage('data:image/png;base64,...');
     const [url, opts] = lastCall();

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -24,6 +24,7 @@ async function request(path, options = {}, allowRefresh = true) {
   if (res.status === 401 && allowRefresh && !logoutInFlight && path !== '/auth/refresh' && path !== '/auth/login' && path !== '/auth/logout') {
     const refreshed = await refreshSession();
     if (refreshed.ok && !logoutInFlight) return request(path, options, false);
+    if (!logoutInFlight) return request(path, options, false);
   }
 
   return { ok: res.ok, status: res.status, data };


### PR DESCRIPTION
## Summary
- normalize database timestamps before session and PAT expiry comparisons so PostgreSQL timezone-aware values do not break refresh
- retry the original browser request once after a failed refresh to tolerate another tab or PWA context refreshing cookies first
- add backend and frontend regressions for aware expiry timestamps and stale refresh recovery

## Checks
- `JWT_SECRET=*** DATABASE_URL=sqlite:////tmp/tribu-session-fix.db .venv/bin/python -m pytest tests/test_session_persistence.py -q` — 9 passed
- `npm test -- --runTestsByPath __tests__/lib/api.test.js --runInBand` — 36 passed
- `git diff --check`
