### PR TITLE
Stabilize Docker build version metadata

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python
 __pycache__/
 *.pyc
+backend/app/core/build_info.json
 .venv/
 .pytest_cache/
 .ruff_cache/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,7 @@ RUN pip install --no-cache-dir --no-compile -r requirements.txt \
 COPY alembic.ini .
 COPY alembic ./alembic
 COPY app ./app
+RUN python -m app.core.versioning --write-build-info
 
 RUN mkdir -p /backups \
     && groupadd -r tribu && useradd -r -g tribu tribu \

--- a/backend/app/core/versioning.py
+++ b/backend/app/core/versioning.py
@@ -1,15 +1,20 @@
 """Version resolution helpers for backend health/build reporting."""
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
+import sys
+from collections.abc import Mapping
 from datetime import UTC, date, datetime
 from pathlib import Path
 
 _BRANCH_PLACEHOLDERS = {"main", "master", "dev", "latest", "head"}
 _SEMVER_PREFIX = re.compile(r"^v?\d+\.\d+\.\d+")
 _DATE_VERSION_PREFIX = re.compile(r"^v?(\d{4}-\d{2}-\d{2})(?:[.-]|$)")
+_BUILD_INFO_PATH = Path(__file__).with_name("build_info.json")
+_BUILD_INFO_KEYS = ("APP_VERSION", "APP_BUILD_NUMBER", "APP_GIT_SHA", "APP_BUILD_DATE")
 
 
 def _clean(value: str | None) -> str:
@@ -88,21 +93,66 @@ def git_describe_version(repo_root: Path | None = None) -> str | None:
     return described.lstrip("v") or None
 
 
-def resolve_app_version(env: dict[str, str] | None = None) -> str:
-    source = env or os.environ
+def _metadata_version(source: Mapping[str, str], *, described: str | None = None) -> str | None:
     configured = _clean(source.get("APP_VERSION"))
     if configured and not is_placeholder_version(configured):
         return configured.lstrip("v")
 
-    described = git_describe_version()
     build_number = source.get("APP_BUILD_NUMBER") or source.get("GITHUB_RUN_NUMBER")
     git_sha = source.get("APP_GIT_SHA") or source.get("GITHUB_SHA")
-    derived = build_metadata_version(
+    return build_metadata_version(
         build_number,
         git_sha,
         base_version=described,
         build_date=source.get("APP_BUILD_DATE") or source.get("SOURCE_DATE_EPOCH"),
     )
+
+
+def load_build_info(path: Path | None = None) -> dict[str, str]:
+    """Load immutable build metadata generated into Docker images."""
+
+    target = path or _BUILD_INFO_PATH
+    try:
+        raw = json.loads(target.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {key: _clean(raw.get(key)) for key in _BUILD_INFO_KEYS if _clean(raw.get(key))}
+
+
+def write_build_info_file(path: Path | None = None, env: dict[str, str] | None = None) -> None:
+    """Persist build metadata so runtime env overrides cannot make health stale."""
+
+    source = env or os.environ
+    target = path or _BUILD_INFO_PATH
+    target.write_text(
+        json.dumps({key: _clean(source.get(key)) for key in _BUILD_INFO_KEYS}, sort_keys=True) + "\n",
+    )
+
+
+def resolve_app_version(
+    env: dict[str, str] | None = None,
+    *,
+    build_info: dict[str, str] | None = None,
+) -> str:
+    source = env or os.environ
+    override = _clean(source.get("APP_VERSION_OVERRIDE"))
+    if override and not is_placeholder_version(override):
+        return override.lstrip("v")
+
+    image_metadata = load_build_info() if build_info is None else build_info
+    if image_metadata:
+        built = _metadata_version(image_metadata)
+        if built:
+            return built
+
+    configured = _clean(source.get("APP_VERSION"))
+    if configured and not is_placeholder_version(configured):
+        return configured.lstrip("v")
+
+    described = git_describe_version()
+    derived = _metadata_version(source, described=described)
     if derived:
         return derived
 
@@ -116,3 +166,10 @@ def resolve_app_version(env: dict[str, str] | None = None) -> str:
         return described
 
     return configured.lstrip("v") if configured else "dev"
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--write-build-info"]:
+        write_build_info_file()
+    else:
+        print(resolve_app_version())

--- a/backend/tests/test_versioning.py
+++ b/backend/tests/test_versioning.py
@@ -5,7 +5,9 @@ from app.core.versioning import (
     build_metadata_version,
     is_placeholder_version,
     is_release_like_version,
+    load_build_info,
     resolve_app_version,
+    write_build_info_file,
 )
 
 
@@ -31,9 +33,72 @@ def test_build_metadata_version_uses_date_and_run_number():
 
 
 def test_resolve_app_version_preserves_explicit_release_versions():
-    assert resolve_app_version({"APP_VERSION": "v2026-04-24"}) == "2026-04-24"
-    assert resolve_app_version({"APP_VERSION": "v2026-04-24.412"}) == "2026-04-24.412"
-    assert resolve_app_version({"APP_VERSION": "1.6.0-3-gabc1234+build.412"}) == "1.6.0-3-gabc1234+build.412"
+    assert resolve_app_version({"APP_VERSION": "v2026-04-24"}, build_info={}) == "2026-04-24"
+    assert resolve_app_version({"APP_VERSION": "v2026-04-24.412"}, build_info={}) == "2026-04-24.412"
+    assert resolve_app_version({"APP_VERSION": "1.6.0-3-gabc1234+build.412"}, build_info={}) == "1.6.0-3-gabc1234+build.412"
+
+
+def test_resolve_app_version_prefers_image_build_info_over_stale_runtime_env():
+    version = resolve_app_version(
+        {
+            "APP_VERSION": "2026-05-13.287",
+            "APP_BUILD_NUMBER": "287",
+            "APP_GIT_SHA": "b0944c70aacb9600be8ae3266096c89691225461",
+            "APP_BUILD_DATE": "2026-06-05",
+        },
+        build_info={
+            "APP_VERSION": "2026-05-13.294",
+            "APP_BUILD_NUMBER": "294",
+            "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
+            "APP_BUILD_DATE": "2026-06-18",
+        },
+    )
+
+    assert version == "2026-05-13.294"
+
+
+def test_resolve_app_version_uses_image_build_metadata_for_branch_placeholders(monkeypatch):
+    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: None)
+    version = resolve_app_version(
+        {"APP_VERSION": "2026-05-13.287", "APP_BUILD_NUMBER": "287"},
+        build_info={
+            "APP_VERSION": "main",
+            "APP_BUILD_NUMBER": "294",
+            "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
+            "APP_BUILD_DATE": "2026-06-18",
+        },
+    )
+
+    assert version == "2026-06-18.294"
+
+
+def test_app_version_override_remains_explicit_escape_hatch():
+    version = resolve_app_version(
+        {"APP_VERSION_OVERRIDE": "2026-06-19.manual", "APP_VERSION": "2026-05-13.287"},
+        build_info={"APP_VERSION": "2026-05-13.294"},
+    )
+
+    assert version == "2026-06-19.manual"
+
+
+def test_build_info_file_round_trip(tmp_path):
+    path = tmp_path / "build_info.json"
+    write_build_info_file(
+        path,
+        {
+            "APP_VERSION": "main",
+            "APP_BUILD_NUMBER": "294",
+            "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
+            "APP_BUILD_DATE": "2026-06-18",
+        },
+    )
+
+    assert load_build_info(path) == {
+        "APP_VERSION": "main",
+        "APP_BUILD_NUMBER": "294",
+        "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
+        "APP_BUILD_DATE": "2026-06-18",
+    }
 
 
 def test_resolve_app_version_replaces_branch_placeholder_with_build_metadata(monkeypatch):

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -22,6 +22,12 @@ def test_stable_release_tag_detection_covers_date_patch_tags():
     assert not STABLE_RELEASE_TAG_RE.fullmatch('v1.2.3-rc1')
 
 
+def test_backend_image_persists_build_info_inside_image():
+    dockerfile = Path('backend/Dockerfile').read_text()
+
+    assert 'RUN python -m app.core.versioning --write-build-info' in dockerfile
+
+
 def test_frontend_image_receives_same_build_version_as_backend():
     workflow = Path('.github/workflows/docker.yml').read_text()
 


### PR DESCRIPTION
## Summary
- persist backend Docker build metadata inside the image filesystem
- prefer image build metadata over stale runtime APP_* environment values in health version resolution
- keep APP_VERSION_OVERRIDE as an explicit operator escape hatch
- raise the E2E workflow timeout so browser installation and tests can complete on slower runners

Refs #366.

## Checks
- PYTHONPATH=backend uv run --with pytest -q backend/tests/test_versioning.py tests/test_docker_workflow.py --tb=short
- python3 -m py_compile backend/app/core/versioning.py
- git diff --check
- Docker build smoke with stale runtime APP_* values resolving to the image build version