### PR TITLE
Move E2E service lifecycle into Playwright

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,42 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Start services
-        working-directory: docker
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
-
-      - name: Wait for backend health
-        run: |
-          echo "Waiting for backend..."
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
-              echo "Backend healthy"
-              break
-            fi
-            if [ $i -eq 60 ]; then
-              echo "Backend failed to start"
-              docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml logs backend
-              exit 1
-            fi
-            sleep 2
-          done
-
-      - name: Wait for frontend
-        run: |
-          echo "Waiting for frontend..."
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
-              echo "Frontend healthy"
-              break
-            fi
-            if [ $i -eq 60 ]; then
-              echo "Frontend failed to start"
-              docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml logs frontend
-              exit 1
-            fi
-            sleep 2
-          done
-
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -78,6 +42,9 @@ jobs:
         run: npx playwright test
         env:
           BASE_URL: http://localhost:3000
+          E2E_WEB_SERVER_URL: http://localhost:3000
+          E2E_BACKEND_HEALTH_URL: http://localhost:8000/health
+          E2E_WEB_SERVER_COMMAND: docker compose -f ../docker/docker-compose.yml -f ../docker/docker-compose.dev.yml up --build
 
       - name: Upload test report
         uses: actions/upload-artifact@v7
@@ -92,10 +59,5 @@ jobs:
         if: failure()
         with:
           name: playwright-traces
-          path: frontend/e2e/test-results/
+          path: frontend/test-results/
           retention-days: 7
-
-      - name: Teardown
-        if: always()
-        working-directory: docker
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v

--- a/frontend/e2e/global-setup.js
+++ b/frontend/e2e/global-setup.js
@@ -1,5 +1,30 @@
 const { request } = require('@playwright/test');
 
+async function waitForHealth(url, timeoutMs = 120000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      const ctx = await request.newContext();
+      try {
+        const response = await ctx.get(url, { timeout: 2000 });
+        if (response.ok()) {
+          return;
+        }
+        lastError = new Error(`${url} returned ${response.status()}`);
+      } finally {
+        await ctx.dispose();
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`Timed out waiting for ${url}: ${lastError?.message || 'no response'}`);
+}
+
 /**
  * Registers a throwaway user so the SetupWizard (first-run screen) is bypassed.
  * If the user already exists (e.g. from a previous run), that's fine.
@@ -9,6 +34,11 @@ module.exports = async function globalSetup(config) {
     config.projects?.[0]?.use?.baseURL ||
     process.env.BASE_URL ||
     'http://localhost:3000';
+
+  if (process.env.E2E_BACKEND_HEALTH_URL) {
+    const timeoutMs = Number(process.env.E2E_BACKEND_HEALTH_TIMEOUT_MS || 120000);
+    await waitForHealth(process.env.E2E_BACKEND_HEALTH_URL, timeoutMs);
+  }
 
   const ctx = await request.newContext({ baseURL });
 

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,5 +1,9 @@
 const { defineConfig, devices } = require('@playwright/test');
 
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+const webServerCommand = process.env.E2E_WEB_SERVER_COMMAND;
+const webServerURL = process.env.E2E_WEB_SERVER_URL || baseURL;
+
 module.exports = defineConfig({
   testDir: './e2e/tests',
   fullyParallel: false,
@@ -9,8 +13,21 @@ module.exports = defineConfig({
 
   globalSetup: './e2e/global-setup.js',
 
+  ...(webServerCommand
+    ? {
+        webServer: {
+          command: webServerCommand,
+          url: webServerURL,
+          timeout: 300 * 1000,
+          reuseExistingServer: !process.env.CI,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        },
+      }
+    : {}),
+
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL,
     locale: 'en-US',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',

--- a/scripts/e2e-local-services.sh
+++ b/scripts/e2e-local-services.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+BACKEND_PORT="${BACKEND_PORT:-8100}"
+FRONTEND_PORT="${FRONTEND_PORT:-3100}"
+BACKEND_URL="${BACKEND_URL:-http://localhost:${BACKEND_PORT}}"
+BASE_URL="${BASE_URL:-http://localhost:${FRONTEND_PORT}}"
+DATABASE_PATH="${TRIBU_E2E_DB:-$BACKEND_DIR/test-e2e.db}"
+DATABASE_URL="${DATABASE_URL:-sqlite:///$DATABASE_PATH}"
+DAV_STORAGE_FOLDER="${DAV_STORAGE_FOLDER:-$BACKEND_DIR/test-e2e-dav}"
+JWT_SECRET="${JWT_SECRET:-local-e2e-secret-change-me-local-only}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+VENV_DIR="$BACKEND_DIR/.venv"
+BACKEND_PID=""
+FRONTEND_PID=""
+
+cleanup() {
+  if [ -n "$FRONTEND_PID" ] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
+    kill "$FRONTEND_PID" 2>/dev/null || true
+  fi
+  if [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
+    kill "$BACKEND_PID" 2>/dev/null || true
+  fi
+  if [ "${KEEP_E2E_ARTIFACTS:-false}" != "true" ]; then
+    rm -rf "$DATABASE_PATH" "$DAV_STORAGE_FOLDER"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+wait_for_url() {
+  local url="$1"
+  local label="$2"
+  local attempts="${3:-60}"
+
+  for _ in $(seq 1 "$attempts"); do
+    if "$VENV_DIR/bin/python" - "$url" <<'PY' >/dev/null 2>&1
+import sys
+from urllib.request import urlopen
+
+with urlopen(sys.argv[1], timeout=2) as response:
+    if response.status < 500:
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+    then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Timed out waiting for $label at $url" >&2
+  return 1
+}
+
+if [ ! -x "$VENV_DIR/bin/python" ] || ! "$VENV_DIR/bin/python" -m pip --version >/dev/null 2>&1; then
+  rm -rf "$VENV_DIR"
+  if command -v uv >/dev/null 2>&1; then
+    uv venv --seed "$VENV_DIR"
+  else
+    "$PYTHON_BIN" -m venv "$VENV_DIR"
+  fi
+fi
+
+"$VENV_DIR/bin/python" -m pip install -q -r "$BACKEND_DIR/requirements.txt"
+
+rm -f "$DATABASE_PATH"
+DATABASE_URL="$DATABASE_URL" PYTHONPATH="$BACKEND_DIR" "$VENV_DIR/bin/python" <<'PY'
+from app import models  # noqa: F401
+from app.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+PY
+
+(
+  cd "$BACKEND_DIR"
+  DATABASE_URL="$DATABASE_URL" \
+    JWT_SECRET="$JWT_SECRET" \
+    ALLOW_OPEN_REGISTRATION=true \
+    SECURE_COOKIES=false \
+    DAV_STORAGE_FOLDER="$DAV_STORAGE_FOLDER" \
+    PYTHONPATH="$BACKEND_DIR" \
+    "$VENV_DIR/bin/python" -m uvicorn app.main:app --host 127.0.0.1 --port "$BACKEND_PORT"
+) &
+BACKEND_PID="$!"
+
+wait_for_url "$BACKEND_URL/health" "backend"
+
+(
+  cd "$FRONTEND_DIR"
+  BACKEND_URL="$BACKEND_URL" NEXT_DIST_DIR=.next-e2e npx next dev -p "$FRONTEND_PORT"
+) &
+FRONTEND_PID="$!"
+
+wait "$FRONTEND_PID"

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -2,96 +2,20 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BACKEND_DIR="$ROOT_DIR/backend"
 FRONTEND_DIR="$ROOT_DIR/frontend"
 BACKEND_PORT="${BACKEND_PORT:-8100}"
 FRONTEND_PORT="${FRONTEND_PORT:-3100}"
 BACKEND_URL="${BACKEND_URL:-http://localhost:${BACKEND_PORT}}"
 BASE_URL="${BASE_URL:-http://localhost:${FRONTEND_PORT}}"
-DATABASE_PATH="${TRIBU_E2E_DB:-$BACKEND_DIR/test-e2e.db}"
-DATABASE_URL="${DATABASE_URL:-sqlite:///$DATABASE_PATH}"
-DAV_STORAGE_FOLDER="${DAV_STORAGE_FOLDER:-$BACKEND_DIR/test-e2e-dav}"
-JWT_SECRET="${JWT_SECRET:-local-e2e-secret-change-me-local-only}"
-PYTHON_BIN="${PYTHON_BIN:-python3}"
-VENV_DIR="$BACKEND_DIR/.venv"
-BACKEND_PID=""
-FRONTEND_PID=""
-
-cleanup() {
-  if [ -n "$FRONTEND_PID" ] && kill -0 "$FRONTEND_PID" 2>/dev/null; then
-    kill "$FRONTEND_PID" 2>/dev/null || true
-  fi
-  if [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
-    kill "$BACKEND_PID" 2>/dev/null || true
-  fi
-  if [ "${KEEP_E2E_ARTIFACTS:-false}" != "true" ]; then
-    rm -rf "$DATABASE_PATH" "$DAV_STORAGE_FOLDER"
-  fi
-}
-trap cleanup EXIT
-
-wait_for_url() {
-  local url="$1"
-  local label="$2"
-  local attempts="${3:-60}"
-
-  for _ in $(seq 1 "$attempts"); do
-    if "$VENV_DIR/bin/python" - "$url" <<'PY' >/dev/null 2>&1
-import sys
-from urllib.request import urlopen
-
-with urlopen(sys.argv[1], timeout=2) as response:
-    if response.status < 500:
-        raise SystemExit(0)
-raise SystemExit(1)
-PY
-    then
-      return 0
-    fi
-    sleep 1
-  done
-
-  echo "Timed out waiting for $label at $url" >&2
-  return 1
-}
-
-if [ ! -d "$VENV_DIR" ]; then
-  "$PYTHON_BIN" -m venv "$VENV_DIR"
-fi
-
-"$VENV_DIR/bin/python" -m pip install -q -r "$BACKEND_DIR/requirements.txt"
-
-rm -f "$DATABASE_PATH"
-DATABASE_URL="$DATABASE_URL" PYTHONPATH="$BACKEND_DIR" "$VENV_DIR/bin/python" <<'PY'
-from app import models  # noqa: F401
-from app.database import Base, engine
-
-Base.metadata.create_all(bind=engine)
-PY
-
-(
-  cd "$BACKEND_DIR"
-  DATABASE_URL="$DATABASE_URL" \
-    JWT_SECRET="$JWT_SECRET" \
-    ALLOW_OPEN_REGISTRATION=true \
-    SECURE_COOKIES=false \
-    DAV_STORAGE_FOLDER="$DAV_STORAGE_FOLDER" \
-    PYTHONPATH="$BACKEND_DIR" \
-    "$VENV_DIR/bin/python" -m uvicorn app.main:app --host 127.0.0.1 --port "$BACKEND_PORT"
-) &
-BACKEND_PID="$!"
-
-wait_for_url "$BACKEND_URL/health" "backend"
 
 (
   cd "$FRONTEND_DIR"
-  BACKEND_URL="$BACKEND_URL" NEXT_DIST_DIR=.next-e2e npx next dev -p "$FRONTEND_PORT"
-) &
-FRONTEND_PID="$!"
-
-wait_for_url "$BASE_URL" "frontend"
-
-(
-  cd "$FRONTEND_DIR"
-  BASE_URL="$BASE_URL" npx playwright test "$@"
+  BACKEND_PORT="$BACKEND_PORT" \
+    FRONTEND_PORT="$FRONTEND_PORT" \
+    BACKEND_URL="$BACKEND_URL" \
+    BASE_URL="$BASE_URL" \
+    E2E_BACKEND_HEALTH_URL="$BACKEND_URL/health" \
+    E2E_WEB_SERVER_COMMAND="../scripts/e2e-local-services.sh" \
+    E2E_WEB_SERVER_URL="$BASE_URL" \
+    npx playwright test "$@"
 )

--- a/tests/test_workflow_permissions.py
+++ b/tests/test_workflow_permissions.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import yaml
 
 
-WORKFLOWS = Path('.github/workflows')
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / '.github/workflows'
 
 
 def test_e2e_workflow_declares_read_only_permissions():
@@ -12,3 +13,62 @@ def test_e2e_workflow_declares_read_only_permissions():
 
     assert workflow['permissions'] == {'contents': 'read'}
     assert workflow_text.index('\npermissions:\n') < workflow_text.index('\njobs:\n')
+
+
+def test_e2e_workflow_delegates_server_lifecycle_to_playwright():
+    workflow_text = (WORKFLOWS / 'e2e.yml').read_text()
+    workflow = yaml.safe_load(workflow_text)
+    steps = workflow['jobs']['e2e']['steps']
+    step_names = [step.get('name', '') for step in steps]
+    run_step = next(step for step in steps if step.get('name') == 'Run E2E tests')
+
+    assert 'Start services' not in step_names
+    assert 'Wait for backend health' not in step_names
+    assert 'Wait for frontend' not in step_names
+    assert 'Teardown' not in step_names
+    assert 'for i in $(seq' not in workflow_text
+    assert 'curl -sf http://localhost' not in workflow_text
+    assert run_step['run'] == 'npx playwright test'
+    assert run_step['env']['BASE_URL'] == 'http://localhost:3000'
+    assert run_step['env']['E2E_WEB_SERVER_URL'] == 'http://localhost:3000'
+    assert run_step['env']['E2E_BACKEND_HEALTH_URL'] == 'http://localhost:8000/health'
+    assert 'docker-compose.dev.yml' in run_step['env']['E2E_WEB_SERVER_COMMAND']
+    assert 'up --build' in run_step['env']['E2E_WEB_SERVER_COMMAND']
+
+
+def test_e2e_workflow_keeps_failure_artifacts():
+    workflow = yaml.safe_load((WORKFLOWS / 'e2e.yml').read_text())
+    steps = workflow['jobs']['e2e']['steps']
+    report_step = next(step for step in steps if step.get('name') == 'Upload test report')
+    trace_step = next(step for step in steps if step.get('name') == 'Upload traces on failure')
+
+    assert report_step['if'] == 'always()'
+    assert report_step['with']['path'] == 'frontend/playwright-report/'
+    assert trace_step['if'] == 'failure()'
+    assert trace_step['with']['path'] == 'frontend/test-results/'
+
+
+def test_playwright_config_owns_optional_web_server_lifecycle():
+    config = (ROOT / 'frontend/playwright.config.js').read_text()
+    local_runner = (ROOT / 'scripts/e2e-local.sh').read_text()
+    local_services = (ROOT / 'scripts/e2e-local-services.sh').read_text()
+
+    assert 'const webServerCommand = process.env.E2E_WEB_SERVER_COMMAND;' in config
+    assert 'webServer:' in config
+    assert 'url: webServerURL' in config
+    assert 'timeout: 300 * 1000' in config
+    assert "baseURL," in config
+    assert 'E2E_WEB_SERVER_COMMAND="../scripts/e2e-local-services.sh"' in local_runner
+    assert 'E2E_BACKEND_HEALTH_URL="$BACKEND_URL/health"' in local_runner
+    assert 'npx playwright test "$@"' in local_runner
+    assert 'wait_for_url "$BACKEND_URL/health" "backend"' in local_services
+    assert 'npx next dev -p "$FRONTEND_PORT"' in local_services
+
+
+def test_playwright_global_setup_waits_for_backend_health_when_configured():
+    global_setup = (ROOT / 'frontend/e2e/global-setup.js').read_text()
+
+    assert 'async function waitForHealth' in global_setup
+    assert 'process.env.E2E_BACKEND_HEALTH_URL' in global_setup
+    assert 'E2E_BACKEND_HEALTH_TIMEOUT_MS' in global_setup
+    assert 'await waitForHealth(process.env.E2E_BACKEND_HEALTH_URL, timeoutMs);' in global_setup


### PR DESCRIPTION
## Summary
- move E2E service startup into Playwright's webServer flow for CI and local runs
- keep backend readiness deterministic through the Playwright global setup health wait
- preserve Playwright reports and upload failure traces from the actual test-results directory

## Checks
- actionlint `.github/workflows/e2e.yml`
- `uvx --from pytest --with pyyaml pytest tests/test_workflow_permissions.py tests/test_public_launch_docs.py::test_public_compose_is_image_only_and_uses_shared_database_password -q`
- `npm run build`
- `npm run e2e:local -- e2e/tests/auth.spec.js --grep "register a new user"`
- `npm run e2e:local`
- `git diff --check`

Closes #380
