### PR TITLE
Centralize frontend test rendering utilities

### DIFF
--- a/frontend/__tests__/components/DashboardDailyLoop.test.js
+++ b/frontend/__tests__/components/DashboardDailyLoop.test.js
@@ -1,31 +1,20 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DashboardView from '../../components/DashboardView';
 import { apiListMealPlans } from '../../lib/api';
-
-let mockAppState = {};
+import { buildMockAppState, buildTestMessages, renderWithMockApp } from '../test-utils';
 
 jest.mock('../../contexts/AppContext', () => ({
-  useApp: () => mockAppState,
+  useApp: () => require('../test-utils').getMockAppState(),
 }));
 
-jest.mock('../../lib/i18n', () => ({
-  t: (messages, key) => messages?.[key] || key,
-}));
-
-jest.mock('../../lib/api', () => ({
-  apiGetDashboardLayout: jest.fn(() => new Promise(() => {})),
-  apiGetSetupChecklist: jest.fn().mockResolvedValue({ ok: true, data: null }),
-  apiListMealPlans: jest.fn(() => Promise.resolve({ ok: true, data: [] })),
-  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
-  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
-}));
+jest.mock('../../lib/api', () => require('../test-utils').createMockApi());
 
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
   return <div data-testid="rewards-widget" />;
 });
 
-const messages = {
+const messages = buildTestMessages({
   'module.dashboard.greeting_morning': 'Good morning',
   'module.dashboard.greeting_afternoon': 'Good afternoon',
   'module.dashboard.greeting_evening': 'Good evening',
@@ -34,7 +23,6 @@ const messages = {
   'module.dashboard.all': 'All',
   'module.dashboard.empty_events': 'No upcoming events',
   'module.dashboard.empty_tasks': 'All done!',
-  'module.dashboard.empty_tasks_action': 'Create task',
   'module.tasks.no_tasks': 'No tasks yet',
   'module.dashboard.empty_birthdays': 'No birthdays',
   'module.dashboard.days': 'days',
@@ -57,7 +45,7 @@ const messages = {
   'module.dashboard.daily_loop_open_routines': 'Open routines',
   next_events: 'Next events',
   upcoming_birthdays_4w: 'Birthdays',
-};
+});
 
 function todayIso() {
   const d = new Date();
@@ -67,7 +55,7 @@ function todayIso() {
 }
 
 function baseApp(overrides = {}) {
-  return {
+  return buildMockAppState({
     summary: { next_events: [], upcoming_birthdays: [] },
     me: { display_name: 'Dennis' },
     members: [{ user_id: 1, display_name: 'Dennis' }],
@@ -77,28 +65,23 @@ function baseApp(overrides = {}) {
     ],
     events: [],
     shoppingLists: [{ id: 1, item_count: 4, checked_count: 1 }],
-    quickCaptureInbox: [],
-    familyId: 42,
-    setActiveView: jest.fn(),
     messages,
-    lang: 'en',
-    timeFormat: '24h',
-    isChild: false,
-    isAdmin: false,
-    demoMode: false,
     ...overrides,
-  };
+  });
+}
+
+function renderDashboard(overrides = {}) {
+  return renderWithMockApp(<DashboardView />, baseApp(overrides));
 }
 
 describe('DashboardView daily loop', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockAppState = baseApp();
     apiListMealPlans.mockResolvedValue({ ok: true, data: [{ id: 1 }, { id: 2 }] });
   });
 
   it('renders the Today loop directly after quick capture with visual action tiles', async () => {
-    const { container } = render(<DashboardView />);
+    const { container } = renderDashboard();
 
     const modules = Array.from(container.querySelectorAll('.bento-grid > [data-dashboard-module]')).map((module) => module.getAttribute('data-dashboard-module'));
     expect(modules.slice(0, 3)).toEqual(['quick_capture', 'daily_loop', 'events']);
@@ -114,9 +97,8 @@ describe('DashboardView daily loop', () => {
 
   it('routes daily loop tiles to their owning views', () => {
     const setActiveView = jest.fn();
-    mockAppState = baseApp({ setActiveView, familyId: null });
+    renderDashboard({ setActiveView, familyId: null });
 
-    render(<DashboardView />);
     const loop = screen.getByRole('region', { name: 'Today loop' });
 
     fireEvent.click(within(loop).getByRole('button', { name: /Meals planned/i }));
@@ -130,14 +112,12 @@ describe('DashboardView daily loop', () => {
 
   it('keeps daily loop compact when there are no active inputs', async () => {
     apiListMealPlans.mockResolvedValue({ ok: true, data: [] });
-    mockAppState = baseApp({
+    renderDashboard({
       tasks: [
         { id: 1, title: 'Future routine', status: 'open', recurrence: 'weekly', due_date: '2999-01-01T08:00:00' },
       ],
       shoppingLists: [],
     });
-
-    render(<DashboardView />);
 
     const loop = screen.getByRole('region', { name: 'Today loop' });
     await waitFor(() => expect(within(loop).getByRole('button', { name: /Meals planned: Plan meals/i })).toHaveTextContent('0'));

--- a/frontend/__tests__/components/DashboardTodayStatus.test.js
+++ b/frontend/__tests__/components/DashboardTodayStatus.test.js
@@ -1,26 +1,21 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DashboardView from '../../components/DashboardView';
-
-let mockAppState = {};
+import { buildMockAppState, buildTestMessages, renderWithMockApp } from '../test-utils';
 
 jest.mock('../../contexts/AppContext', () => ({
-  useApp: () => mockAppState,
+  useApp: () => require('../test-utils').getMockAppState(),
 }));
 
-jest.mock('../../lib/api', () => ({
-  apiGetDashboardLayout: jest.fn(() => new Promise(() => {})),
-  apiGetSetupChecklist: jest.fn().mockResolvedValue({ ok: true, data: null }),
-  apiListMealPlans: jest.fn(() => Promise.resolve({ ok: true, data: [{ id: 1, plan_date: '2030-01-01', slot: 'evening' }] })),
-  apiResetDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
-  apiUpdateDashboardLayout: jest.fn(() => Promise.resolve({ ok: true, data: { modules: ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'] } })),
+jest.mock('../../lib/api', () => require('../test-utils').createMockApi({
+  apiListMealPlans: jest.fn(() => new Promise(() => {})),
 }));
 
 jest.mock('../../components/RewardsDashboardWidget', () => function RewardsDashboardWidget() {
   return <div data-testid="rewards-widget" />;
 });
 
-const messages = {
+const messages = buildTestMessages({
   'module.dashboard.greeting_morning': 'Good morning',
   'module.dashboard.greeting_afternoon': 'Good afternoon',
   'module.dashboard.greeting_evening': 'Good evening',
@@ -29,7 +24,6 @@ const messages = {
   'module.dashboard.all': 'All',
   'module.dashboard.empty_events': 'No upcoming events',
   'module.dashboard.empty_tasks': 'All done!',
-  'module.dashboard.empty_tasks_action': 'Create task',
   'module.tasks.no_tasks': 'No tasks yet',
   'module.dashboard.empty_birthdays': 'No birthdays',
   'module.dashboard.days': 'days',
@@ -54,7 +48,7 @@ const messages = {
   'module.dashboard.daily_loop_open_routines': 'Open routines',
   next_events: 'Next events',
   upcoming_birthdays_4w: 'Birthdays',
-};
+});
 
 function isoDate(offsetDays = 0) {
   const d = new Date();
@@ -65,34 +59,29 @@ function isoDate(offsetDays = 0) {
 }
 
 function baseApp(overrides = {}) {
-  return {
+  return buildMockAppState({
     summary: { next_events: [], upcoming_birthdays: [{ person_name: 'Grandma', days_until: 5, occurs_on: 'May 17' }] },
     me: { display_name: 'Dennis' },
     members: [{ user_id: 1, display_name: 'Dennis' }],
     tasks: [{ id: 1, title: 'Take out bins', status: 'open' }],
     events: [{ id: 1, title: 'School', starts_at: `${isoDate()}T08:00:00` }],
     shoppingLists: [{ id: 1, item_count: 5, checked_count: 2 }],
-    activity: [],
-    familyId: 42,
-    families: [],
-    setActiveView: jest.fn(),
     messages,
-    lang: 'en',
-    timeFormat: '24h',
-    isChild: false,
-    isAdmin: false,
-    demoMode: false,
     ...overrides,
-  };
+  });
+}
+
+function renderDashboard(overrides = {}) {
+  return renderWithMockApp(<DashboardView />, baseApp(overrides));
 }
 
 describe('DashboardView today status', () => {
   beforeEach(() => {
-    mockAppState = baseApp();
+    jest.clearAllMocks();
   });
 
   it('summarizes today status while keeping the daily loop as its own section', () => {
-    render(<DashboardView />);
+    renderDashboard();
 
     const status = screen.getByRole('group', { name: 'Today status' });
     expect(within(status).getByTestId('today-status-events')).toHaveTextContent('1');
@@ -104,9 +93,7 @@ describe('DashboardView today status', () => {
 
   it('navigates from today status tiles to their owning modules', () => {
     const setActiveView = jest.fn();
-    mockAppState = baseApp({ setActiveView });
-
-    render(<DashboardView />);
+    renderDashboard({ setActiveView });
 
     const status = screen.getByRole('group', { name: 'Today status' });
     fireEvent.click(within(status).getByRole('button', { name: /Events/i }));
@@ -121,7 +108,7 @@ describe('DashboardView today status', () => {
   });
 
   it('keeps household activity out of the permanent dashboard layout', () => {
-    mockAppState = baseApp({
+    renderDashboard({
       activity: [{
         id: 1,
         actor_display_name: 'Dennis',
@@ -129,8 +116,6 @@ describe('DashboardView today status', () => {
         created_at: '2026-04-29T10:00:00Z',
       }],
     });
-
-    render(<DashboardView />);
 
     expect(screen.queryByRole('region', { name: 'Recent activity' })).not.toBeInTheDocument();
     expect(screen.queryByText('Dennis completed task "Pay school lunch"')).not.toBeInTheDocument();

--- a/frontend/__tests__/components/NotificationCenter.test.js
+++ b/frontend/__tests__/components/NotificationCenter.test.js
@@ -1,52 +1,38 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import NotificationCenter from '../../components/NotificationCenter';
-import { buildMessages } from '../../lib/i18n';
 import * as api from '../../lib/api';
+import { buildTestMessages, renderWithMockApp } from '../test-utils';
 
-let mockAppState = {};
-
-jest.mock('../../lib/api', () => ({
-  apiMarkNotificationRead: jest.fn(),
-  apiMarkAllNotificationsRead: jest.fn(),
-  apiDeleteNotification: jest.fn(),
-}));
+jest.mock('../../lib/api', () => require('../test-utils').createMockApi());
 
 jest.mock('../../contexts/AppContext', () => ({
-  useApp: () => mockAppState,
+  useApp: () => require('../test-utils').getMockAppState(),
 }));
 
-function baseState(overrides = {}) {
-  return {
-    messages: buildMessages('en'),
+function renderCenter(overrides = {}) {
+  return renderWithMockApp(<NotificationCenter />, {
+    messages: buildTestMessages(),
     lang: 'en',
-    notifications: [],
-    setNotifications: jest.fn(),
-    unreadCount: 0,
-    setUnreadCount: jest.fn(),
-    loadNotifications: jest.fn(),
-    setActiveView: jest.fn(),
     isAdmin: true,
     isChild: false,
     demoMode: false,
     ...overrides,
-  };
+  });
 }
 
 describe('NotificationCenter external destination callout', () => {
   beforeEach(() => {
     sessionStorage.clear();
+    jest.clearAllMocks();
     api.apiMarkNotificationRead.mockResolvedValue({ ok: true });
     api.apiMarkAllNotificationsRead.mockResolvedValue({ ok: true });
     api.apiDeleteNotification.mockResolvedValue({ ok: true });
-    mockAppState = baseState();
   });
 
   it('links admins from the notifications page to household notification destinations', () => {
     const setActiveView = jest.fn();
-    mockAppState = baseState({ setActiveView });
-
-    render(<NotificationCenter />);
+    renderCenter({ setActiveView });
 
     fireEvent.click(screen.getByRole('button', { name: 'Configure household notifications' }));
 
@@ -55,16 +41,14 @@ describe('NotificationCenter external destination callout', () => {
   });
 
   it('does not show the destination callout to non-admins', () => {
-    mockAppState = baseState({ isAdmin: false });
-
-    render(<NotificationCenter />);
+    renderCenter({ isAdmin: false });
 
     expect(screen.queryByRole('button', { name: 'Configure household notifications' })).not.toBeInTheDocument();
   });
 
   it('localizes scheduler notification body fallbacks', () => {
-    mockAppState = baseState({
-      messages: buildMessages('de'),
+    renderCenter({
+      messages: buildTestMessages({}, 'de'),
       lang: 'de',
       notifications: [
         {
@@ -94,8 +78,6 @@ describe('NotificationCenter external destination callout', () => {
       ],
     });
 
-    render(<NotificationCenter />);
-
     expect(screen.getByText('Beginnt in 15 Minuten')).toBeVisible();
     expect(screen.getByText('Aufgabe ist überfällig')).toBeVisible();
     expect(screen.getByText('Geburtstag morgen (May 13)')).toBeVisible();
@@ -105,7 +87,7 @@ describe('NotificationCenter external destination callout', () => {
 
   it('normalizes concrete notification links to the owning PWA view', () => {
     const setActiveView = jest.fn();
-    mockAppState = baseState({
+    renderCenter({
       setActiveView,
       notifications: [
         {
@@ -120,8 +102,6 @@ describe('NotificationCenter external destination callout', () => {
       ],
     });
 
-    render(<NotificationCenter />);
-
     fireEvent.click(screen.getByRole('button', { name: /Musikschule/i }));
 
     expect(setActiveView).toHaveBeenCalledWith('calendar');
@@ -129,7 +109,7 @@ describe('NotificationCenter external destination callout', () => {
 
   it('routes birthday notification links to contacts in the PWA', () => {
     const setActiveView = jest.fn();
-    mockAppState = baseState({
+    renderCenter({
       setActiveView,
       notifications: [
         {
@@ -143,8 +123,6 @@ describe('NotificationCenter external destination callout', () => {
         },
       ],
     });
-
-    render(<NotificationCenter />);
 
     fireEvent.click(screen.getByRole('button', { name: /Oma/i }));
 

--- a/frontend/__tests__/components/NotificationsTab.test.js
+++ b/frontend/__tests__/components/NotificationsTab.test.js
@@ -1,26 +1,26 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import NotificationsTab from '../../components/settings/NotificationsTab';
-import { buildMessages } from '../../lib/i18n';
 import * as api from '../../lib/api';
 import usePushSubscription from '../../hooks/usePushSubscription';
+import { buildTestMessages, createMockToast, resetMockAppState } from '../test-utils';
 
-let mockAppState = {};
-const toastSuccess = jest.fn();
+let mockToast;
 
 jest.mock('../../lib/api');
 jest.mock('../../hooks/usePushSubscription');
 jest.mock('../../contexts/AppContext', () => ({
-  useApp: () => mockAppState,
+  useApp: () => require('../test-utils').getMockAppState(),
 }));
 jest.mock('../../contexts/ToastContext', () => ({
-  useToast: () => ({ success: toastSuccess }),
+  useToast: () => mockToast,
 }));
 
 describe('NotificationsTab push diagnostics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockAppState = { messages: buildMessages('en'), loggedIn: true, demoMode: false };
+    mockToast = createMockToast();
+    resetMockAppState({ messages: buildTestMessages(), loggedIn: true, demoMode: false });
     api.apiGetNotificationPreferences.mockResolvedValue({
       ok: true,
       data: {

--- a/frontend/__tests__/components/RewardsDashboardWidget.test.js
+++ b/frontend/__tests__/components/RewardsDashboardWidget.test.js
@@ -1,10 +1,10 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import RewardsDashboardWidget from '../../components/RewardsDashboardWidget';
+import { buildMockAppState, renderWithMockApp } from '../test-utils';
 
-let mockAppState = {};
 jest.mock('../../contexts/AppContext', () => ({
-  useApp: () => mockAppState,
+  useApp: () => require('../test-utils').getMockAppState(),
 }));
 
 let mockRewards = {};
@@ -20,13 +20,12 @@ const messages = {
 };
 
 function baseApp(overrides = {}) {
-  return {
+  return buildMockAppState({
     messages,
     isChild: false,
     members: [{ user_id: 2, display_name: 'Mia', is_adult: false }],
-    setActiveView: jest.fn(),
     ...overrides,
-  };
+  });
 }
 
 function baseRewards(overrides = {}) {
@@ -41,14 +40,17 @@ function baseRewards(overrides = {}) {
   };
 }
 
+function renderWidget(overrides = {}) {
+  return renderWithMockApp(<RewardsDashboardWidget />, baseApp(overrides));
+}
+
 describe('RewardsDashboardWidget', () => {
   beforeEach(() => {
-    mockAppState = baseApp();
     mockRewards = baseRewards();
   });
 
   test('renders translated view-all action instead of the raw key', () => {
-    render(<RewardsDashboardWidget />);
+    renderWidget();
 
     expect(screen.getByRole('button', { name: 'Alle anzeigen' })).toBeInTheDocument();
     expect(screen.queryByText('view_all')).not.toBeInTheDocument();
@@ -56,9 +58,8 @@ describe('RewardsDashboardWidget', () => {
 
   test('view-all action opens the rewards view', () => {
     const setActiveView = jest.fn();
-    mockAppState = baseApp({ setActiveView });
+    renderWidget({ setActiveView });
 
-    render(<RewardsDashboardWidget />);
     fireEvent.click(screen.getByRole('button', { name: 'Alle anzeigen' }));
 
     expect(setActiveView).toHaveBeenCalledWith('rewards');
@@ -67,7 +68,7 @@ describe('RewardsDashboardWidget', () => {
   test('keeps the dashboard card visible before a reward currency is configured', () => {
     mockRewards = baseRewards({ currency: null, balances: [] });
 
-    render(<RewardsDashboardWidget />);
+    renderWidget();
 
     expect(screen.getByRole('heading', { name: 'Belohnungen' })).toBeInTheDocument();
     expect(screen.getByText('Noch keine Belohnungs-Währung eingerichtet.')).toBeInTheDocument();

--- a/frontend/__tests__/test-utils/index.js
+++ b/frontend/__tests__/test-utils/index.js
@@ -1,0 +1,87 @@
+import { render } from '@testing-library/react';
+import { buildMessages } from '../../lib/i18n';
+
+let mockAppState = {};
+
+export const DASHBOARD_MODULES = ['quick_capture', 'daily_loop', 'events', 'tasks', 'birthdays', 'rewards'];
+
+export function buildTestMessages(overrides = {}, lang = 'en') {
+  return {
+    ...buildMessages(lang),
+    ...overrides,
+  };
+}
+
+export function buildMockAppState(overrides = {}) {
+  return {
+    messages: buildTestMessages(),
+    lang: 'en',
+    summary: { next_events: [], upcoming_birthdays: [] },
+    me: { display_name: 'Dennis' },
+    members: [],
+    tasks: [],
+    events: [],
+    shoppingLists: [],
+    activity: [],
+    quickCaptureInbox: [],
+    notifications: [],
+    unreadCount: 0,
+    familyId: 42,
+    families: [],
+    isAdmin: false,
+    isChild: false,
+    demoMode: false,
+    loggedIn: true,
+    timeFormat: '24h',
+    setActiveView: jest.fn(),
+    setNotifications: jest.fn(),
+    setUnreadCount: jest.fn(),
+    loadNotifications: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function setMockAppState(nextState) {
+  mockAppState = nextState;
+  return mockAppState;
+}
+
+export function resetMockAppState(overrides = {}) {
+  return setMockAppState(buildMockAppState(overrides));
+}
+
+export function getMockAppState() {
+  return mockAppState;
+}
+
+export function renderWithMockApp(ui, appOverrides = {}, renderOptions) {
+  const appState = resetMockAppState(appOverrides);
+  return {
+    appState,
+    ...render(ui, renderOptions),
+  };
+}
+
+export function createMockApi(overrides = {}) {
+  return {
+    apiGetDashboardLayout: jest.fn(() => new Promise(() => {})),
+    apiGetSetupChecklist: jest.fn().mockResolvedValue({ ok: true, data: null }),
+    apiListMealPlans: jest.fn().mockResolvedValue({ ok: true, data: [] }),
+    apiResetDashboardLayout: jest.fn().mockResolvedValue({ ok: true, data: { modules: DASHBOARD_MODULES } }),
+    apiUpdateDashboardLayout: jest.fn().mockResolvedValue({ ok: true, data: { modules: DASHBOARD_MODULES } }),
+    apiMarkNotificationRead: jest.fn().mockResolvedValue({ ok: true }),
+    apiMarkAllNotificationsRead: jest.fn().mockResolvedValue({ ok: true }),
+    apiDeleteNotification: jest.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  };
+}
+
+export function createMockToast(overrides = {}) {
+  return {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+    ...overrides,
+  };
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -4,7 +4,7 @@ const createJestConfig = nextJest({ dir: './' });
 
 module.exports = createJestConfig({
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['/node_modules/', '/e2e/', '/.next/'],
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/', '/.next/', '/__tests__/test-utils/'],
   modulePathIgnorePatterns: ['<rootDir>/.next/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',


### PR DESCRIPTION
## Summary
- add a shared frontend test utility for AppContext state, render setup, messages, API defaults, and toast mocks
- convert representative component tests to use the shared setup while keeping scenario data inline
- keep Jest from collecting helper modules as empty test suites

## Checks
- `npm test -- --runInBand __tests__/components/DashboardTodayStatus.test.js __tests__/components/DashboardDailyLoop.test.js __tests__/components/RewardsDashboardWidget.test.js __tests__/components/NotificationCenter.test.js __tests__/components/NotificationsTab.test.js`
- `npm test -- --runInBand __tests__/components/NotificationsTab.test.js`
- `npm test`
- `git diff --check`

Closes #388
