### PR TITLE
Simplify E2E navigation setup

### DIFF
--- a/frontend/e2e/helpers/navigation.js
+++ b/frontend/e2e/helpers/navigation.js
@@ -1,8 +1,3 @@
-// Mobile bottom-nav uses mobileLabel which differs from the sidebar label
-const MOBILE_ALIASES = {
-  Dashboard: 'Home',
-};
-
 const VIEW_KEYS = {
   Dashboard: 'dashboard',
   Home: 'dashboard',
@@ -23,88 +18,21 @@ const VIEW_KEYS = {
   Admin: 'admin',
 };
 
-// Items pinned to overflow on mobile - skip bottom-nav check
-const ALWAYS_OVERFLOW = new Set(['Settings', 'Admin']);
-
 /**
- * Navigate to a view in the app.
- * On desktop: clicks sidebar .nav-item
- * On mobile: uses bottom-nav items or the "More" overflow popup
+ * Put tests directly into a view without exercising navigation UI.
+ * Dedicated navigation specs should exercise user-visible navigation controls.
  */
 async function navigateTo(page, viewName) {
-  const viewport = page.viewportSize();
-  const isMobile = viewport ? viewport.width <= 768 : false;
+  const key = VIEW_KEYS[viewName];
+  if (!key) throw new Error(`Unknown navigation target: ${viewName}`);
 
-  const desktopName = Object.entries(MOBILE_ALIASES)
-    .find(([, mobile]) => mobile === viewName)?.[0] || viewName;
-  const mobileName = MOBILE_ALIASES[viewName] || viewName;
-
-  if (!isMobile) {
-    const desktopItem = page.locator('.nav-item', { hasText: desktopName }).first();
-    if (await desktopItem.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await desktopItem.click();
-      return;
-    }
-    await navigateByHash(page, desktopName);
-    return;
-  }
-
-  // Mobile: prefer the user-visible bottom nav when the target is pinned there.
-  if (!ALWAYS_OVERFLOW.has(viewName)) {
-    const bottomNavItem = page.locator('.bottom-nav-item', { hasText: mobileName });
-    if (await bottomNavItem.isVisible({ timeout: 1000 }).catch(() => false)) {
-      try {
-        await bottomNavItem.click({ timeout: 2000 });
-        return;
-      } catch {
-        await navigateByHash(page, desktopName);
-        return;
-      }
-    }
-  }
-
-  // Then try the mobile drawer opened via the header button.
-  const openMenu = page.getByRole('button', { name: 'Open menu' });
-  if (await openMenu.isVisible({ timeout: 1000 }).catch(() => false)) {
-    await openMenu.click();
-    const drawerItem = page.locator('.nav-item', { hasText: desktopName }).first();
-    if (await drawerItem.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await drawerItem.click();
-      return;
-    }
-    const backdrop = page.locator('.sidebar-backdrop.active');
-    if (await backdrop.isVisible({ timeout: 500 }).catch(() => false)) {
-      await backdrop.click({ force: true });
-      await backdrop.waitFor({ state: 'hidden', timeout: 1000 }).catch(() => {});
-    }
-  }
-
-  // Then try bottom-nav overflow when present.
-  const moreBtn = page.locator('.bottom-nav-item', { hasText: 'More' })
-    .or(page.locator('.bottom-nav .bottom-nav-overflow > button'));
-  if (await moreBtn.first().isVisible({ timeout: 1000 }).catch(() => false)) {
-    await moreBtn.first().click();
-    const overflowItem = page.locator('.bottom-nav-overflow-item', { hasText: mobileName });
-    if (await overflowItem.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await overflowItem.click();
-      return;
-    }
-  }
-
-  // Last-resort test navigation: Tribu treats the hash/session value as
-  // the canonical in-app route. This avoids mobile flakiness where hidden
-  // sidebars are present in the DOM but outside the viewport.
-  await navigateByHash(page, desktopName);
-}
-
-async function navigateByHash(page, label) {
-  const key = VIEW_KEYS[label];
-  if (!key) throw new Error(`Unknown navigation target: ${label}`);
+  await page.locator('#main-content').waitFor({ state: 'attached', timeout: 30000 });
   await page.evaluate((view) => {
     sessionStorage.setItem('tribu_view', view);
     history.pushState(null, '', `#${view}`);
     window.dispatchEvent(new PopStateEvent('popstate'));
   }, key);
+  await page.waitForURL(new RegExp(`#${key}$`), { timeout: 5000 });
 }
 
 module.exports = { navigateTo };

--- a/frontend/e2e/tests/navigation.spec.js
+++ b/frontend/e2e/tests/navigation.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('../helpers/fixtures');
+
+test.describe('Navigation UI', () => {
+  test('desktop sidebar changes views', async ({ authedPage: page }) => {
+    const viewport = page.viewportSize();
+    test.skip(!viewport || viewport.width <= 768, 'Desktop-only sidebar navigation check');
+
+    const sidebarNav = page.locator('.nav-groups');
+    await sidebarNav.locator('.nav-item', { hasText: 'Calendar' }).click();
+    await expect(page.locator('.calendar-grid-wrapper')).toBeVisible({ timeout: 10000 });
+    await expect(sidebarNav.locator('.nav-item.active')).toContainText('Calendar');
+
+    await sidebarNav.locator('.nav-item', { hasText: 'Dashboard' }).click();
+    await expect(page.getByRole('region', { name: 'Quick capture' })).toBeVisible({ timeout: 10000 });
+    await expect(sidebarNav.locator('.nav-item.active')).toContainText('Dashboard');
+  });
+
+  test('mobile bottom nav and menu change views', async ({ authedPage: page }) => {
+    const viewport = page.viewportSize();
+    test.skip(!viewport || viewport.width > 768, 'Mobile-only navigation check');
+
+    const bottomNav = page.locator('.bottom-nav');
+    await bottomNav.locator('.bottom-nav-item', { hasText: 'Plan' }).click();
+    await expect(page.locator('.calendar-grid-wrapper')).toBeVisible({ timeout: 10000 });
+    await expect(bottomNav.locator('.bottom-nav-item.active')).toContainText('Plan');
+
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    const sidebar = page.locator('.sidebar.mobile-open');
+    await expect(sidebar).toBeVisible();
+
+    await sidebar.locator('.nav-item', { hasText: 'Settings' }).click();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible({ timeout: 10000 });
+    await expect(sidebar).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- simplify the shared E2E navigation helper so setup uses Tribu's direct hash/session view route
- remove sidebar, bottom-nav, overflow, and menu click fallback branches from non-navigation setup
- add a focused navigation UI spec for desktop sidebar and mobile bottom-nav/menu behavior

## Checks
- `node -c e2e/helpers/navigation.js`
- `node -c e2e/tests/navigation.spec.js`
- `npx playwright test --list`
- `npm run e2e:local -- e2e/tests/navigation.spec.js`
- `npm run e2e:local -- e2e/tests/gifts.spec.js`
- `npm run e2e:local`
- helper UI selector scan
- `git diff --check`

Closes #387
