### PR TITLE
Fix /families/me flipping between families

### DIFF
--- a/backend/app/modules/families_router.py
+++ b/backend/app/modules/families_router.py
@@ -28,6 +28,9 @@ def my_families(user: User = Depends(current_user), db: Session = Depends(get_db
             db.query(Membership)
             .options(joinedload(Membership.family))
             .filter(Membership.user_id == user.id)
+            # Stable order so clients always pick the same "first" family
+            # instead of flipping between families on every request.
+            .order_by(Membership.family_id)
             .all()
         )
         return [

--- a/backend/app/modules/invitations_router.py
+++ b/backend/app/modules/invitations_router.py
@@ -13,6 +13,7 @@ patch_asyncio_iscoroutinefunction()
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+from app.core import cache
 from app.core import oidc as oidc_core
 from app.core.deps import current_user, ensure_family_admin
 from app.core.scopes import require_scope
@@ -267,6 +268,10 @@ def register_with_invite(
     response = JSONResponse(content={"status": "ok"})
     issue_session_cookies(response, db, user)
     db.commit()
+    # The joiner now belongs to a new family; drop the cached families list so
+    # /families/me doesn't keep serving the stale pre-join set for up to 300s
+    # (which made clients fall back to the wrong family).
+    cache.invalidate_pattern("tribu:families:*")
     return response
 
 

--- a/backend/tests/test_families_me_ordering.py
+++ b/backend/tests/test_families_me_ordering.py
@@ -1,0 +1,60 @@
+"""Regression test: /families/me must return a stable, ordered list.
+
+Without an explicit ORDER BY the membership query returned families in
+non-deterministic order, so mobile/web clients that pick the "first" family
+flipped between families on every request. The handler now orders by
+family_id; this locks that in.
+"""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models import Family, Membership, User
+from app.modules.families_router import my_families
+from app.security import hash_password
+
+engine = create_engine(
+    "sqlite:///./test-families-order.db",
+    connect_args={"check_same_thread": False},
+)
+TestSession = sessionmaker(bind=engine)
+
+
+def setup_function():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def teardown_function():
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_my_families_is_ordered_by_family_id():
+    db = TestSession()
+    try:
+        user = User(
+            email="order@example.com",
+            password_hash=hash_password("Secure1Pass"),
+            display_name="Order User",
+        )
+        db.add(user)
+        db.flush()
+
+        # Two real families; add the memberships in reverse-id order so the
+        # result only comes out sorted because of the explicit ORDER BY.
+        first = Family(name="Braun")
+        second = Family(name="Tribu")
+        db.add_all([first, second])
+        db.flush()
+        db.add(Membership(user_id=user.id, family_id=second.id, role="member", is_adult=True))
+        db.add(Membership(user_id=user.id, family_id=first.id, role="admin", is_adult=True))
+        db.commit()
+
+        result = my_families(user=user, db=db, _scope=None)
+        ids = [row["family_id"] for row in result]
+
+        assert ids == sorted(ids)
+        assert ids == [first.id, second.id]
+    finally:
+        db.close()

--- a/backend/tests/test_registration_policy.py
+++ b/backend/tests/test_registration_policy.py
@@ -76,7 +76,13 @@ def test_public_registration_can_be_explicitly_enabled_after_setup(monkeypatch):
     assert second.status_code == 200
 
 
-def test_invite_registration_still_works_after_initial_setup():
+def test_invite_registration_still_works_after_initial_setup(monkeypatch):
+    invalidated_patterns = []
+    monkeypatch.setattr(
+        "app.modules.invitations_router.cache.invalidate_pattern",
+        invalidated_patterns.append,
+    )
+
     db = TestSession()
     try:
         admin = User(
@@ -115,3 +121,4 @@ def test_invite_registration_still_works_after_initial_setup():
         },
     )
     assert resp.status_code == 200
+    assert "tribu:families:*" in invalidated_patterns


### PR DESCRIPTION
## Problem
Clients can jump between a user's families on refresh, sometimes showing the wrong or empty family.

Two backend causes in `/families/me`:

1. **No stable ordering** - the membership query returned families without an explicit order, so a client that picks the first family could flip between families.
2. **Invite registration left a stale families cache** - `register_with_invite` creates the membership but did not drop the per-user `tribu:families:*` cache, so `/families/me` could keep serving the pre-join list for up to 5 minutes.

## Fix
- `/families/me`: order memberships by `family_id` for a stable list.
- `register_with_invite`: invalidate `tribu:families:*` after the join commits, matching the other family mutation paths.
- Add regression coverage for both the stable ordering and invite-registration cache invalidation.

## Tests
- `DATABASE_URL=sqlite:////tmp/tribu-pr373-related.db JWT_SECRET=... python -m pytest tests/test_families_me_ordering.py tests/test_registration_policy.py tests/test_invitation_security.py tests/test_display_devices.py tests/test_session_persistence.py -q`