### PR TITLE
Localize meal plan week dates

### DIFF
--- a/frontend/__tests__/components/MealPlansView.test.js
+++ b/frontend/__tests__/components/MealPlansView.test.js
@@ -2,6 +2,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MealPlansView from '../../components/MealPlansView';
 import { buildDemoMealPlans } from '../../lib/demo-data';
+import { buildMessages } from '../../lib/i18n';
 
 jest.mock('../../contexts/ToastContext', () => ({
   useToast: () => ({ success: jest.fn(), error: jest.fn() }),
@@ -136,6 +137,64 @@ describe('MealPlansView', () => {
     // 21 empty cells (7 days × 3 slots)
     const cells = container.querySelectorAll('.meal-grid-cell');
     expect(cells.length).toBe(21);
+  });
+
+  test('uses Sunday-start US date formatting for English meal-plan weeks', async () => {
+    mockAppState = baseState({
+      lang: 'en',
+      messages: buildMessages('en'),
+      families: [],
+    });
+    const realDate = global.Date;
+    global.Date = class extends realDate {
+      constructor(...args) {
+        if (args.length === 0) {
+          super('2026-01-01T12:00:00');
+        } else {
+          super(...args);
+        }
+      }
+      static now() { return new realDate('2026-01-01T12:00:00').getTime(); }
+    };
+
+    try {
+      const { container } = render(<MealPlansView />);
+      await waitFor(() => expect(apiListMealPlans).toHaveBeenCalledWith('1', '2025-12-28', '2026-01-03'));
+
+      const firstHeader = container.querySelector('.meal-grid-day-header');
+      expect(firstHeader.querySelector('.meal-grid-day-name')).toHaveTextContent('Sunday');
+      expect(firstHeader.querySelector('.meal-grid-day-date')).toHaveTextContent('12/28');
+      expect(container.querySelector('.meal-week-nav-label')).toHaveTextContent(/12\/28\/2025\s*–\s*1\/3\/2026/);
+    } finally {
+      global.Date = realDate;
+    }
+  });
+
+  test('keeps Monday-start German date formatting and shows both years at New Year', async () => {
+    mockAppState = baseState({ families: [] });
+    const realDate = global.Date;
+    global.Date = class extends realDate {
+      constructor(...args) {
+        if (args.length === 0) {
+          super('2026-01-01T12:00:00');
+        } else {
+          super(...args);
+        }
+      }
+      static now() { return new realDate('2026-01-01T12:00:00').getTime(); }
+    };
+
+    try {
+      const { container } = render(<MealPlansView />);
+      await waitFor(() => expect(apiListMealPlans).toHaveBeenCalledWith('1', '2025-12-29', '2026-01-04'));
+
+      const firstHeader = container.querySelector('.meal-grid-day-header');
+      expect(firstHeader.querySelector('.meal-grid-day-name')).toHaveTextContent('Mo');
+      expect(firstHeader.querySelector('.meal-grid-day-date')).toHaveTextContent('29.12.');
+      expect(container.querySelector('.meal-week-nav-label')).toHaveTextContent(/29\.12\.2025\s*–\s*0?4\.0?1\.2026/);
+    } finally {
+      global.Date = realDate;
+    }
   });
 
   test('opens dialog on add button click and shows the meal name field', async () => {

--- a/frontend/__tests__/lib/dates.test.js
+++ b/frontend/__tests__/lib/dates.test.js
@@ -1,0 +1,33 @@
+import { formatDayMonth, formatWeekRange, localeForLang, startOfWeek, weekStartsOn } from '../../lib/dates';
+import { formatIsoDate } from '../../hooks/useMealPlans';
+
+function normalizeRange(value) {
+  return value.replace(/[\u2009\u202f]/g, ' ');
+}
+
+describe('localized date helpers', () => {
+  it('maps English meal planning weeks to Sunday and other languages to Monday', () => {
+    expect(weekStartsOn('en')).toBe(0);
+    expect(weekStartsOn('de')).toBe(1);
+    expect(weekStartsOn('fr')).toBe(1);
+  });
+
+  it('calculates localized week starts across year boundaries', () => {
+    expect(formatIsoDate(startOfWeek(new Date('2026-01-01T12:00:00'), weekStartsOn('en')))).toBe('2025-12-28');
+    expect(formatIsoDate(startOfWeek(new Date('2026-01-01T12:00:00'), weekStartsOn('de')))).toBe('2025-12-29');
+  });
+
+  it('formats day/month labels with the selected locale ordering', () => {
+    const date = new Date(2026, 6, 13);
+    expect(formatDayMonth(date, localeForLang('en'))).toBe('7/13');
+    expect(formatDayMonth(date, localeForLang('de'))).toBe('13.7.');
+  });
+
+  it('keeps both years visible when a localized week crosses New Year', () => {
+    const en = normalizeRange(formatWeekRange(new Date(2025, 11, 28), new Date(2026, 0, 3), localeForLang('en')));
+    const de = normalizeRange(formatWeekRange(new Date(2025, 11, 29), new Date(2026, 0, 4), localeForLang('de')));
+
+    expect(en).toMatch(/12\/28\/2025\s*–\s*1\/3\/2026/);
+    expect(de).toMatch(/29\.12\.2025\s*–\s*0?4\.0?1\.2026/);
+  });
+});

--- a/frontend/components/MealPlansView.js
+++ b/frontend/components/MealPlansView.js
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight, Plus, Edit2, CalendarDays, GripVertical, Sho
 import { useApp } from '../contexts/AppContext';
 import { useMealPlans, formatIsoDate, weekDays } from '../hooks/useMealPlans';
 import { MEAL_SLOTS } from '../lib/meal-plans';
+import { formatDayMonth, formatWeekRange, localeForLang } from '../lib/dates';
 import { apiListRecipes } from '../lib/api';
 import { t } from '../lib/i18n';
 import ConfirmDialog from './ConfirmDialog';
@@ -22,8 +23,8 @@ function slotLabel(messages, slot) {
   return t(messages, `module.meal_plans.slot.${slot}`);
 }
 
-function formatDayNumber(date) {
-  return `${date.getDate()}.${date.getMonth() + 1}.`;
+function weekdayKeyForDate(date) {
+  return WEEKDAY_KEYS[(date.getDay() + 6) % 7];
 }
 
 function ingredientsSummary(messages, ingredients) {
@@ -31,11 +32,6 @@ function ingredientsSummary(messages, ingredients) {
   if (count === 0) return '';
   if (count === 1) return t(messages, 'module.meal_plans.ingredients_summary_one');
   return t(messages, 'module.meal_plans.ingredients_summary').replace('{count}', String(count));
-}
-
-function weekRangeLabel(weekStart, weekEnd) {
-  const fmt = (d) => `${d.getDate()}.${d.getMonth() + 1}.`;
-  return `${fmt(weekStart)} - ${fmt(weekEnd)}${weekStart.getFullYear() === weekEnd.getFullYear() ? ` ${weekEnd.getFullYear()}` : ''}`;
 }
 
 function isSameDay(a, b) {
@@ -119,7 +115,7 @@ function FilledMealCell({
   );
 }
 
-function EmptyMealCell({ date, slot, messages, onClick, isDropOver, onDragOver, onDrop }) {
+function EmptyMealCell({ date, slot, messages, locale, onClick, isDropOver, onDragOver, onDrop }) {
   return (
     <button
       type="button"
@@ -129,7 +125,7 @@ function EmptyMealCell({ date, slot, messages, onClick, isDropOver, onDragOver, 
       onDrop={onDrop}
       aria-label={t(messages, 'module.meal_plans.add_for_slot_aria')
         .replace('{slot}', slotLabel(messages, slot))
-        .replace('{date}', formatDayNumber(date))}
+        .replace('{date}', formatDayMonth(date, locale))}
     >
       <Plus size={14} aria-hidden="true" />
     </button>
@@ -137,7 +133,7 @@ function EmptyMealCell({ date, slot, messages, onClick, isDropOver, onDragOver, 
 }
 
 export default function MealPlansView() {
-  const { familyId, families, messages, demoMode, shoppingLists = [] } = useApp();
+  const { familyId, families, messages, lang, demoMode, shoppingLists = [] } = useApp();
   const hook = useMealPlans();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState(null);
@@ -171,11 +167,12 @@ export default function MealPlansView() {
   }, [shoppingLists, selectedWeekListId]);
 
   const currentFamilyName = families.find((f) => String(f.family_id) === String(familyId))?.family_name || '';
+  const locale = localeForLang(lang);
   const days = weekDays(hook.weekStart);
   const today = new Date();
-  const moveTargets = days.flatMap((day, dayIndex) => {
+  const moveTargets = days.flatMap((day) => {
     const iso = formatIsoDate(day);
-    const dayLabel = `${t(messages, WEEKDAY_KEYS[dayIndex])} ${formatDayNumber(day)}`;
+    const dayLabel = `${t(messages, weekdayKeyForDate(day))} ${formatDayMonth(day, locale)}`;
     return MEAL_SLOTS.map((slot) => ({
       value: `${iso}:${slot}`,
       label: `${dayLabel} · ${slotLabel(messages, slot)}`,
@@ -318,7 +315,7 @@ export default function MealPlansView() {
           </span>
           <div>
             <h1 className="view-title">{t(messages, 'module.meal_plans.name')}</h1>
-            <div className="view-subtitle">{currentFamilyName || weekRangeLabel(hook.weekStart, hook.weekEnd)}</div>
+            <div className="view-subtitle">{currentFamilyName || formatWeekRange(hook.weekStart, hook.weekEnd, locale)}</div>
           </div>
         </div>
         <div className="meal-header-actions">
@@ -338,7 +335,7 @@ export default function MealPlansView() {
               aria-label={t(messages, 'module.meal_plans.today')}
             >
               <CalendarDays size={14} aria-hidden="true" />
-              {weekRangeLabel(hook.weekStart, hook.weekEnd)}
+              {formatWeekRange(hook.weekStart, hook.weekEnd, locale)}
             </button>
             <button
               type="button"
@@ -403,8 +400,8 @@ export default function MealPlansView() {
             key={d.toISOString()}
             className={`meal-grid-day-header${isSameDay(d, today) ? ' meal-grid-day-today' : ''}`}
           >
-            <span className="meal-grid-day-name">{t(messages, WEEKDAY_KEYS[idx])}</span>
-            <span className="meal-grid-day-date">{formatDayNumber(d)}</span>
+            <span className="meal-grid-day-name">{t(messages, weekdayKeyForDate(d))}</span>
+            <span className="meal-grid-day-date">{formatDayMonth(d, locale)}</span>
           </div>
         ))}
 
@@ -446,6 +443,7 @@ export default function MealPlansView() {
                   date={d}
                   slot={slot}
                   messages={messages}
+                  locale={locale}
                   onClick={openAdd}
                   isDropOver={isDropOver}
                   {...dragTargetProps}

--- a/frontend/e2e/tests/meal-plans.spec.js
+++ b/frontend/e2e/tests/meal-plans.spec.js
@@ -37,6 +37,10 @@ test.describe('Meal plan', () => {
 
     await expect(page.locator('.meal-plans-page')).toBeVisible({ timeout: 30000 });
     await expect(page.getByRole('heading', { name: 'Meal plan' })).toBeVisible();
+    const firstDayHeader = page.locator('.meal-grid-day-header').first();
+    await expect(firstDayHeader.locator('.meal-grid-day-name')).toHaveText('Sunday');
+    await expect(firstDayHeader.locator('.meal-grid-day-date')).toHaveText(/\d{1,2}\/\d{1,2}/);
+    await expect(page.locator('.meal-week-nav-label')).toHaveText(/\d{1,2}\/\d{1,2}\/\d{4}/);
     await expect(page.getByText(/Porridge with berries|Porridge mit Beeren/)).toBeVisible();
     await expect(page.getByText('Not available in demo mode')).toHaveCount(0);
 

--- a/frontend/hooks/useMealPlans.js
+++ b/frontend/hooks/useMealPlans.js
@@ -5,17 +5,8 @@ import { errorText } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { announce } from '../lib/announce';
 import { createEmptyMealForm } from '../lib/meal-plans';
+import { startOfWeek, weekStartsOn } from '../lib/dates';
 import * as api from '../lib/api';
-
-/** Return the Monday of the ISO week for a given date, in local time. */
-function isoWeekStart(date) {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  // getDay: 0 = Sunday. We want Monday as week start.
-  const dayOfWeek = (d.getDay() + 6) % 7; // 0 = Mon ... 6 = Sun
-  d.setDate(d.getDate() - dayOfWeek);
-  return d;
-}
 
 export function formatIsoDate(d) {
   const y = d.getFullYear();
@@ -45,10 +36,10 @@ function ingredientNamesFromMeals(items) {
 }
 
 export function useMealPlans() {
-  const { familyId, messages, demoMode, mealPlans: demoMeals = [], setMealPlans } = useApp();
+  const { familyId, messages, lang, demoMode, mealPlans: demoMeals = [], setMealPlans } = useApp();
   const { success: toastSuccess, error: toastError } = useToast();
 
-  const [weekStart, setWeekStart] = useState(() => isoWeekStart(new Date()));
+  const [weekStart, setWeekStart] = useState(() => startOfWeek(new Date(), weekStartsOn(lang)));
   const [meals, setMeals] = useState([]);
   const [loading, setLoading] = useState(false);
   const [ingredientHints, setIngredientHints] = useState([]);
@@ -95,7 +86,14 @@ export function useMealPlans() {
 
   const goPrevWeek = useCallback(() => setWeekStart((w) => addDays(w, -7)), []);
   const goNextWeek = useCallback(() => setWeekStart((w) => addDays(w, 7)), []);
-  const goToday = useCallback(() => setWeekStart(isoWeekStart(new Date())), []);
+  const goToday = useCallback(() => setWeekStart(startOfWeek(new Date(), weekStartsOn(lang))), [lang]);
+
+  useEffect(() => {
+    setWeekStart((current) => {
+      const next = startOfWeek(addDays(current, 3), weekStartsOn(lang));
+      return formatIsoDate(next) === formatIsoDate(current) ? current : next;
+    });
+  }, [lang]);
 
   const byCell = useMemo(() => {
     const map = new Map();

--- a/frontend/lib/dates.js
+++ b/frontend/lib/dates.js
@@ -1,0 +1,45 @@
+export function localeForLang(lang) {
+  if (lang === 'en') return 'en-US';
+  return lang || 'en-US';
+}
+
+export function weekStartsOn(lang) {
+  return lang === 'en' ? 0 : 1;
+}
+
+export function startOfWeek(date, firstDay = 1) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  const normalizedFirstDay = Number.isInteger(firstDay) && firstDay >= 0 && firstDay <= 6 ? firstDay : 1;
+  const offset = (d.getDay() - normalizedFirstDay + 7) % 7;
+  d.setDate(d.getDate() - offset);
+  return d;
+}
+
+export function formatDayMonth(date, locale) {
+  return new Intl.DateTimeFormat(locale || 'en-US', {
+    month: 'numeric',
+    day: 'numeric',
+  }).format(date);
+}
+
+function fallbackWeekRange(start, end, locale) {
+  const formatter = new Intl.DateTimeFormat(locale || 'en-US', {
+    month: 'numeric',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  return `${formatter.format(start)} – ${formatter.format(end)}`;
+}
+
+export function formatWeekRange(start, end, locale) {
+  const formatter = new Intl.DateTimeFormat(locale || 'en-US', {
+    month: 'numeric',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  if (typeof formatter.formatRange === 'function') {
+    return formatter.formatRange(start, end);
+  }
+  return fallbackWeekRange(start, end, locale);
+}


### PR DESCRIPTION
## Summary
- Format Meal Plan week and day labels with the selected app language
- Use Sunday-start weeks for English and keep Monday-start weeks for other supported languages
- Keep Meal Plan week ranges unambiguous when a week crosses New Year

## Checks
- npm run i18n:check
- npm test -- --runInBand
- npm run build
- ./scripts/e2e-local.sh e2e/tests/meal-plans.spec.js --project='Desktop Chrome'

Closes #419
