### PR TITLE
refactor: collapse shopping websocket broadcasts

### DIFF
--- a/backend/app/core/ws_broadcast.py
+++ b/backend/app/core/ws_broadcast.py
@@ -8,13 +8,14 @@ event loop reference at startup and use `asyncio.run_coroutine_threadsafe`.
 import asyncio
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 from app.core.ws_manager import manager
 
 logger = logging.getLogger(__name__)
 
 _loop: asyncio.AbstractEventLoop | None = None
+ShoppingBroadcastScope = Literal["list", "family"]
 
 
 def set_event_loop(loop: asyncio.AbstractEventLoop):
@@ -30,25 +31,18 @@ def _fire(coro_factory: Callable[[], Any]):
     asyncio.run_coroutine_threadsafe(coro_factory(), _loop)
 
 
-def broadcast_item_added(list_id: int, item: dict):
-    _fire(lambda: manager.broadcast(list_id, {"type": "item_added", "item": item}))
-
-
-def broadcast_item_updated(list_id: int, item: dict):
-    _fire(lambda: manager.broadcast(list_id, {"type": "item_updated", "item": item}))
-
-
-def broadcast_item_deleted(list_id: int, item_id: int):
-    _fire(lambda: manager.broadcast(list_id, {"type": "item_deleted", "item_id": item_id}))
-
-
-def broadcast_items_cleared(list_id: int, deleted_count: int):
-    _fire(lambda: manager.broadcast(list_id, {"type": "items_cleared", "list_id": list_id, "deleted_count": deleted_count}))
-
-
-def broadcast_list_created(family_id: int, list_data: dict):
-    _fire(lambda: manager.broadcast_to_family(family_id, {"type": "list_created", "list": list_data}))
-
-
-def broadcast_list_deleted(family_id: int, list_id: int):
-    _fire(lambda: manager.broadcast_to_family(family_id, {"type": "list_deleted", "list_id": list_id}))
+def broadcast_shopping_event(
+    scope: ShoppingBroadcastScope,
+    scope_id: int,
+    event_type: str,
+    payload: dict[str, Any],
+):
+    """Broadcast a shopping WebSocket event to a list or family scope."""
+    event = {"type": event_type, **payload}
+    if scope == "list":
+        _fire(lambda: manager.broadcast(scope_id, event))
+        return
+    if scope == "family":
+        _fire(lambda: manager.broadcast_to_family(scope_id, event))
+        return
+    raise ValueError(f"Unsupported shopping broadcast scope: {scope}")

--- a/backend/app/modules/meal_plans_router.py
+++ b/backend/app/modules/meal_plans_router.py
@@ -28,7 +28,7 @@ from app.core.errors import (
 )
 from app.core.scopes import require_scope
 from app.core.shopping_notifications import dispatch_shopping_destination_event
-from app.core.ws_broadcast import broadcast_item_added
+from app.core.ws_broadcast import broadcast_shopping_event
 from app.database import get_db
 from app.models import MealPlan, Membership, ShoppingItem, ShoppingList, User
 from app.schemas import (
@@ -470,9 +470,11 @@ def add_week_ingredients_to_shopping(
     db.commit()
     for item in created:
         db.refresh(item)
-        broadcast_item_added(
+        broadcast_shopping_event(
+            "list",
             shopping_list.id,
-            ShoppingItemResponse.model_validate(item).model_dump(mode="json"),
+            "item_added",
+            {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
         )
     if created:
         dispatch_shopping_destination_event(
@@ -552,9 +554,11 @@ def add_ingredients_to_shopping(
     db.commit()
     for item in created:
         db.refresh(item)
-        broadcast_item_added(
+        broadcast_shopping_event(
+            "list",
             shopping_list.id,
-            ShoppingItemResponse.model_validate(item).model_dump(mode="json"),
+            "item_added",
+            {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
         )
     if created:
         dispatch_shopping_destination_event(

--- a/backend/app/modules/recipes_router.py
+++ b/backend/app/modules/recipes_router.py
@@ -21,7 +21,7 @@ from app.core.errors import (
 )
 from app.core.scopes import require_scope
 from app.core.shopping_notifications import dispatch_shopping_destination_event
-from app.core.ws_broadcast import broadcast_item_added
+from app.core.ws_broadcast import broadcast_shopping_event
 from app.database import get_db
 from app.models import Membership, Recipe, ShoppingItem, ShoppingList, User
 from app.schemas import (
@@ -372,9 +372,11 @@ def add_recipe_ingredients_to_shopping(
     db.commit()
     for item in created:
         db.refresh(item)
-        broadcast_item_added(
+        broadcast_shopping_event(
+            "list",
             shopping_list.id,
-            ShoppingItemResponse.model_validate(item).model_dump(mode="json"),
+            "item_added",
+            {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
         )
     if created:
         dispatch_shopping_destination_event(

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -8,14 +8,7 @@ from app.core.activity import record_activity
 from app.core.scopes import require_scope
 from app.database import get_db
 from app.models import ShoppingItem, ShoppingList, ShoppingTemplate, ShoppingTemplateItem, User
-from app.core.ws_broadcast import (
-    broadcast_item_added,
-    broadcast_item_deleted,
-    broadcast_item_updated,
-    broadcast_items_cleared,
-    broadcast_list_created,
-    broadcast_list_deleted,
-)
+from app.core.ws_broadcast import broadcast_shopping_event
 from app.core.shopping_notifications import dispatch_shopping_destination_event
 from app.core.webhooks import dispatch_webhook_event
 from app.schemas import (
@@ -257,7 +250,12 @@ def apply_template(
     db.commit()
     for item in created_items:
         db.refresh(item)
-        broadcast_item_added(sl.id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
+        broadcast_shopping_event(
+            "list",
+            sl.id,
+            "item_added",
+            {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
+        )
     if created_items:
         dispatch_shopping_destination_event(
             family_id=sl.family_id,
@@ -335,7 +333,12 @@ def create_list(
     db.commit()
     db.refresh(sl)
     resp = _list_response(sl)
-    broadcast_list_created(sl.family_id, resp.model_dump(mode="json"))
+    broadcast_shopping_event(
+        "family",
+        sl.family_id,
+        "list_created",
+        {"list": resp.model_dump(mode="json")},
+    )
     dispatch_webhook_event(
         db,
         family_id=sl.family_id,
@@ -376,7 +379,7 @@ def delete_list(
     list_name = sl.name
     db.delete(sl)
     db.commit()
-    broadcast_list_deleted(family_id, list_id)
+    broadcast_shopping_event("family", family_id, "list_deleted", {"list_id": list_id})
     dispatch_shopping_destination_event(
         family_id=family_id,
         event_type="shopping.list.changed",
@@ -462,7 +465,7 @@ def add_item(
         db.commit()
         db.refresh(checked_match)
         resp = ShoppingItemResponse.model_validate(checked_match).model_dump(mode="json")
-        broadcast_item_updated(list_id, resp)
+        broadcast_shopping_event("list", list_id, "item_updated", {"item": resp})
         dispatch_webhook_event(
             db,
             family_id=sl.family_id,
@@ -504,7 +507,12 @@ def add_item(
     )
     db.commit()
     db.refresh(item)
-    broadcast_item_added(list_id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
+    broadcast_shopping_event(
+        "list",
+        list_id,
+        "item_added",
+        {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
+    )
     dispatch_webhook_event(
         db,
         family_id=sl.family_id,
@@ -574,7 +582,12 @@ def update_item(
 
     db.commit()
     db.refresh(item)
-    broadcast_item_updated(item.list_id, ShoppingItemResponse.model_validate(item).model_dump(mode="json"))
+    broadcast_shopping_event(
+        "list",
+        item.list_id,
+        "item_updated",
+        {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
+    )
     dispatch_webhook_event(
         db,
         family_id=sl.family_id,
@@ -622,7 +635,7 @@ def delete_item(
     item_name = item.name
     db.delete(item)
     db.commit()
-    broadcast_item_deleted(list_id, item_id)
+    broadcast_shopping_event("list", list_id, "item_deleted", {"item_id": item_id})
     dispatch_shopping_destination_event(
         family_id=sl.family_id,
         event_type="shopping.item.changed",
@@ -658,7 +671,12 @@ def clear_checked(
         ShoppingItem.checked,
     ).delete(synchronize_session="fetch")
     db.commit()
-    broadcast_items_cleared(list_id, deleted)
+    broadcast_shopping_event(
+        "list",
+        list_id,
+        "items_cleared",
+        {"list_id": list_id, "deleted_count": deleted},
+    )
     if deleted:
         dispatch_shopping_destination_event(
             family_id=sl.family_id,

--- a/backend/tests/test_ws_broadcast.py
+++ b/backend/tests/test_ws_broadcast.py
@@ -1,0 +1,69 @@
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from app.core import ws_broadcast
+
+
+class FakeShoppingManager:
+    def __init__(self):
+        self.calls = []
+
+    async def broadcast(self, list_id, event):
+        self.calls.append(("list", list_id, event))
+
+    async def broadcast_to_family(self, family_id, event):
+        self.calls.append(("family", family_id, event))
+
+
+@pytest.fixture
+def captured_broadcasts(monkeypatch):
+    manager = FakeShoppingManager()
+    monkeypatch.setattr(ws_broadcast, "manager", manager)
+    monkeypatch.setattr(ws_broadcast, "_loop", object())
+
+    def run_now(coro, _loop):
+        asyncio.run(coro)
+
+    monkeypatch.setattr(ws_broadcast.asyncio, "run_coroutine_threadsafe", run_now)
+    return manager.calls
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload", "expected_event"),
+    [
+        ("item_added", {"item": {"id": 10, "name": "Milk"}}, {"type": "item_added", "item": {"id": 10, "name": "Milk"}}),
+        ("item_updated", {"item": {"id": 11, "checked": True}}, {"type": "item_updated", "item": {"id": 11, "checked": True}}),
+        ("item_deleted", {"item_id": 12}, {"type": "item_deleted", "item_id": 12}),
+        (
+            "items_cleared",
+            {"list_id": 42, "deleted_count": 3},
+            {"type": "items_cleared", "list_id": 42, "deleted_count": 3},
+        ),
+    ],
+)
+def test_broadcast_shopping_event_keeps_list_event_payloads(captured_broadcasts, event_type, payload, expected_event):
+    ws_broadcast.broadcast_shopping_event("list", 42, event_type, payload)
+
+    assert captured_broadcasts == [("list", 42, expected_event)]
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload", "expected_event"),
+    [
+        ("list_created", {"list": {"id": 42, "name": "Groceries"}}, {"type": "list_created", "list": {"id": 42, "name": "Groceries"}}),
+        ("list_deleted", {"list_id": 42}, {"type": "list_deleted", "list_id": 42}),
+    ],
+)
+def test_broadcast_shopping_event_keeps_family_event_payloads(captured_broadcasts, event_type, payload, expected_event):
+    ws_broadcast.broadcast_shopping_event("family", 7, event_type, payload)
+
+    assert captured_broadcasts == [("family", 7, expected_event)]
+
+
+def test_broadcast_shopping_event_rejects_unknown_scope(captured_broadcasts):
+    with pytest.raises(ValueError, match="Unsupported shopping broadcast scope"):
+        ws_broadcast.broadcast_shopping_event(cast(Any, "household"), 7, "list_created", {})
+
+    assert captured_broadcasts == []


### PR DESCRIPTION
## Summary
- Replace the shopping WebSocket broadcast one-line wrappers with one scoped helper.
- Keep the existing shopping event names and payload envelopes for list and family broadcasts.
- Add focused coverage for every shopping WebSocket event shape and invalid scope handling.

## Verification
- `DATABASE_URL=sqlite:///./test-392-shopping.db JWT_SECRET=... python -m pytest tests/test_ws_broadcast.py tests/test_shopping_ws_auth.py tests/test_shopping_item_reuse.py tests/test_shopping_templates.py -q` → 15 passed
- `DATABASE_URL=sqlite:///./test-392-recipes.db JWT_SECRET=... python -m pytest tests/test_recipes.py -q` → 9 passed
- `DATABASE_URL=sqlite:///./test-392-mealplans.db JWT_SECRET=... python -m pytest tests/test_meal_plans.py -q` → 21 passed
- `npm test -- --runTestsByPath __tests__/hooks/useWebSocket.test.js __tests__/hooks/useShoppingHelpers.test.js __tests__/components/ShoppingView.test.js --runInBand` → 16 passed
- Backend workflow subset run by file: cors 2 passed, mobile auth 3 passed, OIDC flow 28 passed
- `git diff --check`

Closes #392
