### PR TITLE
Simplify backend version resolution

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,6 @@ jobs:
             version="${build_date}.${GITHUB_RUN_NUMBER}"
           fi
           echo "value=${version}" >> "$GITHUB_OUTPUT"
-          echo "date=${build_date}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v4
 
@@ -83,9 +82,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.app_version.outputs.value }}
-            APP_BUILD_NUMBER=${{ github.run_number }}
-            APP_GIT_SHA=${{ github.sha }}
-            APP_BUILD_DATE=${{ steps.app_version.outputs.date }}
           cache-from: type=gha,scope=backend
           cache-to: type=gha,scope=backend,mode=max
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Python
 __pycache__/
 *.pyc
-backend/app/core/build_info.json
 .venv/
 .pytest_cache/
 .ruff_cache/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,7 @@
 FROM python:3.13-slim
 
 ARG APP_VERSION=dev
-ARG APP_BUILD_NUMBER=""
-ARG APP_GIT_SHA=""
-ARG APP_BUILD_DATE=""
 ENV APP_VERSION=${APP_VERSION}
-ENV APP_BUILD_NUMBER=${APP_BUILD_NUMBER}
-ENV APP_GIT_SHA=${APP_GIT_SHA}
-ENV APP_BUILD_DATE=${APP_BUILD_DATE}
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PIP_NO_COMPILE=1
 
@@ -23,7 +17,6 @@ RUN pip install --no-cache-dir --no-compile -r requirements.txt \
 COPY alembic.ini .
 COPY alembic ./alembic
 COPY app ./app
-RUN python -m app.core.versioning --write-build-info
 
 RUN mkdir -p /backups \
     && groupadd -r tribu && useradd -r -g tribu tribu \

--- a/backend/app/core/versioning.py
+++ b/backend/app/core/versioning.py
@@ -1,175 +1,31 @@
-"""Version resolution helpers for backend health/build reporting."""
+"""Version resolution helpers for backend health reporting."""
 from __future__ import annotations
 
-import json
 import os
-import re
-import subprocess
-import sys
 from collections.abc import Mapping
-from datetime import UTC, date, datetime
-from pathlib import Path
-
-_BRANCH_PLACEHOLDERS = {"main", "master", "dev", "latest", "head"}
-_SEMVER_PREFIX = re.compile(r"^v?\d+\.\d+\.\d+")
-_DATE_VERSION_PREFIX = re.compile(r"^v?(\d{4}-\d{2}-\d{2})(?:[.-]|$)")
-_BUILD_INFO_PATH = Path(__file__).with_name("build_info.json")
-_BUILD_INFO_KEYS = ("APP_VERSION", "APP_BUILD_NUMBER", "APP_GIT_SHA", "APP_BUILD_DATE")
 
 
 def _clean(value: str | None) -> str:
     return (value or "").strip()
 
 
-def _valid_iso_date(value: str) -> str | None:
-    try:
-        return date.fromisoformat(value).isoformat()
-    except ValueError:
-        return None
-
-
-def _date_version_base(version: str | None) -> str | None:
-    value = _clean(version)
-    match = _DATE_VERSION_PREFIX.match(value)
-    if not match:
-        return None
-    return _valid_iso_date(match.group(1))
-
-
-def _build_date(value: str | None) -> str:
+def _normalize_version(value: str | None) -> str | None:
     cleaned = _clean(value)
-    if cleaned:
-        parsed = _valid_iso_date(cleaned[:10])
-        if parsed:
-            return parsed
-        if cleaned.isdigit():
-            try:
-                return datetime.fromtimestamp(int(cleaned), UTC).date().isoformat()
-            except (OSError, OverflowError, ValueError):
-                pass
-    return datetime.now(UTC).date().isoformat()
-
-
-def is_placeholder_version(version: str | None) -> bool:
-    value = _clean(version)
-    if not value:
-        return True
-    return value.lower().lstrip("v") in _BRANCH_PLACEHOLDERS
-
-
-def is_release_like_version(version: str | None) -> bool:
-    value = _clean(version)
-    return bool(value and (_date_version_base(value) or _SEMVER_PREFIX.match(value)))
-
-
-def build_metadata_version(
-    build_number: str | None,
-    git_sha: str | None = None,
-    *,
-    base_version: str | None = None,
-    build_date: str | None = None,
-) -> str | None:
-    number = _clean(build_number)
-    base = _date_version_base(base_version) or _build_date(build_date)
-    if number:
-        return f"{base}.{number}"
-    if _clean(git_sha):
-        return f"{base}.dev"
-    return None
-
-
-def git_describe_version(repo_root: Path | None = None) -> str | None:
-    root = repo_root or Path(__file__).resolve().parents[3]
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(root), "describe", "--tags", "--abbrev=7", "--match", "v[0-9]*", "--always"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except (OSError, subprocess.CalledProcessError):
+    if not cleaned:
         return None
-    described = _clean(result.stdout)
-    return described.lstrip("v") or None
+    return cleaned.removeprefix("v") or None
 
 
-def _metadata_version(source: Mapping[str, str], *, described: str | None = None) -> str | None:
-    configured = _clean(source.get("APP_VERSION"))
-    if configured and not is_placeholder_version(configured):
-        return configured.lstrip("v")
-
-    build_number = source.get("APP_BUILD_NUMBER") or source.get("GITHUB_RUN_NUMBER")
-    git_sha = source.get("APP_GIT_SHA") or source.get("GITHUB_SHA")
-    return build_metadata_version(
-        build_number,
-        git_sha,
-        base_version=described,
-        build_date=source.get("APP_BUILD_DATE") or source.get("SOURCE_DATE_EPOCH"),
-    )
-
-
-def load_build_info(path: Path | None = None) -> dict[str, str]:
-    """Load immutable build metadata generated into Docker images."""
-
-    target = path or _BUILD_INFO_PATH
-    try:
-        raw = json.loads(target.read_text())
-    except (OSError, json.JSONDecodeError):
-        return {}
-    if not isinstance(raw, dict):
-        return {}
-    return {key: _clean(raw.get(key)) for key in _BUILD_INFO_KEYS if _clean(raw.get(key))}
-
-
-def write_build_info_file(path: Path | None = None, env: dict[str, str] | None = None) -> None:
-    """Persist build metadata so runtime env overrides cannot make health stale."""
+def resolve_app_version(env: Mapping[str, str] | None = None) -> str:
+    """Resolve the backend version from supported runtime environment values."""
 
     source = env or os.environ
-    target = path or _BUILD_INFO_PATH
-    target.write_text(
-        json.dumps({key: _clean(source.get(key)) for key in _BUILD_INFO_KEYS}, sort_keys=True) + "\n",
+    return (
+        _normalize_version(source.get("APP_VERSION_OVERRIDE"))
+        or _normalize_version(source.get("APP_VERSION"))
+        or "dev"
     )
-
-
-def resolve_app_version(
-    env: dict[str, str] | None = None,
-    *,
-    build_info: dict[str, str] | None = None,
-) -> str:
-    source = env or os.environ
-    override = _clean(source.get("APP_VERSION_OVERRIDE"))
-    if override and not is_placeholder_version(override):
-        return override.lstrip("v")
-
-    image_metadata = load_build_info() if build_info is None else build_info
-    if image_metadata:
-        built = _metadata_version(image_metadata)
-        if built:
-            return built
-
-    configured = _clean(source.get("APP_VERSION"))
-    if configured and not is_placeholder_version(configured):
-        return configured.lstrip("v")
-
-    described = git_describe_version()
-    derived = _metadata_version(source, described=described)
-    if derived:
-        return derived
-
-    if described and _date_version_base(described) == described:
-        return described
-
-    if described and is_release_like_version(described):
-        return described
-
-    if described and not is_placeholder_version(described):
-        return described
-
-    return configured.lstrip("v") if configured else "dev"
 
 
 if __name__ == "__main__":
-    if sys.argv[1:] == ["--write-build-info"]:
-        write_build_info_file()
-    else:
-        print(resolve_app_version())
+    print(resolve_app_version())

--- a/backend/tests/test_versioning.py
+++ b/backend/tests/test_versioning.py
@@ -1,164 +1,48 @@
 """Tests for backend app version resolution."""
 from __future__ import annotations
 
-from app.core.versioning import (
-    build_metadata_version,
-    is_placeholder_version,
-    is_release_like_version,
-    load_build_info,
-    resolve_app_version,
-    write_build_info_file,
-)
+import importlib
+
+from app.core.versioning import resolve_app_version
 
 
-def test_placeholder_versions_are_detected():
-    assert is_placeholder_version("main") is True
-    assert is_placeholder_version("vmain") is True
-    assert is_placeholder_version("dev") is True
-    assert is_placeholder_version("v2026-04-24") is False
-    assert is_placeholder_version("1.6.0-3-gabc1234") is False
+def test_resolve_app_version_prefers_explicit_override():
+    version = resolve_app_version({"APP_VERSION_OVERRIDE": "2026-06-20.manual", "APP_VERSION": "2026-06-20.123"})
+
+    assert version == "2026-06-20.manual"
 
 
-def test_release_like_versions_include_product_dates_and_semver():
-    assert is_release_like_version("v2026-04-24") is True
-    assert is_release_like_version("2026-04-24.412") is True
-    assert is_release_like_version("1.6.0-3-gabc1234") is True
-    assert is_release_like_version("build.412-gabcdef1") is False
+def test_resolve_app_version_reads_release_version_from_environment():
+    assert resolve_app_version({"APP_VERSION": "2026-06-20.456"}) == "2026-06-20.456"
+    assert resolve_app_version({"APP_VERSION": "v2026-06-20"}) == "2026-06-20"
 
 
-def test_build_metadata_version_uses_date_and_run_number():
-    assert build_metadata_version("412", "abcdef123456", build_date="2026-04-24") == "2026-04-24.412"
-    assert build_metadata_version("412", None, base_version="v2026-04-23-2-gabcdef1") == "2026-04-23.412"
-    assert build_metadata_version(None, "abcdef123456", build_date="2026-04-24") == "2026-04-24.dev"
+def test_resolve_app_version_falls_back_to_dev_without_environment():
+    assert resolve_app_version({}) == "dev"
+    assert resolve_app_version({"APP_VERSION": " ", "APP_VERSION_OVERRIDE": ""}) == "dev"
 
 
-def test_resolve_app_version_preserves_explicit_release_versions():
-    assert resolve_app_version({"APP_VERSION": "v2026-04-24"}, build_info={}) == "2026-04-24"
-    assert resolve_app_version({"APP_VERSION": "v2026-04-24.412"}, build_info={}) == "2026-04-24.412"
-    assert resolve_app_version({"APP_VERSION": "1.6.0-3-gabc1234+build.412"}, build_info={}) == "1.6.0-3-gabc1234+build.412"
-
-
-def test_resolve_app_version_prefers_image_build_info_over_stale_runtime_env():
-    version = resolve_app_version(
-        {
-            "APP_VERSION": "2026-05-13.287",
-            "APP_BUILD_NUMBER": "287",
-            "APP_GIT_SHA": "b0944c70aacb9600be8ae3266096c89691225461",
-            "APP_BUILD_DATE": "2026-06-05",
-        },
-        build_info={
-            "APP_VERSION": "2026-05-13.294",
-            "APP_BUILD_NUMBER": "294",
-            "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
-            "APP_BUILD_DATE": "2026-06-18",
-        },
-    )
-
-    assert version == "2026-05-13.294"
-
-
-def test_resolve_app_version_uses_image_build_metadata_for_branch_placeholders(monkeypatch):
-    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: None)
-    version = resolve_app_version(
-        {"APP_VERSION": "2026-05-13.287", "APP_BUILD_NUMBER": "287"},
-        build_info={
-            "APP_VERSION": "main",
-            "APP_BUILD_NUMBER": "294",
-            "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
-            "APP_BUILD_DATE": "2026-06-18",
-        },
-    )
-
-    assert version == "2026-06-18.294"
-
-
-def test_app_version_override_remains_explicit_escape_hatch():
-    version = resolve_app_version(
-        {"APP_VERSION_OVERRIDE": "2026-06-19.manual", "APP_VERSION": "2026-05-13.287"},
-        build_info={"APP_VERSION": "2026-05-13.294"},
-    )
-
-    assert version == "2026-06-19.manual"
-
-
-def test_build_info_file_round_trip(tmp_path):
-    path = tmp_path / "build_info.json"
-    write_build_info_file(
-        path,
-        {
-            "APP_VERSION": "main",
-            "APP_BUILD_NUMBER": "294",
-            "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
-            "APP_BUILD_DATE": "2026-06-18",
-        },
-    )
-
-    assert load_build_info(path) == {
-        "APP_VERSION": "main",
-        "APP_BUILD_NUMBER": "294",
-        "APP_GIT_SHA": "08edd2634291fe882bc59556f2d56c8bef54176b",
-        "APP_BUILD_DATE": "2026-06-18",
-    }
-
-
-def test_resolve_app_version_replaces_branch_placeholder_with_build_metadata(monkeypatch):
-    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: None)
-    version = resolve_app_version({
-        "APP_VERSION": "main",
-        "APP_BUILD_NUMBER": "412",
-        "APP_GIT_SHA": "abcdef123456",
-        "APP_BUILD_DATE": "2026-04-24",
-    })
-    assert version == "2026-04-24.412"
-
-
-def test_resolve_app_version_prefers_build_metadata_over_bare_git_sha(monkeypatch):
-    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: "abcdef1")
-    version = resolve_app_version({
-        "APP_VERSION": "main",
-        "APP_BUILD_NUMBER": "412",
-        "APP_GIT_SHA": "abcdef123456",
-        "APP_BUILD_DATE": "2026-04-24",
-    })
-    assert version == "2026-04-24.412"
-
-
-def test_resolve_app_version_uses_date_tag_base_for_non_release_builds(monkeypatch):
-    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: "2026-04-23-2-gabc1234")
-    version = resolve_app_version({
-        "APP_VERSION": "main",
-        "APP_BUILD_NUMBER": "412",
-        "APP_GIT_SHA": "abcdef123456",
-        "APP_BUILD_DATE": "2026-04-24",
-    })
-    assert version == "2026-04-23.412"
-
-
-def test_resolve_app_version_appends_build_number_to_exact_date_tag_placeholders(monkeypatch):
-    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: "2026-04-24")
-    version = resolve_app_version({
-        "APP_VERSION": "main",
-        "APP_BUILD_NUMBER": "412",
-        "APP_GIT_SHA": "abcdef123456",
-    })
-    assert version == "2026-04-24.412"
-
-
-def test_resolve_app_version_falls_back_to_git_describe_when_available(monkeypatch):
-    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: "1.6.0-3-gabc1234")
-    version = resolve_app_version({"APP_VERSION": "main"})
-    assert version == "1.6.0-3-gabc1234"
-
-
-def test_config_version_uses_resolver(monkeypatch):
-    monkeypatch.setattr("app.core.versioning.git_describe_version", lambda repo_root=None: None)
-    monkeypatch.setenv("APP_VERSION", "main")
-    monkeypatch.setenv("APP_BUILD_NUMBER", "412")
-    monkeypatch.setenv("APP_GIT_SHA", "abcdef123456")
-    monkeypatch.setenv("APP_BUILD_DATE", "2026-04-24")
+def test_config_version_uses_supported_environment(monkeypatch):
+    monkeypatch.setenv("APP_VERSION", "2026-06-20.789")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.delenv("APP_VERSION_OVERRIDE", raising=False)
 
     import app.core.config as config
-    import importlib
 
     config = importlib.reload(config)
-    assert config.VERSION == "2026-04-24.412"
+    assert config.VERSION == "2026-06-20.789"
+
+
+def test_health_response_keeps_version_contract(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    from fastapi.testclient import TestClient
+    import app.main as main
+
+    monkeypatch.setattr(main, "VERSION", "2026-06-20.789")
+
+    response = TestClient(main.app).get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "tribu-api", "version": "2026-06-20.789"}

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -22,10 +22,14 @@ def test_stable_release_tag_detection_covers_date_patch_tags():
     assert not STABLE_RELEASE_TAG_RE.fullmatch('v1.2.3-rc1')
 
 
-def test_backend_image_persists_build_info_inside_image():
+def test_backend_image_receives_app_version_build_arg_only():
     dockerfile = Path('backend/Dockerfile').read_text()
+    workflow = Path('.github/workflows/docker.yml').read_text()
 
-    assert 'RUN python -m app.core.versioning --write-build-info' in dockerfile
+    assert 'ARG APP_VERSION=dev' in dockerfile
+    assert 'ENV APP_VERSION=${APP_VERSION}' in dockerfile
+    assert 'RUN python -m app.core.versioning --write-build-info' not in dockerfile
+    assert 'APP_VERSION=${{ steps.app_version.outputs.value }}' in workflow
 
 
 def test_frontend_image_receives_same_build_version_as_backend():


### PR DESCRIPTION
## Summary

- reduce backend version resolution to `APP_VERSION_OVERRIDE`, `APP_VERSION`, then `dev`
- remove build-info, git fallback, placeholder parsing, and unused backend build metadata paths
- keep the `/health` response contract stable and update focused tests

Closes #376

## Checks

- `pytest backend/tests/test_versioning.py tests/test_docker_workflow.py -q`
- local `/health` smoke without version environment variables
- backend Docker workflow build-argument inspection
- `pytest backend/tests/test_versioning.py backend/tests/test_cors_headers.py tests/test_docker_workflow.py -q`
- `npm test -- --runInBand __tests__/lib/i18n.test.js __tests__/public-manifest.test.js`
- `npm run build`
- `npm run e2e:local`
- `git diff --check`
