### PR TITLE
Tighten session refresh timestamp handling

### DIFF
--- a/backend/app/core/auth_sessions.py
+++ b/backend/app/core/auth_sessions.py
@@ -13,7 +13,7 @@ from app.core.config import (
     REFRESH_COOKIE_MAX_AGE,
     REFRESH_COOKIE_NAME,
 )
-from app.core.clock import to_utc_naive, utcnow
+from app.core.clock import to_utc_naive, utcnow, utcnow_aware
 from app.models import User, UserSession
 from app.security import (
     create_access_token,
@@ -52,7 +52,7 @@ RefreshRotationResult = Literal["ok", "stale", "invalid"]
 def issue_refresh_session(db: Session, user: User) -> str:
     """Create a revocable refresh session and return the one-time plain token."""
     refresh_token, stored_hash, lookup = generate_refresh_token()
-    now = utcnow()
+    now = utcnow_aware()
     db.add(
         UserSession(
             user_id=user.id,
@@ -67,7 +67,13 @@ def issue_refresh_session(db: Session, user: User) -> str:
 
 
 def rotate_refresh_token(db: Session, refresh_token: str) -> tuple[RefreshRotationResult, User | None, str | None]:
-    """Rotate an opaque refresh token without writing browser cookies."""
+    """Rotate an opaque refresh token without writing browser cookies.
+
+    Successful rotations are left uncommitted so browser and native callers can
+    publish the matching access/refresh response atomically with the DB change.
+    Invalid expired/orphaned sessions are committed here because callers may
+    immediately return or raise a 401 response.
+    """
     session = (
         db.query(UserSession)
         .filter(UserSession.token_lookup == refresh_token_lookup_key(refresh_token))
@@ -77,16 +83,17 @@ def rotate_refresh_token(db: Session, refresh_token: str) -> tuple[RefreshRotati
         return "stale", None, None
     if session.revoked_at is not None:
         return "invalid", None, None
-    now = utcnow()
+    write_now = utcnow_aware()
+    now = to_utc_naive(write_now)
     if to_utc_naive(cast(datetime, session.expires_at)) <= now:
-        session.revoked_at = now
+        session.revoked_at = write_now  # type: ignore[reportAttributeAccessIssue]
         db.commit()
         return "invalid", None, None
     if not verify_refresh_token(refresh_token, session.token_hash):
         return "invalid", None, None
     user = db.query(User).filter(User.id == session.user_id).first()
     if not user:
-        session.revoked_at = now
+        session.revoked_at = write_now  # type: ignore[reportAttributeAccessIssue]
         db.commit()
         return "invalid", None, None
 
@@ -102,8 +109,8 @@ def rotate_refresh_token(db: Session, refresh_token: str) -> tuple[RefreshRotati
             {
                 UserSession.token_lookup: next_lookup,
                 UserSession.token_hash: next_hash,
-                UserSession.last_used_at: now,
-                UserSession.expires_at: now + timedelta(seconds=REFRESH_COOKIE_MAX_AGE),
+                UserSession.last_used_at: write_now,
+                UserSession.expires_at: write_now + timedelta(seconds=REFRESH_COOKIE_MAX_AGE),
             },
             synchronize_session=False,
         )
@@ -140,5 +147,5 @@ def revoke_refresh_session(db: Session, refresh_token: str | None) -> None:
         .first()
     )
     if session and session.revoked_at is None:
-        session.revoked_at = utcnow()
+        session.revoked_at = utcnow_aware()  # type: ignore[reportAttributeAccessIssue]
         db.commit()

--- a/backend/app/core/clock.py
+++ b/backend/app/core/clock.py
@@ -9,6 +9,16 @@ def utcnow() -> datetime:
     return datetime.now(UTC).replace(tzinfo=None)
 
 
+def utcnow_aware() -> datetime:
+    """Return the current UTC instant as a timezone-aware datetime.
+
+    Use this for SQLAlchemy columns declared with ``timezone=True``. Tribu still
+    uses naive UTC for most legacy audit fields, so this helper keeps the two
+    storage contracts explicit instead of changing ``utcnow()`` globally.
+    """
+    return datetime.now(UTC)
+
+
 def to_utc_naive(value: datetime) -> datetime:
     """Normalize a datetime to Tribu's naive UTC storage convention.
 
@@ -22,6 +32,17 @@ def to_utc_naive(value: datetime) -> datetime:
     return value.astimezone(UTC).replace(tzinfo=None)
 
 
+def to_utc_aware(value: datetime) -> datetime:
+    """Normalize a datetime to timezone-aware UTC.
+
+    Naive values are interpreted as Tribu's legacy naive UTC convention. Aware
+    values are converted to UTC without losing the instant.
+    """
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 @lru_cache(maxsize=8)
 def app_timezone(name: str | None = None) -> ZoneInfo:
     timezone_name = (name or os.getenv("TZ") or "UTC").strip() or "UTC"
@@ -31,12 +52,6 @@ def app_timezone(name: str | None = None) -> ZoneInfo:
         return ZoneInfo("UTC")
 
 
-def _as_utc_aware(value: datetime) -> datetime:
-    if value.tzinfo is None or value.utcoffset() is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
-
-
 def local_wall_now(now_utc: datetime | None = None) -> datetime:
     """Return the current Tribu wall-clock time as a naive datetime.
 
@@ -44,7 +59,7 @@ def local_wall_now(now_utc: datetime | None = None) -> datetime:
     scheduler comparisons must use the same clock. Audit/log timestamps should
     continue to use utcnow().
     """
-    instant = _as_utc_aware(now_utc or utcnow())
+    instant = to_utc_aware(now_utc or utcnow())
     return instant.astimezone(app_timezone()).replace(tzinfo=None)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from slowapi.util import get_remote_address
 
 from app.core.deps import current_user
 from app.core.auth_sessions import clear_session_cookies, issue_refresh_session, issue_session_cookies, revoke_refresh_session, rotate_refresh_session, rotate_refresh_token
+from app.core.clock import utcnow_aware
 from app.core.scopes import require_scope, SCOPE_DESCRIPTIONS
 from app.core.errors import (
     error_detail, EMAIL_ALREADY_EXISTS, INVALID_CREDENTIALS, OLD_PASSWORD_INCORRECT,
@@ -542,7 +543,7 @@ def change_password(
         raise HTTPException(status_code=400, detail=error_detail(OLD_PASSWORD_INCORRECT))
     user.password_hash = hash_password(payload.new_password)
     user.must_change_password = False
-    now = utcnow()
+    now = utcnow_aware()
     user.session_invalidated_at = now
     db.query(UserSession).filter(
         UserSession.user_id == user.id,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 
-from app.core.clock import utcnow
+from app.core.clock import utcnow, utcnow_aware
 
 from sqlalchemy import Column, Date, Index, Integer, String, ForeignKey, UniqueConstraint, DateTime, Boolean, func, Text, JSON, text, Time
 from sqlalchemy.orm import relationship
@@ -36,8 +36,8 @@ class UserSession(Base):
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     token_lookup = Column(String(64), unique=True, nullable=False, index=True)
     token_hash = Column(String(256), nullable=False)
-    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
-    last_used_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow_aware)
+    last_used_at = Column(DateTime(timezone=True), nullable=False, default=utcnow_aware)
     expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True, index=True)
 

--- a/backend/tests/test_clock_timezone.py
+++ b/backend/tests/test_clock_timezone.py
@@ -2,7 +2,16 @@ from datetime import UTC, datetime, timezone, timedelta
 
 import pytest
 
-from app.core.clock import app_timezone, local_today, local_wall_now, local_wall_to_utc_naive, to_local_wall_naive
+from app.core.clock import (
+    app_timezone,
+    local_today,
+    local_wall_now,
+    local_wall_to_utc_naive,
+    to_local_wall_naive,
+    to_utc_aware,
+    to_utc_naive,
+    utcnow_aware,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -67,6 +76,31 @@ def test_to_local_wall_naive_converts_utc_values_to_family_wall_time():
     aware_utc = datetime(2026, 5, 9, 7, 15, 0, tzinfo=UTC)
 
     assert to_local_wall_naive(aware_utc).isoformat() == "2026-05-09T09:15:00"
+
+
+def test_utcnow_aware_returns_timezone_aware_utc_instant():
+    now = utcnow_aware()
+
+    assert now.tzinfo is UTC
+    assert now.utcoffset() == timedelta(0)
+
+
+def test_to_utc_naive_preserves_instant_for_aware_offsets():
+    aware = datetime(2026, 5, 9, 9, 15, 0, tzinfo=timezone(timedelta(hours=2)))
+
+    converted = to_utc_naive(aware)
+
+    assert converted.tzinfo is None
+    assert converted.isoformat() == "2026-05-09T07:15:00"
+
+
+def test_to_utc_aware_interprets_naive_values_as_utc():
+    naive = datetime(2026, 5, 9, 7, 15, 0)
+
+    converted = to_utc_aware(naive)
+
+    assert converted.tzinfo is UTC
+    assert converted.isoformat() == "2026-05-09T07:15:00+00:00"
 
 
 def test_local_wall_to_utc_naive_interprets_stored_wall_times_with_dst():

--- a/backend/tests/test_session_persistence.py
+++ b/backend/tests/test_session_persistence.py
@@ -102,6 +102,21 @@ def test_rotate_refresh_token_accepts_aware_postgres_expiry_timestamp():
         db.close()
 
 
+def test_issue_refresh_session_uses_aware_utc_values_for_timezone_columns():
+    user_id = _seed_user()
+    db = TestSession()
+    try:
+        user = db.query(User).filter(User.id == user_id).one()
+        issue_refresh_session(db, user)
+        session = next(obj for obj in db.new if isinstance(obj, UserSession))
+
+        for value in (session.created_at, session.last_used_at, session.expires_at):
+            assert value.tzinfo is not None
+            assert value.utcoffset() == timedelta(0)
+    finally:
+        db.close()
+
+
 def test_expired_refresh_token_with_aware_postgres_timestamp_is_invalid():
     user_id = _seed_user()
     db = TestSession()

--- a/frontend/__tests__/lib/api.test.js
+++ b/frontend/__tests__/lib/api.test.js
@@ -185,6 +185,23 @@ describe('Auth API', () => {
     ]);
   });
 
+  it('does not start another refresh when the single retry remains unauthorized', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'expired' }) })
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'invalid' }) })
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({ detail: 'still expired' }) });
+
+    const result = await apiGetMe();
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual([
+      '/api/auth/me',
+      '/api/auth/refresh',
+      '/api/auth/me',
+    ]);
+  });
+
   it('apiUpdateProfileImage sends PATCH', async () => {
     await apiUpdateProfileImage('data:image/png;base64,...');
     const [url, opts] = lastCall();

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -22,8 +22,7 @@ async function request(path, options = {}, allowRefresh = true) {
   try { data = await res.json(); } catch { data = null; }
 
   if (res.status === 401 && allowRefresh && !logoutInFlight && path !== '/auth/refresh' && path !== '/auth/login' && path !== '/auth/logout') {
-    const refreshed = await refreshSession();
-    if (refreshed.ok && !logoutInFlight) return request(path, options, false);
+    await refreshSession();
     if (!logoutInFlight) return request(path, options, false);
   }
 


### PR DESCRIPTION
## Summary

- keep refresh-session timestamp writes aligned with timezone-aware session columns
- add explicit UTC helpers for timezone-aware values while preserving existing naive UTC and local wall-clock contracts
- simplify the auth retry path and cover the single-retry failure case

## Tests

- `DATABASE_URL=sqlite:////tmp/tribu-session-followup.db JWT_SECRET=*** pytest tests/test_clock_timezone.py tests/test_session_persistence.py -q`
- `npm test -- --runTestsByPath __tests__/lib/api.test.js --runInBand`
- `git diff --check`
- `python -m compileall -q app tests/test_clock_timezone.py tests/test_session_persistence.py`
