### PR TITLE
Add CORS response header regression tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,41 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      DATABASE_URL: sqlite:///./test-backend-ci.db
+      JWT_SECRET: backend-ci-test-secret-key-32-bytes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r backend/requirements.txt pytest
+
+      - name: Run backend release-contract tests
+        run: |
+          PYTHONPATH=backend python -m pytest \
+            backend/tests/test_cors_headers.py \
+            backend/tests/test_mobile_auth.py \
+            backend/tests/test_oidc_flow.py \
+            -q

--- a/backend/tests/test_cors_headers.py
+++ b/backend/tests/test_cors_headers.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_local_web_origin_get_responses_include_cors_headers():
+    origin = "http://127.0.0.1:50448"
+
+    health = client.get("/health", headers={"Origin": origin})
+    assert health.status_code == 200
+    assert health.headers["access-control-allow-origin"] == origin
+
+    unauthorized = client.get("/auth/me", headers={"Origin": origin})
+    assert unauthorized.status_code == 401
+    assert unauthorized.headers["access-control-allow-origin"] == origin
+
+
+def test_local_web_origin_preflight_allows_authorization_header():
+    origin = "http://127.0.0.1:50448"
+
+    response = client.options(
+        "/auth/me",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == origin
+    assert "Authorization" in response.headers["access-control-allow-headers"]


### PR DESCRIPTION
## Summary
- Adds a focused backend regression test for local Flutter Web origins.
- Adds a Backend Tests GitHub Actions workflow for the CORS, mobile auth, and OIDC release-contract subset.
- Verifies CORS headers on actual GET responses, including unauthenticated 401 responses.
- Verifies preflight allows the Authorization header for local Web smoke origins.

## Evidence
- `PYTHONPATH=backend DATABASE_URL=sqlite:///./test-cors-headers.db JWT_SECRET=dev-secret .venv/bin/python -m pytest backend/tests/test_cors_headers.py -q`
- `PYTHONPATH=backend DATABASE_URL=sqlite:///./test-mobile-auth-cors.db JWT_SECRET=dev-secret .venv/bin/python -m pytest backend/tests/test_mobile_auth.py backend/tests/test_oidc_flow.py -q`
- `PYTHONPATH=backend DATABASE_URL=sqlite:///./test-backend-ci-local.db JWT_SECRET=backend-ci-test-secret-key-32-bytes .venv/bin/python -m pytest backend/tests/test_cors_headers.py backend/tests/test_mobile_auth.py backend/tests/test_oidc_flow.py -q`
- `git diff --check`
- GitHub `backend-tests` CI: passed for `backend/tests/test_cors_headers.py`, `backend/tests/test_mobile_auth.py`, and `backend/tests/test_oidc_flow.py` on this PR.

## Release boundary
This PR does not claim the deployed production-like environment is fixed. App RC browser smoke still observed missing CORS on deployed authenticated GET responses while `/api/health` reported the older deployed version. This test guards backend `main`; #366 still needs deployment/rerun evidence.
