### PR TITLE
Use stdlib HTTP for webhook delivery

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install backend test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r backend/requirements.txt pytest
+          python -m pip install -r backend/requirements.txt pytest httpx
 
       - name: Run backend release-contract tests
         run: |

--- a/backend/app/core/webhooks.py
+++ b/backend/app/core/webhooks.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import socket
+import urllib.error
+import urllib.request
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-import httpx
 from sqlalchemy.orm import Session
 
 from app.core.utils import utcnow
@@ -13,6 +16,25 @@ from app.models import WebhookDelivery, WebhookEndpoint
 
 WEBHOOK_TIMEOUT_SECONDS = 3.0
 REDACTED_URL = "[redacted]"
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Keep webhook delivery status codes visible instead of following redirects."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: N802 - stdlib override signature
+        return None
+
+
+class _WebhookHTTPErrorProcessor(urllib.request.HTTPErrorProcessor):
+    """Return non-2xx responses so delivery status can be persisted consistently."""
+
+    def http_response(self, request, response):
+        return response
+
+    https_response = http_response
+
+
+_WEBHOOK_OPENER = urllib.request.build_opener(_NoRedirectHandler, _WebhookHTTPErrorProcessor)
 
 
 def redact_webhook_url(url: str) -> str:
@@ -51,6 +73,23 @@ def _delivery_payload(*, family_id: int, event_type: str, data: dict[str, Any]) 
     }
 
 
+def _webhook_network_error_name(exc: BaseException) -> str:
+    if isinstance(exc, urllib.error.URLError) and exc.reason:
+        return exc.reason.__class__.__name__
+    return exc.__class__.__name__
+
+
+def _post_webhook_json(url: str, *, payload: dict[str, Any], headers: dict[str, str]) -> int:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with _WEBHOOK_OPENER.open(request, timeout=WEBHOOK_TIMEOUT_SECONDS) as response:
+        return int(response.status)
+
+
 def deliver_to_endpoint(
     db: Session,
     endpoint: WebhookEndpoint,
@@ -73,20 +112,22 @@ def deliver_to_endpoint(
         headers[endpoint.secret_header_name] = endpoint.secret_header_value
 
     try:
-        response = httpx.post(
+        status_code = _post_webhook_json(
             endpoint.url,
-            json=_delivery_payload(family_id=endpoint.family_id, event_type=event_type, data=data),
+            payload=_delivery_payload(family_id=endpoint.family_id, event_type=event_type, data=data),
             headers=headers,
-            timeout=WEBHOOK_TIMEOUT_SECONDS,
-            follow_redirects=False,
         )
-        delivery.status_code = response.status_code
-        delivery.status = "delivered" if 200 <= response.status_code < 300 else "failed"
+        delivery.status_code = status_code
+        delivery.status = "delivered" if 200 <= status_code < 300 else "failed"
         if delivery.status == "failed":
-            delivery.error = f"HTTP {response.status_code}"
-    except httpx.HTTPError as exc:
+            delivery.error = f"HTTP {status_code}"
+    except urllib.error.HTTPError as exc:
+        delivery.status_code = exc.code
         delivery.status = "failed"
-        delivery.error = exc.__class__.__name__
+        delivery.error = f"HTTP {exc.code}"
+    except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+        delivery.status = "failed"
+        delivery.error = _webhook_network_error_name(exc)
     except Exception as exc:  # pragma: no cover - defensive guard around network delivery
         delivery.status = "failed"
         delivery.error = exc.__class__.__name__

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,6 @@ apscheduler==3.11.2
 python-multipart==0.0.31
 redis==5.2.1
 pywebpush==2.0.1
-httpx==0.28.1
 radicale==3.7.1
 a2wsgi==1.10.7
 apprise==1.10.0

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import urllib.error
 
 import pytest
 from fastapi.testclient import TestClient
@@ -81,6 +83,26 @@ def _seed_admin(scopes: str = "admin:read,admin:write,shopping:write") -> tuple[
         db.close()
 
 
+def _seed_webhook_endpoint(family_id: int, *, url: str = "https://receiver.example/hook?token=private") -> int:
+    db = TestSession()
+    try:
+        endpoint = WebhookEndpoint(
+            family_id=family_id,
+            name="Receiver",
+            url=url,
+            events=["webhook.test"],
+            active=True,
+            secret_header_name="X-Tribu-Secret",
+            secret_header_value="secret-value",
+        )
+        db.add(endpoint)
+        db.commit()
+        return int(endpoint.id)
+    finally:
+        db.close()
+
+
+
 def test_create_webhook_redacts_url_and_secret():
     token, family_id, _ = _seed_admin()
 
@@ -150,35 +172,59 @@ def test_rejects_reserved_secret_header_name():
     assert "secret-value" not in str(resp.json())
 
 
+def test_webhook_stdlib_post_sets_method_headers_payload_and_timeout(monkeypatch):
+    from app.core import webhooks as webhooks_core
+
+    calls = []
+
+    class FakeResponse:
+        status = 201
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeOpener:
+        def open(self, request, *, timeout):
+            calls.append({"request": request, "timeout": timeout})
+            return FakeResponse()
+
+    monkeypatch.setattr(webhooks_core, "_WEBHOOK_OPENER", FakeOpener())
+
+    status = webhooks_core._post_webhook_json(
+        "https://receiver.example/hook",
+        payload={"event_type": "webhook.test", "data": {"message": "hello"}},
+        headers={"Content-Type": "application/json", "User-Agent": "Tribu-Webhooks/1.0", "X-Tribu-Secret": "secret"},
+    )
+
+    assert status == 201
+    request = calls[0]["request"]
+    assert request.get_method() == "POST"
+    assert calls[0]["timeout"] == webhooks_core.WEBHOOK_TIMEOUT_SECONDS
+    assert dict(request.header_items())["Content-type"] == "application/json"
+    assert dict(request.header_items())["User-agent"] == "Tribu-Webhooks/1.0"
+    assert dict(request.header_items())["X-tribu-secret"] == "secret"
+    assert json.loads(request.data.decode("utf-8"))["event_type"] == "webhook.test"
+
+
 def test_test_webhook_sends_redacted_delivery(monkeypatch):
     token, family_id, _ = _seed_admin()
-    db = TestSession()
-    endpoint = WebhookEndpoint(
-        family_id=family_id,
-        name="Receiver",
-        url="https://receiver.example/hook?token=private",
-        events=["webhook.test"],
-        active=True,
-        secret_header_name="X-Tribu-Secret",
-        secret_header_value="secret-value",
-    )
-    db.add(endpoint)
-    db.commit()
-    endpoint_id = endpoint.id
-    db.close()
+    endpoint_id = _seed_webhook_endpoint(family_id)
 
     calls = []
 
     class FakeResponse:
         status_code = 204
 
-    def fake_post(url, *, json, headers, timeout, follow_redirects=False):
-        calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
-        return FakeResponse()
+    def fake_post(url, *, payload, headers):
+        calls.append({"url": url, "payload": payload, "headers": headers})
+        return FakeResponse.status_code
 
     from app.core import webhooks as webhooks_core
 
-    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+    monkeypatch.setattr(webhooks_core, "_post_webhook_json", fake_post)
 
     resp = client.post(f"/webhooks/{endpoint_id}/test", headers=_auth(token))
 
@@ -188,8 +234,71 @@ def test_test_webhook_sends_redacted_delivery(monkeypatch):
     assert body["delivery"]["status_code"] == 204
     assert calls[0]["url"] == "https://receiver.example/hook?token=private"
     assert calls[0]["headers"]["X-Tribu-Secret"] == "secret-value"
-    assert calls[0]["json"]["event_type"] == "webhook.test"
+    assert calls[0]["payload"]["event_type"] == "webhook.test"
     assert "receiver.example" not in str(body)
+    assert "secret-value" not in str(body)
+
+
+def test_webhook_status_code_failure_is_recorded_safely(monkeypatch):
+    token, family_id, _ = _seed_admin()
+    endpoint_id = _seed_webhook_endpoint(family_id)
+
+    from app.core import webhooks as webhooks_core
+
+    monkeypatch.setattr(webhooks_core, "_post_webhook_json", lambda *_args, **_kwargs: 503)
+
+    resp = client.post(f"/webhooks/{endpoint_id}/test", headers=_auth(token))
+
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["delivery"]["status_code"] == 503
+    assert body["delivery"]["error"] == "HTTP 503"
+    assert "secret-value" not in str(body)
+    assert "token=private" not in str(body)
+
+
+def test_webhook_connection_error_records_safe_operator_error(monkeypatch):
+    token, family_id, _ = _seed_admin()
+    endpoint_id = _seed_webhook_endpoint(family_id)
+
+    def raise_connection_error(*_args, **_kwargs):
+        raise urllib.error.URLError(ConnectionRefusedError("connection refused for token=private"))
+
+    from app.core import webhooks as webhooks_core
+
+    monkeypatch.setattr(webhooks_core, "_post_webhook_json", raise_connection_error)
+
+    resp = client.post(f"/webhooks/{endpoint_id}/test", headers=_auth(token))
+
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["delivery"]["status_code"] is None
+    assert body["delivery"]["error"] == "ConnectionRefusedError"
+    assert "token=private" not in str(body)
+    assert "secret-value" not in str(body)
+
+
+def test_webhook_timeout_error_records_safe_operator_error(monkeypatch):
+    token, family_id, _ = _seed_admin()
+    endpoint_id = _seed_webhook_endpoint(family_id)
+
+    def raise_timeout(*_args, **_kwargs):
+        raise TimeoutError("timeout for token=private")
+
+    from app.core import webhooks as webhooks_core
+
+    monkeypatch.setattr(webhooks_core, "_post_webhook_json", raise_timeout)
+
+    resp = client.post(f"/webhooks/{endpoint_id}/test", headers=_auth(token))
+
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["delivery"]["status_code"] is None
+    assert body["delivery"]["error"] == "TimeoutError"
+    assert "token=private" not in str(body)
     assert "secret-value" not in str(body)
 
 
@@ -214,13 +323,13 @@ def test_subscribed_shopping_event_creates_delivery(monkeypatch):
     class FakeResponse:
         status_code = 200
 
-    def fake_post(url, *, json, headers, timeout, follow_redirects=False):
-        sent_payloads.append(json)
-        return FakeResponse()
+    def fake_post(url, *, payload, headers):
+        sent_payloads.append(payload)
+        return FakeResponse.status_code
 
     from app.core import webhooks as webhooks_core
 
-    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+    monkeypatch.setattr(webhooks_core, "_post_webhook_json", fake_post)
 
     resp = client.post(
         f"/shopping/lists/{list_id}/items",
@@ -261,13 +370,13 @@ def test_task_event_creates_delivery(monkeypatch):
     class FakeResponse:
         status_code = 202
 
-    def fake_post(url, *, json, headers, timeout, follow_redirects=False):
-        sent_payloads.append(json)
-        return FakeResponse()
+    def fake_post(url, *, payload, headers):
+        sent_payloads.append(payload)
+        return FakeResponse.status_code
 
     from app.core import webhooks as webhooks_core
 
-    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+    monkeypatch.setattr(webhooks_core, "_post_webhook_json", fake_post)
 
     resp = client.post(
         "/tasks",
@@ -321,7 +430,7 @@ def test_inactive_or_unsubscribed_webhooks_are_skipped(monkeypatch):
     def fake_post(*args, **kwargs):
         raise AssertionError("No webhook should be sent")
 
-    monkeypatch.setattr(webhooks_core.httpx, "post", fake_post)
+    monkeypatch.setattr(webhooks_core, "_post_webhook_json", fake_post)
 
     resp = client.post(
         f"/shopping/lists/{list_id}/items",


### PR DESCRIPTION
## Summary
- replace the single runtime webhook `httpx` call with a stdlib `urllib.request` POST helper
- preserve webhook status handling for success, non-2xx responses, connection failures, and timeout-like failures
- remove `httpx` from backend runtime requirements while keeping it as a test-only dependency for FastAPI/Starlette `TestClient`

## Checks
- `PYTHONPATH=. python -m pytest tests/test_webhooks.py -q`
- `PYTHONPATH=. python -m pytest tests/test_cors_headers.py tests/test_mobile_auth.py tests/test_oidc_flow.py -q`
- clean requirements-only install and backend runtime import without `httpx`
- runtime source scan for `httpx` imports
- `git diff --check`

Closes #384
