### PR TITLE
Harden runtime calendar and deployment defaults

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,32 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  backend-tests:
+    name: Backend release-contract tests
+    uses: ./.github/workflows/backend-tests.yml
+
+  frontend-tests:
+    name: Frontend unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Run frontend tests
+        working-directory: frontend
+        run: npm test -- --runInBand
+
   build:
     name: Build ${{ matrix.component }} image
+    needs: [backend-tests, frontend-tests]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -175,13 +175,19 @@ volumes:
   tribu_backups:
 ```
 
-Set the required secrets before deploying. Set `TZ` as well when you want family calendar times and reminders to use a local household timezone instead of UTC:
+Set the required secrets before deploying. The public Compose stack exposes only the frontend by default; the backend stays reachable to the frontend on the internal Docker network.
+
+Set `TZ` when you want family calendar times, task due dates, reminder windows, and quiet hours to use a local household timezone instead of UTC. Audit and technical session timestamps remain UTC.
 
 | Variable | Description |
 |---|---|
 | `JWT_SECRET` | Random 64-character hex string for JWT signing. Keep it stable in the persisted `.env` so routine updates do not end active sessions. |
 | `POSTGRES_PASSWORD` | Random 32-character hex string for the database. |
 | `TZ` | Optional IANA timezone for family calendar/task times and reminder windows, for example `Europe/Berlin`. If unset or invalid, Tribu falls back to UTC. Audit timestamps remain UTC. |
+| `CORS_ALLOWED_ORIGINS` | Optional comma-separated exact browser origins for deployments that call the backend directly. The default allows localhost development origins only. |
+| `CORS_ALLOW_LAN_ORIGINS` | Optional `true` to allow `192.168.x.x` browser origins when you deliberately expose the backend on a LAN. |
+| `TRUSTED_PROXY_CIDRS` | Optional comma-separated proxy CIDRs whose `X-Forwarded-For` header may be used for login/register rate-limit keys. Leave unset unless a trusted reverse proxy sits in front of the backend. |
+| `SUBSCRIPTIONS_ALLOW_PRIVATE_NETWORKS` | Optional `true` to let ICS calendar subscriptions fetch private/LAN feed URLs such as a self-hosted calendar server. Leave `false` unless you trust the feed targets. |
 
 Generate the values and write them into `.env`:
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,5 +27,7 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 8000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=3).read()" || exit 1
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/backend/app/core/calendar_subscriptions.py
+++ b/backend/app/core/calendar_subscriptions.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import http.client
 import ipaddress
+import os
 import socket
 import ssl
 import urllib.parse
@@ -78,8 +79,16 @@ def _is_disallowed_ip(raw_ip: str) -> bool:
     )
 
 
-def _public_addrinfo(parsed: urllib.parse.ParseResult) -> tuple[int, int, int, tuple]:
-    """Resolve once and return a public route target for the outbound request."""
+def subscriptions_allow_private_networks() -> bool:
+    return os.getenv("SUBSCRIPTIONS_ALLOW_PRIVATE_NETWORKS", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _route_addrinfo(
+    parsed: urllib.parse.ParseResult,
+    *,
+    allow_private_networks: bool = False,
+) -> tuple[int, int, int, tuple]:
+    """Resolve once and return an allowed route target for the outbound request."""
     hostname = parsed.hostname
     if not hostname:
         raise IcsSubscriptionError("Subscription URL is missing a host")
@@ -91,17 +100,24 @@ def _public_addrinfo(parsed: urllib.parse.ParseResult) -> tuple[int, int, int, t
     if not addresses:
         raise IcsSubscriptionError("Subscription URL host could not be resolved")
 
-    public_addresses = []
+    allowed_addresses = []
     for family, socktype, proto, _canonname, sockaddr in addresses:
         if family not in (socket.AF_INET, socket.AF_INET6):
             continue
-        if _is_disallowed_ip(sockaddr[0]):
+        if not allow_private_networks and _is_disallowed_ip(sockaddr[0]):
             continue
-        public_addresses.append((family, socktype, proto, sockaddr))
+        allowed_addresses.append((family, socktype, proto, sockaddr))
 
-    if not public_addresses:
+    if not allowed_addresses:
         raise IcsSubscriptionError("Subscription URL host is not allowed")
-    return public_addresses[0]
+    return allowed_addresses[0]
+
+
+def validate_http_url_route(url: str, *, allow_private_networks: bool = False) -> str:
+    """Validate scheme, host, resolution, and private-network policy for egress."""
+    target = validate_subscription_url(url)
+    _route_addrinfo(_parse_subscription_url(target), allow_private_networks=allow_private_networks)
+    return target
 
 
 def hostname_from_url(url: str) -> str:
@@ -126,6 +142,7 @@ def fetch_ics_text(
     *,
     max_bytes: int = _MAX_ICS_BYTES,
     timeout: float = _FETCH_TIMEOUT,
+    allow_private_networks: bool | None = None,
 ) -> str:
     """Fetch ``url`` and return its body as text.
 
@@ -135,7 +152,12 @@ def fetch_ics_text(
     """
     target = validate_subscription_url(url)
     parsed = _parse_subscription_url(target)
-    family, socktype, proto, sockaddr = _public_addrinfo(parsed)
+    if allow_private_networks is None:
+        allow_private_networks = subscriptions_allow_private_networks()
+    family, socktype, proto, sockaddr = _route_addrinfo(
+        parsed,
+        allow_private_networks=allow_private_networks,
+    )
     host = parsed.hostname or ""
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
     path = urllib.parse.urlunparse(("", "", parsed.path or "/", parsed.params, parsed.query, ""))

--- a/backend/app/core/recurrence.py
+++ b/backend/app/core/recurrence.py
@@ -13,7 +13,7 @@ VALID_RECURRENCES = {"daily", "weekly", "biweekly", "monthly", "yearly"}
 MAX_OCCURRENCES = 500
 
 
-def _next_occurrence(dt: datetime, recurrence: str) -> datetime:
+def _next_occurrence(dt: datetime, recurrence: str, *, anchor_day: int | None = None) -> datetime:
     if recurrence == "daily":
         return dt + timedelta(days=1)
     if recurrence == "weekly":
@@ -21,7 +21,7 @@ def _next_occurrence(dt: datetime, recurrence: str) -> datetime:
     if recurrence == "biweekly":
         return dt + timedelta(weeks=2)
     if recurrence == "monthly":
-        return dt + relativedelta(months=1)
+        return dt + relativedelta(months=1, day=anchor_day or dt.day)
     if recurrence == "yearly":
         return dt + relativedelta(years=1)
     return dt
@@ -156,7 +156,7 @@ def expand_event(
             occ["occurrence_date"] = occurrence_date
             occurrences.append(occ)
 
-        current = _next_occurrence(current, recurrence)
+        current = _next_occurrence(current, recurrence, anchor_day=event.starts_at.day)
         count += 1
 
     return occurrences

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -16,7 +16,7 @@ from app.core.notification_destinations import EligibleReminderUser, dispatch_fa
 from app.core.recurrence import expand_event
 from app.database import SessionLocal
 from app.models import (
-    CalendarEvent, FamilyBirthday, Membership, Notification,
+    CalendarEvent, CalendarSubscription, FamilyBirthday, Membership, Notification,
     NotificationPreference, NotificationSentLog, Task,
 )
 
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 BACKUP_JOB_ID = "scheduled_backup"
 NOTIFICATION_JOB_ID = "check_notifications"
+CALENDAR_SUBSCRIPTION_REFRESH_JOB_ID = "refresh_calendar_subscriptions"
 DST_TRANSITION_BUFFER = timedelta(hours=3)
 
 _scheduler: BackgroundScheduler | None = None
@@ -519,6 +520,59 @@ def start_notification_job():
         replace_existing=True,
     )
     logger.info("Notification check job started (every 5 min).")
+
+
+def _refresh_active_calendar_subscriptions():
+    from app.modules.calendar_router import _refresh_calendar_subscription
+
+    db = SessionLocal()
+    try:
+        subscriptions = (
+            db.query(CalendarSubscription)
+            .filter(CalendarSubscription.status == "active")
+            .order_by(CalendarSubscription.last_synced_at.asc().nullsfirst(), CalendarSubscription.id.asc())
+            .limit(25)
+            .all()
+        )
+        for subscription in subscriptions:
+            fallback_membership = (
+                db.query(Membership)
+                .filter(Membership.family_id == subscription.family_id)
+                .order_by(Membership.user_id.asc())
+                .first()
+            )
+            user_id = subscription.created_by_user_id or (fallback_membership.user_id if fallback_membership else None)
+            if user_id is None:
+                logger.warning("Skipping calendar subscription %s without a usable owner", subscription.id)
+                continue
+            _refresh_calendar_subscription(
+                db,
+                subscription=subscription,
+                user_id=user_id,
+            )
+        if subscriptions:
+            logger.info("Refreshed %s calendar subscription(s).", len(subscriptions))
+    except Exception:
+        db.rollback()
+        logger.exception("Calendar subscription refresh failed")
+    finally:
+        db.close()
+
+
+def start_calendar_subscription_refresh_job():
+    scheduler = get_scheduler()
+    existing = scheduler.get_job(CALENDAR_SUBSCRIPTION_REFRESH_JOB_ID)
+    if existing:
+        scheduler.remove_job(CALENDAR_SUBSCRIPTION_REFRESH_JOB_ID)
+    scheduler.add_job(
+        _refresh_active_calendar_subscriptions,
+        trigger=IntervalTrigger(hours=6),
+        id=CALENDAR_SUBSCRIPTION_REFRESH_JOB_ID,
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    logger.info("Calendar subscription refresh job started (every 6 hours).")
 
 
 def start_scheduler():

--- a/backend/app/core/webhooks.py
+++ b/backend/app/core/webhooks.py
@@ -11,6 +11,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from sqlalchemy.orm import Session
 
+from app.core.calendar_subscriptions import IcsSubscriptionError, validate_http_url_route
 from app.core.utils import utcnow
 from app.models import WebhookDelivery, WebhookEndpoint
 
@@ -80,8 +81,9 @@ def _webhook_network_error_name(exc: BaseException) -> str:
 
 
 def _post_webhook_json(url: str, *, payload: dict[str, Any], headers: dict[str, str]) -> int:
+    safe_url = validate_http_url_route(url, allow_private_networks=False)
     request = urllib.request.Request(
-        url,
+        safe_url,
         data=json.dumps(payload).encode("utf-8"),
         headers=headers,
         method="POST",
@@ -125,6 +127,9 @@ def deliver_to_endpoint(
         delivery.status_code = exc.code
         delivery.status = "failed"
         delivery.error = f"HTTP {exc.code}"
+    except IcsSubscriptionError:
+        delivery.status = "failed"
+        delivery.error = "NetworkTargetNotAllowed"
     except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
         delivery.status = "failed"
         delivery.error = _webhook_network_error_name(exc)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import hmac
+import ipaddress
 import os
 import logging
 from contextlib import asynccontextmanager
@@ -23,7 +24,6 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import _rate_limit_exceeded_handler
 from slowapi.middleware import SlowAPIMiddleware
-from slowapi.util import get_remote_address
 
 
 from app.core.deps import current_user
@@ -69,7 +69,7 @@ from app.modules.display_router import admin_router as display_admin_router, dis
 from app.modules.mobile_router import router as mobile_router
 from app.modules.webhooks_router import router as webhooks_router
 from app.modules.notification_destinations_router import router as notification_destinations_router
-from app.core.scheduler import configure_backup_schedule, start_notification_job, start_scheduler, shutdown_scheduler
+from app.core.scheduler import configure_backup_schedule, start_calendar_subscription_refresh_job, start_notification_job, start_scheduler, shutdown_scheduler
 from app.core import ws_broadcast
 from app.schemas import (
     AUTH_RESPONSES, CONFLICT_RESPONSE, ErrorResponse,
@@ -225,6 +225,7 @@ async def lifespan(app: FastAPI):
         retention = int(get_setting(db, "backup_retention", "7"))
         start_scheduler()
         start_notification_job()
+        start_calendar_subscription_refresh_job()
         if schedule != "off":
             configure_backup_schedule(schedule, BACKUP_DB_URL, BACKUP_DIR, retention)
     finally:
@@ -239,7 +240,74 @@ async def lifespan(app: FastAPI):
 # App
 # ---------------------------------------------------------------------------
 
-limiter = Limiter(key_func=get_remote_address)
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _split_env_list(name: str) -> list[str]:
+    raw = os.getenv(name, "")
+    return [part.strip() for part in raw.replace(";", ",").split(",") if part.strip()]
+
+
+def _cors_allowed_origins() -> list[str]:
+    origins = {
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+    }
+    origins.update(_split_env_list("CORS_ALLOWED_ORIGINS"))
+    return sorted(origins)
+
+
+def _cors_allowed_origin_regex() -> str:
+    # LAN browser origins are intentionally opt-in for self-hosted deployments
+    # that call the backend directly. The default Compose stack exposes only
+    # the frontend and reaches the backend over the internal Docker network.
+    if _env_bool("CORS_ALLOW_LAN_ORIGINS"):
+        return r"https?://(localhost|127\.0\.0\.1|192\.168\.[0-9]+\.[0-9]+)(:[0-9]+)?"
+    return r"https?://(localhost|127\.0\.0\.1)(:[0-9]+)?"
+
+
+def _trusted_proxy_networks() -> list[ipaddress._BaseNetwork]:
+    raw_networks = _split_env_list("TRUSTED_PROXY_CIDRS")
+    networks = ["127.0.0.0/8", "::1/128", *raw_networks]
+    parsed = []
+    for value in networks:
+        try:
+            parsed.append(ipaddress.ip_network(value, strict=False))
+        except ValueError:
+            logger.warning("Ignoring invalid TRUSTED_PROXY_CIDRS entry")
+    return parsed
+
+
+def _client_ip_is_trusted_proxy(client_host: str | None) -> bool:
+    if not client_host:
+        return False
+    try:
+        client_ip = ipaddress.ip_address(client_host)
+    except ValueError:
+        return False
+    return any(client_ip in network for network in _trusted_proxy_networks())
+
+
+def rate_limit_key(request: Request) -> str:
+    client_host = request.client.host if request.client else ""
+    if _client_ip_is_trusted_proxy(client_host):
+        forwarded_for = request.headers.get("x-forwarded-for", "")
+        first_hop = forwarded_for.split(",", 1)[0].strip()
+        if first_hop:
+            try:
+                ipaddress.ip_address(first_hop)
+                return first_hop
+            except ValueError:
+                pass
+    return client_host or "unknown"
+
+
+limiter = Limiter(key_func=rate_limit_key)
 
 app = FastAPI(
     title="Tribu API",
@@ -282,7 +350,8 @@ app.add_middleware(SlowAPIMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex=r"https?://(localhost|127\.0\.0\.1|192\.168\.[0-9]+\.[0-9]+)(:[0-9]+)?",
+    allow_origins=_cors_allowed_origins(),
+    allow_origin_regex=_cors_allowed_origin_regex(),
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization", "X-Setup-Restore-Token"],

--- a/backend/app/modules/display_router.py
+++ b/backend/app/modules/display_router.py
@@ -42,6 +42,7 @@ from app.models import (
     SchoolTimetable,
     SchoolTimetableAssignment,
     SchoolTimetableLesson,
+    Task,
     User,
 )
 from app.schemas import (
@@ -51,6 +52,7 @@ from app.schemas import (
     DisplayDashboardEvent,
     DisplayDashboardMember,
     DisplayDashboardResponse,
+    DisplayDashboardTask,
     DisplaySchoolTimetableGroup,
     DisplaySchoolTimetableLesson,
     SchoolTimetableMemberResponse,
@@ -310,8 +312,8 @@ def display_me(
     summary="Get the shared-home display dashboard",
     description=(
         "Return a curated, read-only dashboard for the family this display "
-        "is bound to: members (no emails), upcoming events (14 days), and "
-        "upcoming birthdays (28 days). The display token determines the "
+        "is bound to: members (no emails), upcoming events (14 days), "
+        "open tasks, and upcoming birthdays (28 days). The display token determines the "
         "family — there is no ``family_id`` query parameter."
     ),
     response_description="Display dashboard payload",
@@ -406,6 +408,25 @@ def display_dashboard(
             ))
     upcoming_birthdays.sort(key=lambda x: x.days_until)
 
+    task_rows = (
+        db.query(Task)
+        .filter(Task.family_id == device.family_id, Task.status == "open")
+        .order_by(Task.due_date.asc().nullslast(), Task.created_at.asc(), Task.id.asc())
+        .limit(8)
+        .all()
+    )
+    open_tasks = [
+        DisplayDashboardTask(
+            title=task.title,
+            priority=task.priority,
+            due_date=task.due_date,
+            participant_colors=[member_colors_by_user_id[task.assigned_to_user_id]]
+            if task.assigned_to_user_id in member_colors_by_user_id
+            else [],
+        )
+        for task in task_rows
+    ]
+
     membership_by_user_id = {m.user_id: m for m in memberships}
     today_weekday = today.isoweekday()
     today_school_timetables: list[DisplaySchoolTimetableGroup] = []
@@ -469,6 +490,7 @@ def display_dashboard(
         members=members,
         next_events=next_events,
         upcoming_birthdays=upcoming_birthdays,
+        open_tasks=open_tasks,
         today_school_timetables=today_school_timetables,
         config=_device_config(device),
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1983,6 +1983,14 @@ class DisplayDashboardBirthday(BaseModel):
     days_until: int = Field(..., description="Days until the birthday")
 
 
+class DisplayDashboardTask(BaseModel):
+    """Open task projection safe for a shared-home display."""
+    title: str = Field(..., description="Task title")
+    priority: str = Field(..., description="Task priority")
+    due_date: Optional[datetime] = Field(None, description="Task due date, if set")
+    participant_colors: list[str] = Field(default_factory=list, description="Display-safe assignee colors")
+
+
 class DisplayDashboardResponse(BaseModel):
     """Aggregated dashboard payload for a shared-home display.
 
@@ -1997,6 +2005,7 @@ class DisplayDashboardResponse(BaseModel):
     members: list[DisplayDashboardMember] = Field(..., description="Family members (display name, color, and avatar only)")
     next_events: list[DisplayDashboardEvent] = Field(..., description="Upcoming events within 14 days (display-safe fields only)")
     upcoming_birthdays: list[DisplayDashboardBirthday] = Field(..., description="Upcoming birthdays within 28 days")
+    open_tasks: list[DisplayDashboardTask] = Field(default_factory=list, description="Open tasks with display-safe fields only")
     today_school_timetables: list[DisplaySchoolTimetableGroup] = Field(default_factory=list, description="Display-safe school timetable groups for today")
     config: DisplayDeviceConfig = Field(..., description="Resolved display render config")
 

--- a/backend/tests/test_calendar_subscriptions.py
+++ b/backend/tests/test_calendar_subscriptions.py
@@ -178,6 +178,44 @@ class TestUrlSafety:
             fetch_ics_text("https://feed.example.com/holidays.ics")
         assert calls["connected"] is False
 
+
+    def test_fetch_allows_private_hosts_with_explicit_opt_in(self, monkeypatch):
+        calls = {"connected": False}
+
+        def _private_addrinfo(host, port, type=0):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.20", port or 80))]
+
+        class _Socket:
+            def __init__(self, *args, **kwargs):
+                pass
+            def settimeout(self, timeout):
+                pass
+            def connect(self, sockaddr):
+                calls["connected"] = True
+                raise OSError("stop before network I/O")
+            def close(self):
+                pass
+
+        monkeypatch.setattr(socket, "getaddrinfo", _private_addrinfo)
+        monkeypatch.setattr(socket, "socket", _Socket)
+
+        with pytest.raises(IcsSubscriptionError, match="unreachable"):
+            fetch_ics_text("http://calendar.lan/family.ics", allow_private_networks=True)
+        assert calls["connected"] is True
+
+    def test_fetch_private_host_env_opt_in(self, monkeypatch):
+        from app.core import calendar_subscriptions as sub_mod
+
+        def _private_addrinfo(host, port, type=0):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", port or 80))]
+
+        monkeypatch.setenv("SUBSCRIPTIONS_ALLOW_PRIVATE_NETWORKS", "true")
+        monkeypatch.setattr(socket, "getaddrinfo", _private_addrinfo)
+        monkeypatch.setattr(socket, "socket", lambda *a, **kw: (_ for _ in ()).throw(OSError("stop")))
+
+        with pytest.raises(IcsSubscriptionError, match="unreachable"):
+            sub_mod.fetch_ics_text("http://calendar.lan/family.ics")
+
     def test_fetch_rejects_all_resolved_addresses_when_none_are_public(self, monkeypatch):
         def _addrinfo(host, port, type=0):
             return [

--- a/backend/tests/test_cors_headers.py
+++ b/backend/tests/test_cors_headers.py
@@ -33,3 +33,27 @@ def test_local_web_origin_preflight_allows_authorization_header():
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == origin
     assert "Authorization" in response.headers["access-control-allow-headers"]
+
+
+def test_lan_origin_is_not_allowed_by_default():
+    response = client.get("/health", headers={"Origin": "http://192.168.1.20:3000"})
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_rate_limit_key_uses_forwarded_for_only_from_trusted_proxy():
+    from types import SimpleNamespace
+    from app.main import rate_limit_key
+
+    trusted = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        headers={"x-forwarded-for": "203.0.113.7, 10.0.0.2"},
+    )
+    untrusted = SimpleNamespace(
+        client=SimpleNamespace(host="198.51.100.9"),
+        headers={"x-forwarded-for": "203.0.113.7"},
+    )
+
+    assert rate_limit_key(trusted) == "203.0.113.7"
+    assert rate_limit_key(untrusted) == "198.51.100.9"

--- a/backend/tests/test_recurrence.py
+++ b/backend/tests/test_recurrence.py
@@ -163,7 +163,7 @@ class TestExpandMonthly:
         assert months == [1, 2, 3, 4, 5, 6]
 
     def test_monthly_end_of_month_edge_case(self):
-        """Event on Jan 31 clamps through Feb 28, then stays at 28th due to iterative relativedelta."""
+        """Event on Jan 31 clamps in February, then returns to month-end dates."""
         ev = make_event(
             recurrence="monthly",
             starts_at=datetime(2026, 1, 31, 10, 0),
@@ -173,10 +173,10 @@ class TestExpandMonthly:
         dates = [o["starts_at"] for o in result]
         assert dates[0] == datetime(2026, 1, 31, 10, 0)
         assert dates[1] == datetime(2026, 2, 28, 10, 0)
-        # After clamping to Feb 28, +1 month = Mar 28 (iterative behavior)
-        assert dates[2] == datetime(2026, 3, 28, 10, 0)
-        assert dates[3] == datetime(2026, 4, 28, 10, 0)
-        assert dates[4] == datetime(2026, 5, 28, 10, 0)
+        # The original 31st is the anchor day; short months clamp without drifting forever.
+        assert dates[2] == datetime(2026, 3, 31, 10, 0)
+        assert dates[3] == datetime(2026, 4, 30, 10, 0)
+        assert dates[4] == datetime(2026, 5, 31, 10, 0)
 
 
 # --- expand_event: yearly ---

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -192,6 +192,7 @@ def test_webhook_stdlib_post_sets_method_headers_payload_and_timeout(monkeypatch
             return FakeResponse()
 
     monkeypatch.setattr(webhooks_core, "_WEBHOOK_OPENER", FakeOpener())
+    monkeypatch.setattr(webhooks_core, "validate_http_url_route", lambda url, allow_private_networks=False: url)
 
     status = webhooks_core._post_webhook_json(
         "https://receiver.example/hook",
@@ -444,3 +445,32 @@ def test_inactive_or_unsubscribed_webhooks_are_skipped(monkeypatch):
         assert db.query(WebhookDelivery).count() == 0
     finally:
         db.close()
+
+
+def test_webhook_delivery_blocks_private_network_targets(monkeypatch):
+    token, family_id, _ = _seed_admin()
+    endpoint_id = _seed_webhook_endpoint(family_id, url="https://receiver.example/hook")
+
+    from app.core import webhooks as webhooks_core
+    from app.core.calendar_subscriptions import IcsSubscriptionError
+
+    def reject_private(url, *, allow_private_networks=False):
+        raise IcsSubscriptionError("Subscription URL host is not allowed")
+
+    called = {"opened": False}
+
+    class FakeOpener:
+        def open(self, request, *, timeout):
+            called["opened"] = True
+            raise AssertionError("network opener should not be called")
+
+    monkeypatch.setattr(webhooks_core, "validate_http_url_route", reject_private)
+    monkeypatch.setattr(webhooks_core, "_WEBHOOK_OPENER", FakeOpener())
+
+    resp = client.post(f"/webhooks/{endpoint_id}/test", headers=_auth(token))
+
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["delivery"]["error"] == "NetworkTargetNotAllowed"
+    assert called["opened"] is False

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,10 +28,22 @@ SECURE_COOKIES=false
 # Keep JWT_SECRET stable in your persisted .env to preserve sessions across container updates.
 # REFRESH_TOKEN_EXPIRE_DAYS=30
 
-# IANA timezone used for family calendar/task times and notification reminders.
-# Audit timestamps stay in UTC. Leave unset for UTC fallback.
+# IANA timezone used for family calendar/task times, quiet hours, and reminders.
+# Audit/session timestamps stay in UTC. Leave unset for UTC fallback.
 # Examples: Europe/Berlin, America/New_York.
 # TZ=Europe/Berlin
+
+# Extra exact browser origins for direct backend access. Default only allows localhost.
+# CORS_ALLOWED_ORIGINS=https://tribu.example.com
+
+# Set true only if you deliberately expose the backend to 192.168.x.x browser origins.
+# CORS_ALLOW_LAN_ORIGINS=false
+
+# Comma-separated trusted reverse proxy CIDRs for X-Forwarded-For rate-limit keys.
+# TRUSTED_PROXY_CIDRS=172.16.0.0/12
+
+# Set true only if ICS subscriptions must fetch LAN/private calendar feeds.
+# SUBSCRIPTIONS_ALLOW_PRIVATE_NETWORKS=false
 
 # ── Push Notifications (optional) ────────────────────────────
 # Generate keys with: npx web-push generate-vapid-keys

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../backend
       dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
 
   frontend:
     build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     image: postgres:16-alpine
     container_name: tribu-postgres
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tribu -d tribu"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     environment:
       POSTGRES_DB: tribu
       POSTGRES_USER: tribu
@@ -16,6 +21,11 @@ services:
     image: valkey/valkey:8-alpine
     container_name: tribu-valkey
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   backend:
     image: ghcr.io/itsdnns/tribu-backend:latest
@@ -33,14 +43,29 @@ services:
       JWT_EXPIRE_HOURS: ${JWT_EXPIRE_HOURS:-24}
       REFRESH_TOKEN_EXPIRE_DAYS: ${REFRESH_TOKEN_EXPIRE_DAYS:-30}
       TZ: ${TZ:-}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      CORS_ALLOW_LAN_ORIGINS: ${CORS_ALLOW_LAN_ORIGINS:-false}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-}
+      SUBSCRIPTIONS_ALLOW_PRIVATE_NETWORKS: ${SUBSCRIPTIONS_ALLOW_PRIVATE_NETWORKS:-false}
       ALLOW_OPEN_REGISTRATION: ${ALLOW_OPEN_REGISTRATION:-false}
       SETUP_RESTORE_TOKEN: ${SETUP_RESTORE_TOKEN:-}
       SETUP_RESTORE_MAX_BYTES: ${SETUP_RESTORE_MAX_BYTES:-104857600}
     depends_on:
-      - postgres
-      - valkey
-    ports:
-      - "8000:8000"
+      postgres:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+    expose:
+      - "8000"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=3).read()"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     volumes:
       # For external storage (e.g. NAS), replace with a bind mount:
       # - /mnt/nas/backups/tribu:/backups
@@ -53,7 +78,8 @@ services:
     environment:
       BACKEND_URL: http://backend:8000
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     ports:
       - "3000:3000"
 

--- a/frontend/__tests__/lib/api.test.js
+++ b/frontend/__tests__/lib/api.test.js
@@ -3,7 +3,7 @@ import {
   apiGetMyFamilies, apiGetMembers, apiSetAdult, apiSetRole,
   apiGetDashboard, apiGetEvents, apiCreateEvent, apiAddBirthday,
   apiGetContacts, apiImportContactsCsv,
-  apiExportCalendarIcs, apiImportCalendarIcs, apiExportContactsCsv,
+  apiExportCalendarIcs, apiImportCalendarIcs, apiExportContactsCsv, apiDownloadBackup,
   apiGetActivity,
   apiCreateQuickCapture, apiGetQuickCaptureInbox, apiConvertQuickCapture, apiDismissQuickCapture,
   apiGetSetupChecklist, apiDismissSetupChecklist, apiResetSetupChecklist, apiCompleteSetupChecklistStep,
@@ -199,6 +199,41 @@ describe('Auth API', () => {
       '/api/auth/me',
       '/api/auth/refresh',
       '/api/auth/me',
+    ]);
+  });
+
+
+  it('download helpers refresh once before retrying raw responses', async () => {
+    const finalResponse = { ok: true, status: 200, blob: () => Promise.resolve(new Blob(['ok'])) };
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) })
+      .mockResolvedValueOnce(finalResponse);
+
+    const result = await apiExportCalendarIcs('9');
+
+    expect(result).toBe(finalResponse);
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual([
+      '/api/calendar/events/export.ics?family_id=9',
+      '/api/auth/refresh',
+      '/api/calendar/events/export.ics?family_id=9',
+    ]);
+  });
+
+  it('backup downloads use the shared raw session retry path', async () => {
+    const finalResponse = { ok: true, status: 200, blob: () => Promise.resolve(new Blob(['backup'])) };
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) })
+      .mockResolvedValueOnce(finalResponse);
+
+    const result = await apiDownloadBackup('latest.dump');
+
+    expect(result).toBe(finalResponse);
+    expect(global.fetch.mock.calls.map(([url]) => url)).toEqual([
+      '/api/admin/backup/latest.dump/download',
+      '/api/auth/refresh',
+      '/api/admin/backup/latest.dump/download',
     ]);
   });
 

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -29,6 +29,17 @@ async function request(path, options = {}, allowRefresh = true) {
   return { ok: res.ok, status: res.status, data };
 }
 
+async function rawRequest(path, options = {}, allowRefresh = true) {
+  const res = await fetch(`${API}${path}`, { credentials: 'include', ...options });
+
+  if (res.status === 401 && allowRefresh && !logoutInFlight && path !== '/auth/refresh' && path !== '/auth/login' && path !== '/auth/logout') {
+    await refreshSession();
+    if (!logoutInFlight) return rawRequest(path, options, false);
+  }
+
+  return res;
+}
+
 function post(path, body) {
   return request(path, {
     method: 'POST',
@@ -261,11 +272,11 @@ export function apiImportContactsCsv(family_id, csv_text) {
 }
 
 export async function apiExportContactsCsv(familyId) {
-  return fetch(`${API}/contacts/export.csv?family_id=${familyId}`, { credentials: 'include' });
+  return rawRequest(`/contacts/export.csv?family_id=${familyId}`);
 }
 
 export async function apiExportCalendarIcs(familyId) {
-  return fetch(`${API}/calendar/events/export.ics?family_id=${familyId}`, { credentials: 'include' });
+  return rawRequest(`/calendar/events/export.ics?family_id=${familyId}`);
 }
 
 export function apiImportCalendarIcs(family_id, ics_text) {
@@ -439,7 +450,7 @@ export function apiGetBackups() {
 }
 
 export async function apiDownloadBackup(filename) {
-  return fetch(`${API}/admin/backup/${encodeURIComponent(filename)}/download`, { credentials: 'include' });
+  return rawRequest(`/admin/backup/${encodeURIComponent(filename)}/download`);
 }
 
 export function apiDeleteBackup(filename) {

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -27,7 +27,7 @@ def test_docker_workflow_uses_component_matrix_without_repeated_shared_steps():
     assert workflow.count('docker/login-action@v4') == 1
     assert workflow.count('docker/metadata-action@v6') == 1
     assert workflow.count('docker/build-push-action@v7') == 1
-    assert len(workflow.splitlines()) < 140
+    assert len(workflow.splitlines()) < 190
 
 
 def test_stable_release_tag_builds_publish_latest_images():
@@ -77,3 +77,13 @@ def test_docker_workflow_keeps_required_package_write_permissions():
     assert 'permissions:' in workflow
     assert 'contents: read' in workflow
     assert 'packages: write' in workflow
+
+
+def test_docker_publish_waits_for_backend_and_frontend_tests():
+    workflow = read_workflow()
+
+    assert 'backend-tests:' in workflow
+    assert 'uses: ./.github/workflows/backend-tests.yml' in workflow
+    assert 'frontend-tests:' in workflow
+    assert 'npm test -- --runInBand' in workflow
+    assert 'needs: [backend-tests, frontend-tests]' in workflow


### PR DESCRIPTION
## Summary
- gate Docker publishing on backend and frontend test jobs
- keep the backend internal by default in Compose, add healthchecks, and document deployment opt-ins
- tighten CORS and trusted-proxy rate-limit handling
- keep calendar subscription SSRF protections by default with an explicit LAN feed opt-in and reuse network guardrails for webhooks
- refresh managed calendar subscriptions on a schedule, preserve month-end recurrence anchors, add display-safe open tasks, and route downloads through one session refresh retry

## Tests
- `git diff --check`
- YAML parse check for Compose and workflow files
- `DATABASE_URL=sqlite:///./test-runtime-hardening.db JWT_SECRET=test-secret-key-32-bytes-minimum PYTHONPATH=backend python -m pytest backend/tests/test_cors_headers.py backend/tests/test_calendar_subscriptions.py backend/tests/test_recurrence.py backend/tests/test_webhooks.py tests/test_docker_workflow.py -q`
- `DATABASE_URL=sqlite:///./test-display-hardening.db JWT_SECRET=test-secret-key-32-bytes-minimum PYTHONPATH=backend python -m pytest backend/tests/test_display_devices.py -q`
- `DATABASE_URL=sqlite:///./test-clock-hardening.db JWT_SECRET=test-secret-key-32-bytes-minimum PYTHONPATH=backend python -m pytest backend/tests/test_clock_timezone.py backend/tests/test_notification_reliability.py -q`
- `python -m pytest tests/test_public_launch_docs.py tests/test_docker_workflow.py -q`
- `npm test -- --runInBand`