### PR TITLE
Make Apprise notification destinations explicit

### DIFF
--- a/backend/app/core/notification_destinations.py
+++ b/backend/app/core/notification_destinations.py
@@ -25,6 +25,8 @@ from app.models import Membership, NotificationDestination, NotificationDestinat
 
 logger = logging.getLogger(__name__)
 
+APPRISE_PROVIDER = "apprise"
+
 ALLOWED_APPRISE_SCHEMES = {
     "gotify",
     "gotifys",
@@ -232,7 +234,7 @@ def destination_response(destination: NotificationDestination) -> dict[str, Any]
         "id": destination.id,
         "family_id": destination.family_id,
         "name": destination.name,
-        "provider": destination.provider,
+        "provider": APPRISE_PROVIDER,
         "url_redacted": redact_target_url(destination.target_url_secret),
         "events": destination.events or [],
         "active": destination.active,
@@ -249,7 +251,7 @@ def destination_response(destination: NotificationDestination) -> dict[str, Any]
 
 def provider_status() -> dict[str, Any]:
     return {
-        "provider": "apprise",
+        "provider": APPRISE_PROVIDER,
         "available": is_provider_available(),
         "allowed_schemes": sorted(ALLOWED_APPRISE_SCHEMES),
         "events": sorted(DESTINATION_EVENT_TYPES),

--- a/backend/app/modules/notification_destinations_router.py
+++ b/backend/app/modules/notification_destinations_router.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 
 from app.core.deps import current_user, ensure_family_admin
 from app.core.notification_destinations import (
+    APPRISE_PROVIDER,
     destination_response,
     protect_target_url,
     provider_status,
@@ -50,7 +51,7 @@ def _audit_details(destination: NotificationDestination, action: str) -> dict:
     return {
         "destination_id": destination.id,
         "action": action,
-        "provider": destination.provider,
+        "provider": APPRISE_PROVIDER,
         "url_redacted": redact_target_url(destination.target_url_secret),
         "events": destination.events or [],
         "active": destination.active,
@@ -98,7 +99,11 @@ def get_provider_status(
     "",
     response_model=NotificationDestinationResponse,
     summary="Create notification destination",
-    description="Create an Apprise-backed household notification destination. Admin only. Scope: `admin:write`.",
+    description=(
+        "Create an Apprise-backed household notification destination. "
+        "Legacy provider payload values are ignored; Apprise is always used. "
+        "Admin only. Scope: `admin:write`."
+    ),
 )
 def create_destination(
     payload: NotificationDestinationCreate,
@@ -110,7 +115,7 @@ def create_destination(
     destination = NotificationDestination(
         family_id=payload.family_id,
         name=payload.name.strip(),
-        provider="apprise",
+        provider=APPRISE_PROVIDER,
         target_url_secret=protect_target_url(payload.target_url_secret),
         events=payload.events,
         active=payload.active,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2170,18 +2170,20 @@ class WebhookTestResponse(BaseModel):
 class NotificationDestinationCreate(BaseModel):
     family_id: int = Field(..., description="Family ID")
     name: str = Field(..., min_length=1, max_length=120, description="Destination display name")
-    provider: str = Field("apprise", description="Destination provider")
     target_url_secret: str = Field(..., min_length=3, max_length=2000, description="Apprise destination URL")
     events: list[str] = Field(default_factory=list, description="Subscribed reminder event types")
     active: bool = Field(True, description="Whether deliveries are enabled")
     respect_quiet_hours: bool = Field(True, description="Whether household quiet hours suppress this destination")
 
-    @field_validator("provider")
-    @classmethod
-    def validate_provider(cls, value: str) -> str:
-        if value != "apprise":
-            raise ValueError("Unsupported notification destination provider")
-        return value
+    model_config = ConfigDict(
+        extra="ignore",
+        json_schema_extra={
+            "description": (
+                "Create an Apprise-backed notification destination. The legacy "
+                "provider input is ignored when present; Apprise is always used."
+            )
+        },
+    )
 
     @field_validator("target_url_secret")
     @classmethod

--- a/backend/tests/test_notification_destinations.py
+++ b/backend/tests/test_notification_destinations.py
@@ -36,6 +36,7 @@ from app.models import (
     User,
 )
 from app.security import PAT_PREFIX, hash_password
+from app.schemas import NotificationDestinationCreate
 
 engine = create_engine(
     "sqlite://",
@@ -178,6 +179,25 @@ def _seed_shopping_list(family_id: int, user_id: int, name: str = "Coverage list
         db.close()
 
 
+def test_create_schema_omits_provider_configuration_but_ignores_legacy_input():
+    schema = NotificationDestinationCreate.model_json_schema()
+    assert "provider" not in schema["properties"]
+    assert "legacy provider input is ignored" in schema["description"]
+
+    payload = NotificationDestinationCreate.model_validate(
+        {
+            "family_id": 1,
+            "name": "Compatibility destination",
+            "provider": "unsupported-provider",
+            "target_url_secret": "mailto://compatibility@example.com",
+            "events": ["calendar.reminder"],
+        }
+    )
+
+    assert not hasattr(payload, "provider")
+    assert payload.target_url_secret == "mailto://compatibility@example.com"
+
+
 def test_admin_crud_redacts_secret_and_audits_safe_metadata():
     token, family_id, _ = _seed_member()
     raw_url = "ntfy://ntfy.sh/placeholder-topic?token=placeholder-token"
@@ -188,6 +208,7 @@ def test_admin_crud_redacts_secret_and_audits_safe_metadata():
         json={
             "family_id": family_id,
             "name": "Kitchen ntfy",
+            "provider": "unsupported-provider",
             "target_url_secret": raw_url,
             "events": ["calendar.reminder", "task.reminder"],
             "active": True,
@@ -207,12 +228,16 @@ def test_admin_crud_redacts_secret_and_audits_safe_metadata():
 
     db = TestSession()
     try:
-        stored = db.get(NotificationDestination, body["id"]).target_url_secret
+        stored_destination = db.get(NotificationDestination, body["id"])
+        assert stored_destination is not None
+        stored = getattr(stored_destination, "target_url_secret")
+        stored_provider = getattr(stored_destination, "provider")
     finally:
         db.close()
 
     from app.core.notification_destinations import reveal_target_url
 
+    assert stored_provider == "apprise"
     assert stored.startswith("enc:v1:")
     assert raw_url not in stored
     assert "placeholder-token" not in stored
@@ -234,6 +259,21 @@ def test_admin_crud_redacts_secret_and_audits_safe_metadata():
 
     deleted = client.delete(f"/notification-destinations/{body['id']}", headers=_auth(token))
     assert deleted.status_code == 200
+
+
+def test_response_normalizes_legacy_stored_provider_to_apprise():
+    token, family_id, user_id = _seed_member()
+    db = TestSession()
+    try:
+        db.add(_destination(family_id, user_id, provider="legacy-provider", target_url_secret="mailto://legacy@example.com"))
+        db.commit()
+    finally:
+        db.close()
+
+    listed = client.get(f"/notification-destinations?family_id={family_id}", headers=_auth(token))
+
+    assert listed.status_code == 200, listed.json()
+    assert listed.json()[0]["provider"] == "apprise"
 
 
 def test_admin_authorization_cross_family_and_pat_scope_split():

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -47,7 +47,7 @@ See [Self-Hosting: Push Notifications](https://github.com/itsDNNS/tribu/wiki/Sel
 
 ## Household Notification Destinations (Optional)
 
-Admins can add Apprise-backed destinations for human-readable household reminders and opt-in shopping activity, such as Gotify, ntfy, Telegram, Matrix, or email. Use placeholder examples in public docs and screenshots, for example `ntfy://ntfy.sh/family-topic` or `gotify://host.example/token`, not real tokens.
+Admins can add Apprise-backed destinations for human-readable household reminders and opt-in shopping activity, such as Gotify, ntfy, Telegram, Matrix, or email. Use placeholder examples in public docs and screenshots, for example `ntfy://ntfy.sh/family-topic` or `gotify://host.example/token`, not real tokens. The destination API always uses Apprise for new destinations; `provider: "apprise"` is still returned for compatibility, and any legacy `provider` value sent on create is ignored.
 
 Destination URLs are stored encrypted with a key derived from `NOTIFICATION_DESTINATION_SECRET_KEY` when set, otherwise `JWT_SECRET`. Keep that secret stable across upgrades and restores. Existing legacy plaintext rows are still readable so old installs can upgrade in place, but newly saved or updated destinations are encrypted.
 


### PR DESCRIPTION
## Summary
- make Apprise the explicit notification destination implementation while keeping response compatibility
- ignore legacy `provider` input on create and always store/return `apprise` for new destinations
- add coverage for schema compatibility, Apprise status, creation, and delivery behavior
- document the compatibility behavior in self-hosting docs

## Checks
- `PYTHONPATH=. python -m pytest tests/test_notification_destinations.py -q`
- `PYTHONPATH=. python -m pytest tests/test_notification_reliability.py -q`
- `PYTHONPATH=. python -m pytest tests/test_cors_headers.py tests/test_mobile_auth.py tests/test_oidc_flow.py -q`
- backend OpenAPI/schema smoke for notification destination create/response provider fields
- provider-branch source scan
- `git diff --check`

Closes #386
