### PR TITLE
Improve account birthdate editing

### DIFF
--- a/frontend/__tests__/components/AccountTab.test.js
+++ b/frontend/__tests__/components/AccountTab.test.js
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AccountTab from '../../components/settings/AccountTab';
+import * as api from '../../lib/api';
+
+let mockAppState = {};
+const toastSuccess = jest.fn();
+const toastError = jest.fn();
+
+jest.mock('../../contexts/AppContext', () => ({
+  useApp: () => mockAppState,
+}));
+
+jest.mock('../../contexts/ToastContext', () => ({
+  useToast: () => ({ success: toastSuccess, error: toastError }),
+}));
+
+jest.mock('../../components/settings/SecuritySection', () => function SecuritySection() {
+  return <section aria-label="Security panel">Security panel</section>;
+});
+
+jest.mock('../../lib/api', () => ({
+  apiDeleteAccount: jest.fn(),
+  apiLeaveFamily: jest.fn(),
+  apiSetMemberBirthdate: jest.fn(),
+  apiSetMemberColor: jest.fn(),
+  apiUpdateProfileImage: jest.fn(),
+}));
+
+const messages = {
+  profile: 'Profile',
+  profile_image: 'Profile image',
+  birthdate: 'Date of birth',
+  personal_color: 'Personal color',
+  color_taken_by: 'Taken by {name}',
+  theme: 'Theme',
+  language: 'Language',
+  child: 'Child',
+  member: 'Member',
+  danger_zone: 'Danger zone',
+  leave_family: 'Leave family',
+  leave_family_desc: 'Leave this family.',
+  leave_family_confirm: 'Really leave?',
+  leave_family_last_admin: 'Last admin',
+  left_family: 'Left family',
+  delete_account: 'Delete Account',
+  delete_account_desc: 'Delete your account.',
+  delete_account_confirm: 'Type DELETE to confirm.',
+  delete_account_placeholder: 'Type DELETE',
+  account_deleted: 'Account deleted',
+  cancel: 'Cancel',
+  'toast.error': 'Something went wrong',
+  'toast.profile_updated': 'Profile updated',
+};
+
+function baseState(overrides = {}) {
+  const loadMembers = jest.fn().mockResolvedValue(undefined);
+  return {
+    theme: 'light',
+    setTheme: jest.fn(),
+    lang: 'en',
+    setLang: jest.fn(),
+    availableThemes: [{ key: 'light', name: 'Light' }],
+    availableLanguages: [{ key: 'en', nativeName: 'English' }],
+    messages,
+    me: { user_id: 7, display_name: 'Dennis', email: 'dennis@example.test' },
+    isAdmin: true,
+    isChild: false,
+    loggedIn: true,
+    profileImage: null,
+    setProfileImage: jest.fn(),
+    members: [{ user_id: 7, display_name: 'Dennis', email: 'dennis@example.test', role: 'admin', is_adult: true, date_of_birth: '1985-07-15' }],
+    familyId: 42,
+    loadMembers,
+    logout: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderAccount(overrides = {}) {
+  mockAppState = baseState(overrides);
+  return render(<AccountTab />);
+}
+
+describe('AccountTab birthdate input', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    api.apiSetMemberBirthdate.mockResolvedValue({ ok: true, data: { date_of_birth: '1990-05-12' } });
+  });
+
+  test('does not save partial or segment edits before the field is committed', () => {
+    renderAccount();
+
+    const input = screen.getByLabelText('Date of birth');
+    fireEvent.change(input, { target: { value: '0001-05-12' } });
+
+    expect(input).toHaveValue('0001-05-12');
+    expect(api.apiSetMemberBirthdate).not.toHaveBeenCalled();
+  });
+
+  test('reverts out-of-range years on blur instead of saving year 0001', async () => {
+    renderAccount();
+
+    const input = screen.getByLabelText('Date of birth');
+    fireEvent.change(input, { target: { value: '0001-05-12' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(input).toHaveValue('1985-07-15'));
+    expect(api.apiSetMemberBirthdate).not.toHaveBeenCalled();
+  });
+
+  test('saves a valid typed birthdate only on blur', async () => {
+    renderAccount();
+
+    const input = screen.getByLabelText('Date of birth');
+    fireEvent.change(input, { target: { value: '1990-05-12' } });
+
+    expect(api.apiSetMemberBirthdate).not.toHaveBeenCalled();
+
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(api.apiSetMemberBirthdate).toHaveBeenCalledWith(42, 7, '1990-05-12'));
+    expect(mockAppState.loadMembers).toHaveBeenCalledTimes(1);
+  });
+
+  test('pressing Enter commits the current birthdate', async () => {
+    renderAccount();
+
+    const input = screen.getByLabelText('Date of birth');
+    fireEvent.change(input, { target: { value: '1991-06-13' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(api.apiSetMemberBirthdate).toHaveBeenCalledWith(42, 7, '1991-06-13'));
+  });
+
+  test('does not double-save when Enter is followed by blur before the request finishes', async () => {
+    let resolveSave;
+    api.apiSetMemberBirthdate.mockReturnValueOnce(new Promise((resolve) => { resolveSave = resolve; }));
+    renderAccount();
+
+    const input = screen.getByLabelText('Date of birth');
+    fireEvent.change(input, { target: { value: '1992-07-14' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.blur(input);
+
+    expect(api.apiSetMemberBirthdate).toHaveBeenCalledTimes(1);
+    expect(api.apiSetMemberBirthdate).toHaveBeenCalledWith(42, 7, '1992-07-14');
+
+    resolveSave({ ok: true, data: { date_of_birth: '1992-07-14' } });
+    await waitFor(() => expect(mockAppState.loadMembers).toHaveBeenCalledTimes(1));
+  });
+
+  test('clearing the field stores null on blur', async () => {
+    renderAccount();
+
+    const input = screen.getByLabelText('Date of birth');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(api.apiSetMemberBirthdate).toHaveBeenCalledWith(42, 7, null));
+  });
+
+  test('blur without changes does not call the birthdate API', () => {
+    renderAccount();
+
+    fireEvent.blur(screen.getByLabelText('Date of birth'));
+
+    expect(api.apiSetMemberBirthdate).not.toHaveBeenCalled();
+  });
+
+  test('resets to the last saved value when saving fails', async () => {
+    api.apiSetMemberBirthdate.mockResolvedValue({ ok: false, data: { detail: 'Nope' } });
+    renderAccount();
+
+    const input = screen.getByLabelText('Date of birth');
+    fireEvent.change(input, { target: { value: '1990-05-12' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(input).toHaveValue('1985-07-15');
+  });
+});

--- a/frontend/components/settings/AccountTab.js
+++ b/frontend/components/settings/AccountTab.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { User, Palette, Globe, Check, AlertTriangle, LogOut, Trash2 } from 'lucide-react';
 import { useApp } from '../../contexts/AppContext';
 import { useToast } from '../../contexts/ToastContext';
@@ -18,6 +18,19 @@ const THEME_PREVIEWS = {
   'midnight-glass': { bg: '#06080f', surface: '#111628', accent: '#7c3aed' },
 };
 
+const MIN_BIRTHDATE = '1900-01-01';
+
+function formatBirthdateInputValue(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function isBirthdateInRange(value, maxBirthdate) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && value >= MIN_BIRTHDATE && value <= maxBirthdate;
+}
+
 export default function AccountTab() {
   const { theme, setTheme, lang, setLang, availableThemes, availableLanguages, messages, me, isAdmin, isChild, loggedIn, profileImage, setProfileImage, members, familyId, loadMembers, logout } = useApp();
   const { success: toastSuccess, error: toastError } = useToast();
@@ -29,6 +42,44 @@ export default function AccountTab() {
   const initials = (me?.display_name || 'U').charAt(0).toUpperCase();
   const currentMember = members.find((m) => m.user_id === me?.user_id);
   const myColor = currentMember?.color || null;
+  const savedBirthdate = currentMember?.date_of_birth || '';
+  const [birthdateDraft, setBirthdateDraft] = useState(savedBirthdate);
+  const savedBirthdateRef = useRef(savedBirthdate);
+  const pendingBirthdateRef = useRef(null);
+  const maxBirthdate = formatBirthdateInputValue(new Date());
+
+  useEffect(() => {
+    savedBirthdateRef.current = savedBirthdate;
+    setBirthdateDraft(savedBirthdate);
+  }, [savedBirthdate]);
+
+  async function commitBirthdate(input) {
+    const value = (input?.value || '').trim();
+    const currentSavedBirthdate = savedBirthdateRef.current;
+
+    if (input?.validity?.badInput) {
+      setBirthdateDraft(currentSavedBirthdate);
+      return;
+    }
+
+    if (value && !isBirthdateInRange(value, maxBirthdate)) {
+      setBirthdateDraft(currentSavedBirthdate);
+      return;
+    }
+
+    if (value === currentSavedBirthdate || pendingBirthdateRef.current === value) return;
+
+    pendingBirthdateRef.current = value;
+    const { ok, data } = await api.apiSetMemberBirthdate(familyId, me?.user_id, value || null);
+    pendingBirthdateRef.current = null;
+    if (!ok) {
+      setBirthdateDraft(currentSavedBirthdate);
+      return toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
+    }
+    savedBirthdateRef.current = value;
+    setBirthdateDraft(value);
+    await loadMembers();
+  }
 
   function onProfileImage(e) {
     const file = e.target.files?.[0];
@@ -69,19 +120,24 @@ export default function AccountTab() {
           <input type="file" accept="image/*" onChange={onProfileImage} className="set-file-input" />
         </div>
         <div className="set-field-group">
-          <label className="set-label">
+          <label className="set-label" htmlFor="account-birthdate">
             {t(messages, 'birthdate')}
           </label>
           <input
+            id="account-birthdate"
             type="date"
             className="form-input set-input-narrow"
-            value={currentMember?.date_of_birth || ''}
-            onChange={async (e) => {
-              const val = e.target.value || null;
-              if (val && !/^\d{4}-\d{2}-\d{2}$/.test(val)) return;
-              const { ok, data } = await api.apiSetMemberBirthdate(familyId, me?.user_id, val);
-              if (!ok) return toastError(errorText(data?.detail, t(messages, 'toast.error'), messages));
-              await loadMembers();
+            value={birthdateDraft}
+            min={MIN_BIRTHDATE}
+            max={maxBirthdate}
+            aria-label={t(messages, 'birthdate')}
+            onChange={(e) => setBirthdateDraft(e.target.value)}
+            onBlur={(e) => { void commitBirthdate(e.currentTarget); }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                void commitBirthdate(e.currentTarget);
+              }
             }}
           />
         </div>

--- a/frontend/e2e/tests/settings.spec.js
+++ b/frontend/e2e/tests/settings.spec.js
@@ -1,6 +1,23 @@
 const { test, expect } = require('../helpers/fixtures');
 const { navigateTo } = require('../helpers/navigation');
 
+async function openAccountSettings(page) {
+  await navigateTo(page, 'Settings');
+
+  const birthdateInput = page.getByLabel('Date of birth');
+  if (await birthdateInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+    return birthdateInput;
+  }
+
+  const accountItem = page.locator('.settings-mobile-item', { hasText: 'Account' });
+  if (await accountItem.waitFor({ state: 'visible', timeout: 10000 }).then(() => true).catch(() => false)) {
+    await accountItem.click();
+  }
+
+  await expect(birthdateInput).toBeVisible({ timeout: 10000 });
+  return birthdateInput;
+}
+
 test.describe('Settings', () => {
   test('open settings and see account tab', async ({ authedPage: page, testUser }) => {
     await navigateTo(page, 'Settings');
@@ -14,6 +31,34 @@ test.describe('Settings', () => {
     await expect(page.locator('.profile-name')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('.profile-name')).toContainText(testUser.displayName);
     await expect(page.locator('.profile-email')).toContainText(testUser.email);
+  });
+
+  test('lets Account users type and clear a birthdate without using the calendar picker', async ({ authedPage: page }) => {
+    const birthdateInput = await openAccountSettings(page);
+
+    await birthdateInput.fill('1990-05-12');
+    const saveBirthdate = page.waitForResponse((response) => (
+      response.request().method() === 'PATCH'
+      && response.url().includes('/birthdate')
+      && response.ok()
+    ));
+    await birthdateInput.blur();
+    await saveBirthdate;
+    await expect(birthdateInput).toHaveValue('1990-05-12');
+
+    await page.reload();
+    const reloadedBirthdateInput = await openAccountSettings(page);
+    await expect(reloadedBirthdateInput).toHaveValue('1990-05-12', { timeout: 10000 });
+
+    await reloadedBirthdateInput.fill('');
+    const clearBirthdate = page.waitForResponse((response) => (
+      response.request().method() === 'PATCH'
+      && response.url().includes('/birthdate')
+      && response.ok()
+    ));
+    await reloadedBirthdateInput.blur();
+    await clearBirthdate;
+    await expect(reloadedBirthdateInput).toHaveValue('');
   });
 
   test('keeps Account settings focused on preference selectors without duplicate pack inventory', async ({ authedPage: page }) => {


### PR DESCRIPTION
## Summary
- Keep Account birthdate edits local while users type and save only on blur or Enter
- Reject out-of-range years such as 0001 instead of persisting partial datepicker input
- Cover typed save, clear-to-null, unchanged blur, failed save, and duplicate Enter/blur commit handling

## Checks
- npm run i18n:check
- npm test -- --runTestsByPath __tests__/components/AccountTab.test.js --runInBand
- npm test -- --runInBand
- npm run build
- ./scripts/e2e-local.sh e2e/tests/settings.spec.js --project='Desktop Chrome'
- ./scripts/e2e-local.sh e2e/tests/settings.spec.js --project='Mobile Chrome'

Closes #418