### PR TITLE
Collapse Docker image workflow into matrix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,24 +9,37 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/tribu-backend
-  FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/tribu-frontend
 
 jobs:
-  build-backend:
+  build:
+    name: Build ${{ matrix.component }} image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: backend
+            image: ghcr.io/${{ github.repository_owner }}/tribu-backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+            cache_scope: backend
+          - component: frontend
+            image: ghcr.io/${{ github.repository_owner }}/tribu-frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+            cache_scope: frontend
 
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-
       - name: Detect stable release tag
         id: release_tag
+        shell: bash
         run: |
           stable=false
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
@@ -36,77 +49,7 @@ jobs:
 
       - name: Derive app version
         id: app_version
-        run: |
-          raw="$(git describe --tags --abbrev=7 --match 'v[0-9]*' --always)"
-          cleaned="${raw#v}"
-          build_date="$(date -u +%F)"
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v?[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-            version="${GITHUB_REF_NAME#v}"
-          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            version="${cleaned}"
-          elif [[ "${cleaned}" =~ ^([0-9]{4}-[0-9]{2}-[0-9]{2})(-|$) ]]; then
-            version="${BASH_REMATCH[1]}.${GITHUB_RUN_NUMBER}"
-          else
-            version="${build_date}.${GITHUB_RUN_NUMBER}"
-          fi
-          echo "value=${version}" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/setup-qemu-action@v4
-
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version from tag
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.BACKEND_IMAGE }}
-          tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-            type=raw,value=latest,enable=${{ steps.release_tag.outputs.stable == 'true' || github.ref_name == github.event.repository.default_branch }}
-            type=ref,event=branch
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: ./backend
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            APP_VERSION=${{ steps.app_version.outputs.value }}
-          cache-from: type=gha,scope=backend
-          cache-to: type=gha,scope=backend,mode=max
-
-  build-frontend:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Detect stable release tag
-        id: release_tag
-        run: |
-          stable=false
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-            stable=true
-          fi
-          echo "stable=${stable}" >> "$GITHUB_OUTPUT"
-
-      - name: Derive frontend app version
-        id: frontend_app_version
+        shell: bash
         run: |
           raw="$(git describe --tags --abbrev=7 --match 'v[0-9]*' --always)"
           cleaned="${raw#v}"
@@ -123,6 +66,34 @@ jobs:
           echo "value=${version}" >> "$GITHUB_OUTPUT"
           echo "date=${build_date}" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare component build args
+        id: build_args
+        shell: bash
+        run: |
+          case "${{ matrix.component }}" in
+            backend)
+              {
+                echo 'value<<BUILD_ARGS'
+                echo 'APP_VERSION=${{ steps.app_version.outputs.value }}'
+                echo 'BUILD_ARGS'
+              } >> "$GITHUB_OUTPUT"
+              ;;
+            frontend)
+              {
+                echo 'value<<BUILD_ARGS'
+                echo 'NEXT_PUBLIC_APP_VERSION=${{ steps.app_version.outputs.value }}'
+                echo 'NEXT_PUBLIC_APP_BUILD_NUMBER=${{ github.run_number }}'
+                echo 'NEXT_PUBLIC_APP_GIT_SHA=${{ github.sha }}'
+                echo 'NEXT_PUBLIC_APP_BUILD_DATE=${{ steps.app_version.outputs.date }}'
+                echo 'BUILD_ARGS'
+              } >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unknown component: ${{ matrix.component }}" >&2
+              exit 1
+              ;;
+          esac
+
       - uses: docker/setup-qemu-action@v4
 
       - uses: docker/setup-buildx-action@v4
@@ -137,7 +108,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.FRONTEND_IMAGE }}
+          images: ${{ matrix.image }}
           tags: |
             type=ref,event=tag
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
@@ -147,15 +118,12 @@ jobs:
 
       - uses: docker/build-push-action@v7
         with:
-          context: ./frontend
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            NEXT_PUBLIC_APP_VERSION=${{ steps.frontend_app_version.outputs.value }}
-            NEXT_PUBLIC_APP_BUILD_NUMBER=${{ github.run_number }}
-            NEXT_PUBLIC_APP_GIT_SHA=${{ github.sha }}
-            NEXT_PUBLIC_APP_BUILD_DATE=${{ steps.frontend_app_version.outputs.date }}
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
+          build-args: ${{ steps.build_args.outputs.value }}
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,scope=${{ matrix.cache_scope }},mode=max

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -5,12 +5,37 @@ from pathlib import Path
 STABLE_RELEASE_TAG_RE = re.compile(r'^v([0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+)$')
 
 
+def read_workflow() -> str:
+    return Path('.github/workflows/docker.yml').read_text()
+
+
+def test_docker_workflow_uses_component_matrix_without_repeated_shared_steps():
+    workflow = read_workflow()
+
+    assert 'build-backend:' not in workflow
+    assert 'build-frontend:' not in workflow
+    assert 'component: backend' in workflow
+    assert 'component: frontend' in workflow
+    assert 'image: ghcr.io/${{ github.repository_owner }}/tribu-backend' in workflow
+    assert 'image: ghcr.io/${{ github.repository_owner }}/tribu-frontend' in workflow
+    assert 'context: ./backend' in workflow
+    assert 'context: ./frontend' in workflow
+    assert 'dockerfile: ./backend/Dockerfile' in workflow
+    assert 'dockerfile: ./frontend/Dockerfile' in workflow
+    assert workflow.count('docker/setup-qemu-action@v4') == 1
+    assert workflow.count('docker/setup-buildx-action@v4') == 1
+    assert workflow.count('docker/login-action@v4') == 1
+    assert workflow.count('docker/metadata-action@v6') == 1
+    assert workflow.count('docker/build-push-action@v7') == 1
+    assert len(workflow.splitlines()) < 140
+
+
 def test_stable_release_tag_builds_publish_latest_images():
-    workflow = Path('.github/workflows/docker.yml').read_text()
+    workflow = read_workflow()
     expected = "type=raw,value=latest,enable=${{ steps.release_tag.outputs.stable == 'true' || github.ref_name == github.event.repository.default_branch }}"
 
-    assert workflow.count('id: release_tag') == 2
-    assert workflow.count(expected) == 2
+    assert workflow.count('id: release_tag') == 1
+    assert workflow.count(expected) == 1
     assert 'type=raw,value=latest,enable={{is_default_branch}}' not in workflow
 
 
@@ -24,18 +49,31 @@ def test_stable_release_tag_detection_covers_date_patch_tags():
 
 def test_backend_image_receives_app_version_build_arg_only():
     dockerfile = Path('backend/Dockerfile').read_text()
-    workflow = Path('.github/workflows/docker.yml').read_text()
+    workflow = read_workflow()
 
     assert 'ARG APP_VERSION=dev' in dockerfile
     assert 'ENV APP_VERSION=${APP_VERSION}' in dockerfile
     assert 'RUN python -m app.core.versioning --write-build-info' not in dockerfile
-    assert 'APP_VERSION=${{ steps.app_version.outputs.value }}' in workflow
+    assert "case \"${{ matrix.component }}\" in" in workflow
+    assert 'backend)' in workflow
+    assert "echo 'APP_VERSION=${{ steps.app_version.outputs.value }}'" in workflow
 
 
 def test_frontend_image_receives_same_build_version_as_backend():
-    workflow = Path('.github/workflows/docker.yml').read_text()
+    workflow = read_workflow()
 
-    assert 'id: frontend_app_version' in workflow
-    assert 'NEXT_PUBLIC_APP_VERSION=${{ steps.frontend_app_version.outputs.value }}' in workflow
-    assert 'NEXT_PUBLIC_APP_BUILD_NUMBER=${{ github.run_number }}' in workflow
-    assert 'NEXT_PUBLIC_APP_GIT_SHA=${{ github.sha }}' in workflow
+    assert 'id: app_version' in workflow
+    assert 'id: frontend_app_version' not in workflow
+    assert 'frontend)' in workflow
+    assert "echo 'NEXT_PUBLIC_APP_VERSION=${{ steps.app_version.outputs.value }}'" in workflow
+    assert "echo 'NEXT_PUBLIC_APP_BUILD_NUMBER=${{ github.run_number }}'" in workflow
+    assert "echo 'NEXT_PUBLIC_APP_GIT_SHA=${{ github.sha }}'" in workflow
+    assert "echo 'NEXT_PUBLIC_APP_BUILD_DATE=${{ steps.app_version.outputs.date }}'" in workflow
+
+
+def test_docker_workflow_keeps_required_package_write_permissions():
+    workflow = read_workflow()
+
+    assert 'permissions:' in workflow
+    assert 'contents: read' in workflow
+    assert 'packages: write' in workflow


### PR DESCRIPTION
## Summary
- collapse the backend and frontend Docker image builds into one matrix-driven job
- keep component-specific image names, contexts, Dockerfiles, cache scopes, and build args explicit in the matrix flow
- retain the existing release/default-branch tag strategy and package-write permissions

## Checks
- actionlint `.github/workflows/docker.yml`
- `uvx --from pytest --with pyyaml pytest tests/test_workflow_permissions.py tests/test_docker_workflow.py -q`
- `git diff --check`

Closes #379
