### PR TITLE
Handle legacy school timetable lessons

### DIFF
--- a/backend/app/modules/school_timetables_router.py
+++ b/backend/app/modules/school_timetables_router.py
@@ -135,6 +135,10 @@ def _serialize(db: Session, timetable: SchoolTimetable) -> SchoolTimetableRespon
     memberships = db.query(Membership).filter(Membership.family_id == timetable.family_id).all()
     membership_by_user_id = {m.user_id: m for m in memberships}
     period_by_id = {p.id: p for p in timetable.periods}
+    lessons_with_periods = [
+        (lesson, period_by_id.get(lesson.period_id))
+        for lesson in timetable.lessons
+    ]
     assigned_members = [
         _member_response(assignment.member, membership_by_user_id)
         for assignment in timetable.assignments
@@ -166,13 +170,20 @@ def _serialize(db: Session, timetable: SchoolTimetable) -> SchoolTimetableRespon
                 id=lesson.id,
                 period_id=lesson.period_id,
                 weekday=lesson.weekday,
-                period_position=period_by_id[lesson.period_id].position,
+                period_position=period.position,
                 subject=lesson.subject,
                 room=lesson.room,
                 teacher=lesson.teacher,
                 color=lesson.color,
             )
-            for lesson in sorted(timetable.lessons, key=lambda l: (l.weekday, period_by_id[l.period_id].position))
+            for lesson, period in sorted(
+                lessons_with_periods,
+                key=lambda item: (
+                    item[0].weekday,
+                    item[1].position if item[1] is not None else 10_000,
+                ),
+            )
+            if period is not None
         ],
         created_by_user_id=timetable.created_by_user_id,
         created_at=timetable.created_at,

--- a/backend/tests/test_display_devices.py
+++ b/backend/tests/test_display_devices.py
@@ -14,7 +14,7 @@ import json as json_module
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import sessionmaker
 
 from app.database import Base, get_db
@@ -811,6 +811,36 @@ class TestSchoolTimetables:
         assert listed.status_code == 200, listed.text
         assert listed.json()[0]["lessons"][0]["subject"] == "Math"
 
+    def test_list_skips_legacy_lessons_without_period_rows(self):
+        admin_token, _, family_id = _seed_member_with_pat(
+            "schoolLegacyLesson", role="admin", is_adult=True, scopes="school_timetables:read,school_timetables:write"
+        )
+        child_id = _seed_child(family_id, "Legacy")
+
+        created = client.post(
+            "/school-timetables",
+            json=_school_payload(family_id, [child_id]),
+            headers=_auth(admin_token),
+        )
+        assert created.status_code == 200, created.text
+        lesson_id = created.json()["lessons"][0]["id"]
+
+        db = TestSession()
+        try:
+            db.execute(text("PRAGMA foreign_keys=OFF"))
+            db.execute(
+                text("UPDATE school_timetable_lessons SET period_id = :period_id WHERE id = :lesson_id"),
+                {"period_id": 999_999, "lesson_id": lesson_id},
+            )
+            db.commit()
+            db.execute(text("PRAGMA foreign_keys=ON"))
+        finally:
+            db.close()
+
+        listed = client.get(f"/school-timetables?family_id={family_id}", headers=_auth(admin_token))
+        assert listed.status_code == 200, listed.text
+        assert all(lesson["period_id"] != 999_999 for lesson in listed.json()[0]["lessons"])
+
     def test_rejects_adult_members_as_child_assignments(self):
         admin_token, admin_user_id, family_id = _seed_member_with_pat(
             "schoolAdultAssignment", role="admin", is_adult=True, scopes="school_timetables:write"
@@ -835,13 +865,9 @@ class TestSchoolTimetables:
 
     def test_display_dashboard_includes_today_school_timetable_without_ids(self, monkeypatch):
         import app.modules.display_router as display_router
+        from datetime import date
 
-        class FixedDate(display_router.date):
-            @classmethod
-            def today(cls):
-                return cls(2026, 4, 27)
-
-        monkeypatch.setattr(display_router, "date", FixedDate)
+        monkeypatch.setattr(display_router, "local_today", lambda: date(2026, 4, 27))
 
         admin_token, _, family_id = _seed_member_with_pat("schoolDisplay", role="admin", is_adult=True)
         child_a = _seed_child(family_id, "TwinA", color="#7c3aed")


### PR DESCRIPTION
## Summary
- prevent `/school-timetables` serialization from failing when legacy lesson rows reference a missing period
- omit orphaned lessons from the response while preserving valid periods, lessons, and assignments
- stabilize the display dashboard timetable test by patching the imported `local_today` clock entry point

## Validation
- `python3 -m py_compile backend/app/modules/school_timetables_router.py backend/app/modules/display_router.py`
- `git diff --check`
- `DATABASE_URL=sqlite:///./test-school-timetables-smoke.db JWT_SECRET=test-secret .venv/bin/pytest backend/tests/test_display_devices.py::TestSchoolTimetables -q`
- `DATABASE_URL=sqlite:///./test-display-devices.db JWT_SECRET=test-secret .venv/bin/pytest backend/tests/test_display_devices.py -q`

## Release impact
This addresses the backend failure shape found while running the app release-candidate core smoke against a production-like backend. The app release evidence should remain blocked until this backend change is deployed and the credentialed core smoke is rerun against the deployed environment.