### PR TITLE
Replace meal plan drag dependency

### DIFF
--- a/frontend/components/MealPlansView.js
+++ b/frontend/components/MealPlansView.js
@@ -1,15 +1,5 @@
 import { useEffect, useState } from 'react';
 import { ChevronLeft, ChevronRight, Plus, Edit2, CalendarDays, GripVertical, ShoppingCart, UtensilsCrossed } from 'lucide-react';
-import {
-  DndContext,
-  DragOverlay,
-  PointerSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
-  useDraggable,
-  useDroppable,
-} from '@dnd-kit/core';
 import { useApp } from '../contexts/AppContext';
 import { useMealPlans, formatIsoDate, weekDays } from '../hooks/useMealPlans';
 import { MEAL_SLOTS } from '../lib/meal-plans';
@@ -52,27 +42,38 @@ function isSameDay(a, b) {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 }
 
-function DraggableFilledCell({ meal, onClick, messages }) {
-  const draggable = useDraggable({ id: `meal:${meal.id}`, data: { mealId: meal.id } });
-  const droppable = useDroppable({ id: `slot:${meal.plan_date}:${meal.slot}` });
-  const setContainerRef = (node) => {
-    draggable.setNodeRef(node);
-    droppable.setNodeRef(node);
-  };
+function FilledMealCell({
+  meal,
+  onClick,
+  messages,
+  moveTargets,
+  moveMenuOpen,
+  isDragging,
+  isDropOver,
+  onToggleMoveMenu,
+  onMoveMeal,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop,
+}) {
   const classes = [
     'meal-grid-cell',
     'meal-grid-cell-filled',
     `meal-grid-slot-${meal.slot}`,
-    draggable.isDragging ? 'meal-grid-cell-dragging' : '',
-    droppable.isOver ? 'meal-grid-cell-drop-over' : '',
+    isDragging ? 'meal-grid-cell-dragging' : '',
+    isDropOver ? 'meal-grid-cell-drop-over' : '',
   ].filter(Boolean).join(' ');
+  const moveLabel = t(messages, 'module.meal_plans.drag_aria').replace('{name}', meal.meal_name);
+  const moveControlId = `meal-move-${meal.id}`;
+
   return (
-    <div ref={setContainerRef} className={classes}>
+    <div className={classes} onDragOver={onDragOver} onDrop={onDrop}>
       <button
         type="button"
         className="meal-cell-edit-btn"
         onClick={() => {
-          if (draggable.isDragging) return;
+          if (isDragging) return;
           onClick(meal);
         }}
         aria-label={t(messages, 'module.meal_plans.edit_aria').replace('{name}', meal.meal_name)}
@@ -84,28 +85,48 @@ function DraggableFilledCell({ meal, onClick, messages }) {
         <Edit2 size={12} className="meal-cell-edit-icon" aria-hidden="true" />
       </button>
       <button
-        ref={draggable.setActivatorNodeRef}
         type="button"
         className="meal-cell-grip-btn"
-        aria-label={t(messages, 'module.meal_plans.drag_aria').replace('{name}', meal.meal_name)}
-        {...draggable.listeners}
-        {...draggable.attributes}
+        aria-label={moveLabel}
+        aria-controls={moveMenuOpen ? moveControlId : undefined}
+        aria-expanded={moveMenuOpen}
+        draggable
+        onClick={(event) => {
+          event.stopPropagation();
+          onToggleMoveMenu(meal.id);
+        }}
+        onDragStart={(event) => onDragStart(event, meal)}
+        onDragEnd={onDragEnd}
       >
         <GripVertical size={14} aria-hidden="true" />
       </button>
+      {moveMenuOpen && (
+        <div className="meal-cell-move-panel" onClick={(event) => event.stopPropagation()}>
+          <label className="sr-only" htmlFor={moveControlId}>{moveLabel}</label>
+          <select
+            id={moveControlId}
+            className="form-input meal-cell-move-select"
+            value={`${meal.plan_date}:${meal.slot}`}
+            onChange={(event) => onMoveMeal(meal.id, event.target.value)}
+          >
+            {moveTargets.map((target) => (
+              <option key={target.value} value={target.value}>{target.label}</option>
+            ))}
+          </select>
+        </div>
+      )}
     </div>
   );
 }
 
-function DroppableEmptyCell({ date, slot, messages, onClick }) {
-  const iso = formatIsoDate(date);
-  const { setNodeRef, isOver } = useDroppable({ id: `slot:${iso}:${slot}` });
+function EmptyMealCell({ date, slot, messages, onClick, isDropOver, onDragOver, onDrop }) {
   return (
     <button
-      ref={setNodeRef}
       type="button"
-      className={`meal-grid-cell meal-grid-cell-empty${isOver ? ' meal-grid-cell-drop-over' : ''}`}
+      className={`meal-grid-cell meal-grid-cell-empty${isDropOver ? ' meal-grid-cell-drop-over' : ''}`}
       onClick={() => onClick(date, slot)}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
       aria-label={t(messages, 'module.meal_plans.add_for_slot_aria')
         .replace('{slot}', slotLabel(messages, slot))
         .replace('{date}', formatDayNumber(date))}
@@ -122,15 +143,13 @@ export default function MealPlansView() {
   const [editingId, setEditingId] = useState(null);
   const [form, setForm] = useState(hook.emptyFormFor(formatIsoDate(hook.weekStart), 'noon'));
   const [confirmAction, setConfirmAction] = useState(null);
-  const [activeDrag, setActiveDrag] = useState(null);
+  const [draggingMealId, setDraggingMealId] = useState(null);
+  const [dragOverCell, setDragOverCell] = useState(null);
+  const [moveMenuMealId, setMoveMenuMealId] = useState(null);
   const [recipes, setRecipes] = useState([]);
   const [selectedWeekListId, setSelectedWeekListId] = useState('');
   const [pushingWeek, setPushingWeek] = useState(false);
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor),
-  );
 
   useEffect(() => {
     if (!familyId || demoMode) {
@@ -154,6 +173,14 @@ export default function MealPlansView() {
   const currentFamilyName = families.find((f) => String(f.family_id) === String(familyId))?.family_name || '';
   const days = weekDays(hook.weekStart);
   const today = new Date();
+  const moveTargets = days.flatMap((day, dayIndex) => {
+    const iso = formatIsoDate(day);
+    const dayLabel = `${t(messages, WEEKDAY_KEYS[dayIndex])} ${formatDayNumber(day)}`;
+    return MEAL_SLOTS.map((slot) => ({
+      value: `${iso}:${slot}`,
+      label: `${dayLabel} · ${slotLabel(messages, slot)}`,
+    }));
+  });
   const visibleMeals = days.flatMap((day) => (
     MEAL_SLOTS.map((slot) => hook.getCell(formatIsoDate(day), slot)).filter(Boolean)
   ));
@@ -202,26 +229,42 @@ export default function MealPlansView() {
     closeDialog();
   }
 
-  function handleDragStart(event) {
-    const id = event.active?.data?.current?.mealId ?? null;
-    setActiveDrag(hook.meals.find((m) => m.id === id) || null);
+  function handleNativeDragStart(event, meal) {
+    setDraggingMealId(meal.id);
+    setMoveMenuMealId(null);
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', String(meal.id));
   }
 
-  async function handleDragEnd(event) {
-    setActiveDrag(null);
-    const { active, over } = event;
-    if (!over || !active) return;
-    const mealId = active?.data?.current?.mealId;
-    if (mealId == null) return;
-    const overId = String(over.id);
-    if (!overId.startsWith('slot:')) return;
-    const [, planDate, slot] = overId.split(':');
-    if (!planDate || !slot) return;
+  function handleNativeDragEnd() {
+    setDraggingMealId(null);
+    setDragOverCell(null);
+  }
+
+  function handleNativeDragOver(event, planDate, slot) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setDragOverCell(`${planDate}:${slot}`);
+  }
+
+  async function handleNativeDrop(event, planDate, slot) {
+    event.preventDefault();
+    const mealId = Number(event.dataTransfer.getData('text/plain'));
+    setDraggingMealId(null);
+    setDragOverCell(null);
+    if (!Number.isFinite(mealId)) return;
     await hook.moveMeal(mealId, planDate, slot);
   }
 
-  function handleDragCancel() {
-    setActiveDrag(null);
+  async function handleMoveSelection(mealId, targetValue) {
+    const [planDate, slot] = String(targetValue).split(':');
+    if (!planDate || !slot) return;
+    const moved = await hook.moveMeal(mealId, planDate, slot);
+    if (moved) setMoveMenuMealId(null);
+  }
+
+  function toggleMoveMenu(mealId) {
+    setMoveMenuMealId((current) => (current === mealId ? null : mealId));
   }
 
   async function handlePushWeekToShopping() {
@@ -353,63 +396,65 @@ export default function MealPlansView() {
 
       {hook.loading && <p className="meal-loading">{t(messages, 'module.meal_plans.loading')}</p>}
 
-      <DndContext
-        sensors={sensors}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
-        onDragCancel={handleDragCancel}
-      >
-        <section className="meal-grid" aria-label={t(messages, 'module.meal_plans.name')}>
-          <div className="meal-grid-corner" aria-hidden="true" />
-          {days.map((d, idx) => (
-            <div
-              key={d.toISOString()}
-              className={`meal-grid-day-header${isSameDay(d, today) ? ' meal-grid-day-today' : ''}`}
-            >
-              <span className="meal-grid-day-name">{t(messages, WEEKDAY_KEYS[idx])}</span>
-              <span className="meal-grid-day-date">{formatDayNumber(d)}</span>
-            </div>
-          ))}
+      <section className="meal-grid" aria-label={t(messages, 'module.meal_plans.name')}>
+        <div className="meal-grid-corner" aria-hidden="true" />
+        {days.map((d, idx) => (
+          <div
+            key={d.toISOString()}
+            className={`meal-grid-day-header${isSameDay(d, today) ? ' meal-grid-day-today' : ''}`}
+          >
+            <span className="meal-grid-day-name">{t(messages, WEEKDAY_KEYS[idx])}</span>
+            <span className="meal-grid-day-date">{formatDayNumber(d)}</span>
+          </div>
+        ))}
 
-          {MEAL_SLOTS.map((slot) => (
-            <div key={slot} className="meal-grid-row">
-              <div className="meal-grid-slot-label">
-                {slotLabel(messages, slot)}
-              </div>
-              {days.map((d) => {
-                const iso = formatIsoDate(d);
-                const meal = hook.getCell(iso, slot);
-                if (meal) {
-                  return (
-                    <DraggableFilledCell
-                      key={`${iso}:${slot}`}
-                      meal={meal}
-                      onClick={openEdit}
-                      messages={messages}
-                    />
-                  );
-                }
+        {MEAL_SLOTS.map((slot) => (
+          <div key={slot} className="meal-grid-row">
+            <div className="meal-grid-slot-label">
+              {slotLabel(messages, slot)}
+            </div>
+            {days.map((d) => {
+              const iso = formatIsoDate(d);
+              const meal = hook.getCell(iso, slot);
+              const isDropOver = dragOverCell === `${iso}:${slot}`;
+              const dragTargetProps = {
+                onDragOver: (event) => handleNativeDragOver(event, iso, slot),
+                onDrop: (event) => handleNativeDrop(event, iso, slot),
+              };
+              if (meal) {
                 return (
-                  <DroppableEmptyCell
+                  <FilledMealCell
                     key={`${iso}:${slot}`}
-                    date={d}
-                    slot={slot}
+                    meal={meal}
+                    onClick={openEdit}
                     messages={messages}
-                    onClick={openAdd}
+                    moveTargets={moveTargets}
+                    moveMenuOpen={moveMenuMealId === meal.id}
+                    isDragging={draggingMealId === meal.id}
+                    isDropOver={isDropOver}
+                    onToggleMoveMenu={toggleMoveMenu}
+                    onMoveMeal={handleMoveSelection}
+                    onDragStart={handleNativeDragStart}
+                    onDragEnd={handleNativeDragEnd}
+                    {...dragTargetProps}
                   />
                 );
-              })}
-            </div>
-          ))}
-        </section>
-        <DragOverlay>
-          {activeDrag ? (
-            <div className={`meal-grid-cell meal-grid-cell-filled meal-grid-slot-${activeDrag.slot} meal-cell-overlay`}>
-              <span className="meal-cell-title">{activeDrag.meal_name}</span>
-            </div>
-          ) : null}
-        </DragOverlay>
-      </DndContext>
+              }
+              return (
+                <EmptyMealCell
+                  key={`${iso}:${slot}`}
+                  date={d}
+                  slot={slot}
+                  messages={messages}
+                  onClick={openAdd}
+                  isDropOver={isDropOver}
+                  {...dragTargetProps}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </section>
     </div>
   );
 }

--- a/frontend/e2e/tests/meal-plans.spec.js
+++ b/frontend/e2e/tests/meal-plans.spec.js
@@ -51,6 +51,34 @@ test.describe('Meal plan', () => {
     await expect(page.getByText('Demo soup')).toBeVisible();
   });
 
+  test('moves a demo meal with the native slot picker', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 90000 });
+    await page.getByRole('button', { name: /try demo/i }).first().click();
+    await page.locator('#main-content').waitFor({ state: 'attached', timeout: 90000 });
+
+    await navigateTo(page, 'Meal plan');
+
+    const mealCell = page.locator('.meal-grid-cell-filled').first();
+    await expect(mealCell).toBeVisible({ timeout: 30000 });
+    const mealName = (await mealCell.locator('.meal-cell-title').innerText()).trim();
+
+    await mealCell.locator('.meal-cell-grip-btn').click();
+    const moveSelect = mealCell.locator('.meal-cell-move-select');
+    await expect(moveSelect).toBeVisible();
+
+    const targetValue = await moveSelect.evaluate((select) => (
+      Array.from(select.options).find((option) => option.value !== select.value)?.value
+    ));
+    expect(targetValue).toBeTruthy();
+    const targetSlot = targetValue.split(':')[1];
+    await moveSelect.selectOption(targetValue);
+
+    const movedMealCell = page
+      .locator(`.meal-grid-cell-filled.meal-grid-slot-${targetSlot}`)
+      .filter({ hasText: mealName });
+    await expect(movedMealCell).toBeVisible({ timeout: 30000 });
+  });
+
   test('pushes the current week ingredients to a shopping list', async ({ page, baseURL, browserName }) => {
     const workerUser = await registerWorkerUser(baseURL, browserName);
     await page.context().addCookies(workerUser.cookies);

--- a/frontend/i18n/bg.json
+++ b/frontend/i18n/bg.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Добавете седмица към списъка за пазаруване",
   "module.meal_plans.push_week_to_shopping_aria": "Поставете всички съставки от тази седмица в списък за пазаруване",
   "module.meal_plans.push_to_shopping": "Към списъка за пазаруване",
-  "module.meal_plans.drag_aria": "Плъзнете \"{name}\" в друг слот",
+  "module.meal_plans.drag_aria": "Преместете „{name}“ в друг слот",
   "module.meal_plans.pushed_one": "1 съставка е избутана в списъка за пазаруване",
   "module.meal_plans.pushed_many": "{count} съставки, избутани в списъка за пазаруване",
   "module.recipes.name": "Рецепти",

--- a/frontend/i18n/cs.json
+++ b/frontend/i18n/cs.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Přidejte týden do nákupního seznamu",
   "module.meal_plans.push_week_to_shopping_aria": "Zatlačte všechny ingredience z tohoto týdne do nákupního seznamu",
   "module.meal_plans.push_to_shopping": "Do nákupního seznamu",
-  "module.meal_plans.drag_aria": "Přetáhněte \"{name}\" do jiného slotu",
+  "module.meal_plans.drag_aria": "Přesunout „{name}“ do jiného slotu",
   "module.meal_plans.pushed_one": "1 ingredience zatlačena do nákupního seznamu",
   "module.meal_plans.pushed_many": "Ingredience {count} posunuty na nákupní seznam",
   "module.recipes.name": "Recepty",

--- a/frontend/i18n/da.json
+++ b/frontend/i18n/da.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Tilføj uge til indkøbslisten",
   "module.meal_plans.push_week_to_shopping_aria": "Skub alle ingredienser fra denne uge til en indkøbsliste",
   "module.meal_plans.push_to_shopping": "Til indkøbsliste",
-  "module.meal_plans.drag_aria": "Træk \"{name}\" til en anden plads",
+  "module.meal_plans.drag_aria": "Flyt \"{name}\" til et andet felt",
   "module.meal_plans.pushed_one": "1 ingrediens skubbet til indkøbslisten",
   "module.meal_plans.pushed_many": "{count} ingredienser skubbet til indkøbslisten",
   "module.recipes.name": "Opskrifter",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Woche zur Einkaufsliste hinzufügen",
   "module.meal_plans.push_week_to_shopping_aria": "Alle Zutaten dieser Woche in Einkaufsliste schieben",
   "module.meal_plans.push_to_shopping": "In Einkaufsliste",
-  "module.meal_plans.drag_aria": "\"{name}\" auf einen anderen Slot ziehen",
+  "module.meal_plans.drag_aria": "„{name}“ in einen anderen Platz verschieben",
   "module.meal_plans.pushed_one": "1 Zutat auf die Einkaufsliste geschoben",
   "module.meal_plans.pushed_many": "{count} Zutaten auf die Einkaufsliste geschoben",
   "module.recipes.name": "Rezepte",

--- a/frontend/i18n/el.json
+++ b/frontend/i18n/el.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Προσθήκη εβδομάδας στη λίστα αγορών",
   "module.meal_plans.push_week_to_shopping_aria": "Σπρώξτε όλα τα συστατικά από αυτήν την εβδομάδα σε μια λίστα αγορών",
   "module.meal_plans.push_to_shopping": "Στη λίστα αγορών",
-  "module.meal_plans.drag_aria": "Σύρετε το \"{name}\" σε άλλη υποδοχή",
+  "module.meal_plans.drag_aria": "Μετακίνηση του «{name}» σε άλλη θέση",
   "module.meal_plans.pushed_one": "1 συστατικό μπήκε στη λίστα αγορών",
   "module.meal_plans.pushed_many": "Τα συστατικά {count} μπήκαν στη λίστα αγορών",
   "module.recipes.name": "Συνταγές",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Add week to shopping list",
   "module.meal_plans.push_week_to_shopping_aria": "Push all ingredients from this week to a shopping list",
   "module.meal_plans.push_to_shopping": "To shopping list",
-  "module.meal_plans.drag_aria": "Drag \"{name}\" to another slot",
+  "module.meal_plans.drag_aria": "Move \"{name}\" to another slot",
   "module.meal_plans.pushed_one": "1 ingredient pushed to the shopping list",
   "module.meal_plans.pushed_many": "{count} ingredients pushed to the shopping list",
   "module.recipes.name": "Recipes",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Añadir la semana a la lista de compras",
   "module.meal_plans.push_week_to_shopping_aria": "Enviar todos los ingredientes de esta semana a una lista de compras",
   "module.meal_plans.push_to_shopping": "A la lista de compras",
-  "module.meal_plans.drag_aria": "Arrastrar \"{name}\" a otro horario",
+  "module.meal_plans.drag_aria": "Mover «{name}» a otro espacio",
   "module.meal_plans.pushed_one": "1 ingrediente enviado a la lista de compras",
   "module.meal_plans.pushed_many": "{count} ingredientes enviados a la lista de compras",
   "module.recipes.name": "Recetas",

--- a/frontend/i18n/et.json
+++ b/frontend/i18n/et.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Lisage nädal ostunimekirja",
   "module.meal_plans.push_week_to_shopping_aria": "Lükake kõik selle nädala koostisosad ostunimekirja",
   "module.meal_plans.push_to_shopping": "Ostunimekirja juurde",
-  "module.meal_plans.drag_aria": "Lohistage \"{name}\" teise pessa",
+  "module.meal_plans.drag_aria": "Teisalda „{name}“ teise ajapessa",
   "module.meal_plans.pushed_one": "1 koostisosa lükati ostunimekirja",
   "module.meal_plans.pushed_many": "{count} koostisosad lükati ostunimekirja",
   "module.recipes.name": "Retseptid",

--- a/frontend/i18n/fi.json
+++ b/frontend/i18n/fi.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Lisää viikko ostoslistalle",
   "module.meal_plans.push_week_to_shopping_aria": "Työnnä kaikki tämän viikon ainekset ostoslistalle",
   "module.meal_plans.push_to_shopping": "Ostoslistalle",
-  "module.meal_plans.drag_aria": "Vedä \"{name}\" toiseen paikkaan",
+  "module.meal_plans.drag_aria": "Siirrä \"{name}\" toiseen paikkaan",
   "module.meal_plans.pushed_one": "1 ainesosa työnnetty ostoslistalle",
   "module.meal_plans.pushed_many": "{count} ainekset työnnetty ostoslistalle",
   "module.recipes.name": "Reseptit",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Ajouter la semaine à la liste de courses",
   "module.meal_plans.push_week_to_shopping_aria": "Envoyer tous les ingrédients de cette semaine vers une liste de courses",
   "module.meal_plans.push_to_shopping": "Vers la liste de courses",
-  "module.meal_plans.drag_aria": "Glisser \"{name}\" vers un autre créneau",
+  "module.meal_plans.drag_aria": "Déplacer « {name} » vers un autre créneau",
   "module.meal_plans.pushed_one": "1 ingrédient ajouté à la liste de courses",
   "module.meal_plans.pushed_many": "{count} ingrédients ajoutés à la liste de courses",
   "module.recipes.name": "Recettes",

--- a/frontend/i18n/ga.json
+++ b/frontend/i18n/ga.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Cuir seachtain leis an liosta siopadóireachta",
   "module.meal_plans.push_week_to_shopping_aria": "Brúigh na comhábhair go léir ón tseachtain seo chuig liosta siopadóireachta",
   "module.meal_plans.push_to_shopping": "Go dtí an liosta siopadóireachta",
-  "module.meal_plans.drag_aria": "Tarraing \"{name}\" chuig sliotán eile",
+  "module.meal_plans.drag_aria": "Bog \"{name}\" go sliotán eile",
   "module.meal_plans.pushed_one": "1 chomhábhar brú chuig an liosta siopadóireachta",
   "module.meal_plans.pushed_many": "Comhábhair {count} bhrú ar an liosta siopadóireachta",
   "module.recipes.name": "Oidis",

--- a/frontend/i18n/hr.json
+++ b/frontend/i18n/hr.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Dodajte tjedan na popis za kupovinu",
   "module.meal_plans.push_week_to_shopping_aria": "Stavite sve sastojke iz ovog tjedna na popis za kupovinu",
   "module.meal_plans.push_to_shopping": "Na popis za kupovinu",
-  "module.meal_plans.drag_aria": "Povucite \"{name}\" u drugi utor",
+  "module.meal_plans.drag_aria": "Premjesti „{name}“ u drugi termin",
   "module.meal_plans.pushed_one": "1 sastojak gurnut na popis za kupnju",
   "module.meal_plans.pushed_many": "{count} sastojci gurnuti na popis za kupovinu",
   "module.recipes.name": "Recepti",

--- a/frontend/i18n/hu.json
+++ b/frontend/i18n/hu.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Hét hozzáadása a bevásárlólistához",
   "module.meal_plans.push_week_to_shopping_aria": "Töltsd fel az e hét összes hozzávalóját a bevásárlólistára",
   "module.meal_plans.push_to_shopping": "A bevásárló listához",
-  "module.meal_plans.drag_aria": "Húzza a „{name}” elemet egy másik nyílásba",
+  "module.meal_plans.drag_aria": "Helyezd át a(z) „{name}” ételt egy másik helyre",
   "module.meal_plans.pushed_one": "1 hozzávaló felkerült a bevásárlólistára",
   "module.meal_plans.pushed_many": "A {count} összetevők felkerültek a bevásárlólistára",
   "module.recipes.name": "Receptek",

--- a/frontend/i18n/it.json
+++ b/frontend/i18n/it.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Aggiungi settimana alla lista della spesa",
   "module.meal_plans.push_week_to_shopping_aria": "Inserisci tutti gli ingredienti di questa settimana nella lista della spesa",
   "module.meal_plans.push_to_shopping": "Alla lista della spesa",
-  "module.meal_plans.drag_aria": "Trascina \"{name}\" in un altro slot",
+  "module.meal_plans.drag_aria": "Sposta \"{name}\" in un altro spazio",
   "module.meal_plans.pushed_one": "1 ingrediente inserito nella lista della spesa",
   "module.meal_plans.pushed_many": "{count} ingredienti inseriti nella lista della spesa",
   "module.recipes.name": "Ricette",

--- a/frontend/i18n/lt.json
+++ b/frontend/i18n/lt.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Į pirkinių sąrašą įtraukite savaitę",
   "module.meal_plans.push_week_to_shopping_aria": "Perkelkite visus šios savaitės ingredientus į pirkinių sąrašą",
   "module.meal_plans.push_to_shopping": "Į pirkinių sąrašą",
-  "module.meal_plans.drag_aria": "Vilkite „{name}“ į kitą lizdą",
+  "module.meal_plans.drag_aria": "Perkelti „{name}“ į kitą laiką",
   "module.meal_plans.pushed_one": "1 ingredientas įtrauktas į pirkinių sąrašą",
   "module.meal_plans.pushed_many": "{count} sudedamosios dalys įtrauktos į pirkinių sąrašą",
   "module.recipes.name": "Receptai",

--- a/frontend/i18n/lv.json
+++ b/frontend/i18n/lv.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Pievienojiet nedēļu iepirkumu sarakstam",
   "module.meal_plans.push_week_to_shopping_aria": "Ievietojiet visas šīs nedēļas sastāvdaļas iepirkumu sarakstā",
   "module.meal_plans.push_to_shopping": "Uz iepirkumu sarakstu",
-  "module.meal_plans.drag_aria": "Velciet \"{name}\" uz citu slotu",
+  "module.meal_plans.drag_aria": "Pārvietot “{name}” uz citu vietu",
   "module.meal_plans.pushed_one": "1 sastāvdaļa ir ievietota iepirkumu sarakstā",
   "module.meal_plans.pushed_many": "{count} sastāvdaļas ir iekļautas iepirkumu sarakstā",
   "module.recipes.name": "Receptes",

--- a/frontend/i18n/nb.json
+++ b/frontend/i18n/nb.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Legg til uke på handlelisten",
   "module.meal_plans.push_week_to_shopping_aria": "Overfør alle ingrediensene fra denne uken til en handleliste",
   "module.meal_plans.push_to_shopping": "Til handleliste",
-  "module.meal_plans.drag_aria": "Dra \"{name}\" til et annet spor",
+  "module.meal_plans.drag_aria": "Flytt «{name}» til et annet tidspunkt",
   "module.meal_plans.pushed_one": "1 ingrediens presset til handlelisten",
   "module.meal_plans.pushed_many": "{count} ingredienser presset til handlelisten",
   "module.recipes.name": "Oppskrifter",

--- a/frontend/i18n/nl.json
+++ b/frontend/i18n/nl.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Week toevoegen aan boodschappenlijstje",
   "module.meal_plans.push_week_to_shopping_aria": "Zet alle ingrediënten van deze week op een boodschappenlijstje",
   "module.meal_plans.push_to_shopping": "Naar boodschappenlijstje",
-  "module.meal_plans.drag_aria": "Sleep \"{name}\" naar een ander slot",
+  "module.meal_plans.drag_aria": "Verplaats \"{name}\" naar een ander moment",
   "module.meal_plans.pushed_one": "1 ingrediënt naar het boodschappenlijstje geduwd",
   "module.meal_plans.pushed_many": "{count}-ingrediënten naar het boodschappenlijstje gepusht",
   "module.recipes.name": "Recepten",

--- a/frontend/i18n/pl.json
+++ b/frontend/i18n/pl.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Dodaj tydzień do listy zakupów",
   "module.meal_plans.push_week_to_shopping_aria": "Przenieś wszystkie składniki z tego tygodnia na listę zakupów",
   "module.meal_plans.push_to_shopping": "Do listy zakupów",
-  "module.meal_plans.drag_aria": "Przeciągnij „{name}” do innego miejsca",
+  "module.meal_plans.drag_aria": "Przenieś „{name}” do innego miejsca",
   "module.meal_plans.pushed_one": "1 składnik przeniesiony na listę zakupów",
   "module.meal_plans.pushed_many": "{count} składników przeniesiono na listę zakupów",
   "module.recipes.name": "Przepisy",

--- a/frontend/i18n/pt.json
+++ b/frontend/i18n/pt.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Adicionar semana à lista de compras",
   "module.meal_plans.push_week_to_shopping_aria": "Empurre todos os ingredientes desta semana para uma lista de compras",
   "module.meal_plans.push_to_shopping": "Para lista de compras",
-  "module.meal_plans.drag_aria": "Arraste \"{name}\" para outro slot",
+  "module.meal_plans.drag_aria": "Mover \"{name}\" para outro horário",
   "module.meal_plans.pushed_one": "1 ingrediente enviado para a lista de compras",
   "module.meal_plans.pushed_many": "Ingredientes {count} enviados para a lista de compras",
   "module.recipes.name": "Receitas",

--- a/frontend/i18n/ro.json
+++ b/frontend/i18n/ro.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Adăugați săptămâna la lista de cumpărături",
   "module.meal_plans.push_week_to_shopping_aria": "Împingeți toate ingredientele din această săptămână într-o listă de cumpărături",
   "module.meal_plans.push_to_shopping": "La lista de cumpărături",
-  "module.meal_plans.drag_aria": "Trageți „{name}” într-un alt slot",
+  "module.meal_plans.drag_aria": "Mută „{name}” în alt interval",
   "module.meal_plans.pushed_one": "1 ingredient împins în lista de cumpărături",
   "module.meal_plans.pushed_many": "Ingredientele {count} împinse în lista de cumpărături",
   "module.recipes.name": "Rețete",

--- a/frontend/i18n/sk.json
+++ b/frontend/i18n/sk.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Pridajte týždeň do nákupného zoznamu",
   "module.meal_plans.push_week_to_shopping_aria": "Zatlačte všetky ingrediencie z tohto týždňa do nákupného zoznamu",
   "module.meal_plans.push_to_shopping": "Do nákupného zoznamu",
-  "module.meal_plans.drag_aria": "Presuňte „{name}“ do iného slotu",
+  "module.meal_plans.drag_aria": "Presunúť „{name}“ do iného miesta",
   "module.meal_plans.pushed_one": "1 ingrediencia zatlačená do nákupného zoznamu",
   "module.meal_plans.pushed_many": "{count} ingrediencie zaradené do nákupného zoznamu",
   "module.recipes.name": "Recepty",

--- a/frontend/i18n/sl.json
+++ b/frontend/i18n/sl.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Dodajte teden na nakupovalni seznam",
   "module.meal_plans.push_week_to_shopping_aria": "Potisnite vse sestavine iz tega tedna na nakupovalni seznam",
   "module.meal_plans.push_to_shopping": "Na nakupovalni seznam",
-  "module.meal_plans.drag_aria": "Povlecite \"{name}\" v drugo režo",
+  "module.meal_plans.drag_aria": "Premakni »{name}« na drugo mesto",
   "module.meal_plans.pushed_one": "1 sestavina potisnjena na nakupovalni seznam",
   "module.meal_plans.pushed_many": "{count} sestavine potisnjene na nakupovalni seznam",
   "module.recipes.name": "Recepti",

--- a/frontend/i18n/sv.json
+++ b/frontend/i18n/sv.json
@@ -1062,7 +1062,7 @@
   "module.meal_plans.push_week_to_shopping": "Lägg till vecka på inköpslistan",
   "module.meal_plans.push_week_to_shopping_aria": "Lägg alla ingredienser från denna vecka till en inköpslista",
   "module.meal_plans.push_to_shopping": "Till inköpslistan",
-  "module.meal_plans.drag_aria": "Dra \"{name}\" till en annan plats",
+  "module.meal_plans.drag_aria": "Flytta \"{name}\" till en annan plats",
   "module.meal_plans.pushed_one": "1 ingrediens tryckt till inköpslistan",
   "module.meal_plans.pushed_many": "{count} ingredienser skjuts till inköpslistan",
   "module.recipes.name": "Recept",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "tribu-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
         "lucide-react": "^0.542.0",
         "next": "16.2.6",
         "react": "19.2.4",
@@ -669,45 +668,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.1",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
     "lucide-react": "^0.542.0",
     "next": "16.2.6",
     "react": "19.2.4",

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -3221,7 +3221,7 @@ body { font-family: var(--font-ui); background: var(--void); color: var(--text-p
   .meal-ingredient-row { grid-template-columns: 1fr 80px 60px auto; }
 }
 
-/* Meal DnD */
+/* Meal move controls */
 .meal-grid-cell-filled { padding: 0; }
 .meal-cell-edit-btn {
   background: transparent; border: none; color: inherit; font-family: inherit;
@@ -3241,17 +3241,35 @@ body { font-family: var(--font-ui); background: var(--void); color: var(--text-p
   display: inline-flex; align-items: center; justify-content: center;
   cursor: grab;
   opacity: 0; transition: opacity 0.15s;
-  touch-action: none;
+  touch-action: manipulation;
   min-height: auto;
 }
 .meal-grid-cell-filled:hover .meal-cell-grip-btn,
+.meal-cell-grip-btn[aria-expanded="true"],
 .meal-cell-grip-btn:focus-visible { opacity: 1; }
 .meal-cell-grip-btn:hover { color: var(--text-primary); background: rgba(120, 130, 180, 0.12); }
 .meal-cell-grip-btn:focus-visible { outline: 2px solid var(--amethyst); outline-offset: 2px; }
 .meal-cell-grip-btn:active { cursor: grabbing; }
 .meal-grid-cell-dragging { opacity: 0.3; }
 .meal-grid-cell-drop-over { border-color: var(--amethyst); background: rgba(124, 58, 237, 0.08); }
-.meal-cell-overlay { box-shadow: 0 12px 32px -8px rgba(0, 0, 0, 0.4); transform: rotate(-1deg); background: var(--void-elevated); cursor: grabbing; max-width: 220px; padding: 10px 12px; border-radius: var(--radius-sm); border: 1px solid var(--glass-border); }
+.meal-cell-move-panel {
+  position: absolute;
+  z-index: 4;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  padding: 6px;
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  background: var(--void-elevated);
+  box-shadow: var(--shadow-soft);
+}
+.meal-cell-move-select {
+  width: 100%;
+  min-height: 34px;
+  padding: 6px 8px;
+  font-size: 0.78rem;
+}
 
 /* Meal shopping push section */
 .meal-push { display: flex; flex-direction: column; gap: 6px; padding: var(--space-sm); border: 1px dashed var(--glass-border); border-radius: var(--radius-sm); background: rgba(124, 58, 237, 0.04); }
@@ -3477,10 +3495,9 @@ body { font-family: var(--font-ui); background: var(--void); color: var(--text-p
   border-color: var(--amethyst);
   background: color-mix(in srgb, var(--amethyst) 10%, var(--surface-paper));
 }
-.meal-plans-page .meal-cell-overlay {
+.meal-plans-page .meal-cell-move-panel {
   border-color: var(--border-subtle);
   background: var(--surface-paper);
-  box-shadow: var(--shadow-soft);
 }
 
 @media (max-width: 780px) {


### PR DESCRIPTION
## Summary

- replace the meal-plan drag library with native drag handling and a slot picker for keyboard and touch users
- remove `@dnd-kit/core` from the frontend dependencies and lockfile
- update meal movement coverage and localized move-control labels

Closes #377

## Checks

- `npm run i18n:check`
- locale key/placeholder parity check for 24 language bundles
- `npm run build`
- `npm test -- --runInBand`
- `npm run e2e:local -- e2e/tests/meal-plans.spec.js --grep "moves a demo meal"`
- `npm run e2e:local`
- `npm ls @dnd-kit/core`
- `git diff --check`
