### PR TITLE
Add dashboard current time clock

### DIFF
--- a/frontend/__tests__/components/DashboardHero.test.js
+++ b/frontend/__tests__/components/DashboardHero.test.js
@@ -38,6 +38,7 @@ const messages = {
   'module.dashboard.days': 'days',
   'module.dashboard.quick_event': 'Event',
   'module.dashboard.today_command_center': 'Today command center',
+  'module.dashboard.current_time': 'Current time',
   'module.dashboard.next_up_title': 'Next up',
   'module.dashboard.next_up_empty': 'Nothing else scheduled',
   'module.dashboard.next_up_empty_hint': 'Use quick capture to park anything the family should remember.',
@@ -202,6 +203,43 @@ describe('DashboardView hero', () => {
     const { container } = render(<DashboardView />);
     expect(container.querySelectorAll('.dashboard-header-actions .btn-icon')).toHaveLength(0);
     expect(screen.queryByRole('group', { name: 'Quick actions' })).not.toBeInTheDocument();
+  });
+
+  it('keeps a live clock in the dashboard date line', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 6, 13, 8, 15, 0));
+
+    try {
+      mockAppState = baseApp({ demoMode: true });
+      const { container } = render(<DashboardView />);
+      const dateLine = container.querySelector('.today-command-family');
+      const clock = screen.getByTestId('dashboard-clock');
+
+      expect(dateLine).toContainElement(clock);
+      expect(clock).toHaveAccessibleName('Current time: 08:15');
+      expect(clock).toHaveTextContent('08:15');
+      expect(container.querySelector('.dashboard-header-actions [data-testid="dashboard-clock"]')).not.toBeInTheDocument();
+
+      jest.setSystemTime(new Date(2026, 6, 13, 8, 16, 0));
+      fireEvent(document, new Event('visibilitychange'));
+      expect(clock).toHaveTextContent('08:16');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('formats the dashboard clock with the household 12-hour preference', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 6, 13, 8, 15, 0));
+
+    try {
+      mockAppState = baseApp({ demoMode: true, timeFormat: '12h' });
+      render(<DashboardView />);
+
+      expect(screen.getByTestId('dashboard-clock').textContent).toMatch(/^8:15\s?AM$/i);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('moves global search into the dashboard header and removes the duplicated date chip', () => {

--- a/frontend/__tests__/hooks/useCurrentMinute.test.js
+++ b/frontend/__tests__/hooks/useCurrentMinute.test.js
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCurrentMinute } from '../../hooks/useCurrentMinute';
+
+describe('useCurrentMinute', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-13T10:00:47.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('updates on the next minute boundary and keeps minute cadence', () => {
+    const { result, unmount } = renderHook(() => useCurrentMinute());
+
+    expect(result.current.toISOString()).toBe('2026-07-13T10:00:47.000Z');
+
+    act(() => {
+      jest.advanceTimersByTime(12999);
+    });
+    expect(result.current.toISOString()).toBe('2026-07-13T10:00:47.000Z');
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.toISOString()).toBe('2026-07-13T10:01:00.000Z');
+
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+    expect(result.current.toISOString()).toBe('2026-07-13T10:02:00.000Z');
+
+    unmount();
+  });
+
+  it('resynchronizes when the tab becomes visible again', () => {
+    const { result } = renderHook(() => useCurrentMinute());
+
+    jest.setSystemTime(new Date('2026-07-13T10:07:12.000Z'));
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(result.current.toISOString()).toBe('2026-07-13T10:07:12.000Z');
+  });
+});

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -5,6 +5,7 @@ import { prettyDate, parseDate } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import { getMemberColor } from '../lib/member-colors';
 import { apiCompleteSetupChecklistStep, apiDismissSetupChecklist, apiGetDashboardLayout, apiGetSetupChecklist, apiListMealPlans, apiResetDashboardLayout, apiUpdateDashboardLayout } from '../lib/api';
+import { useCurrentMinute } from '../hooks/useCurrentMinute';
 import AssignedBadges from './AssignedBadges';
 import MemberAvatar from './MemberAvatar';
 import RewardsDashboardWidget from './RewardsDashboardWidget';
@@ -112,6 +113,14 @@ function formatEventTime(value, locale, timeFormat) {
   const date = parseDate(value);
   if (!date) return '';
   return date.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: timeFormat === '12h' });
+}
+
+function formatClockTime(value, locale, timeFormat) {
+  return value.toLocaleTimeString(locale, {
+    hour: timeFormat === '12h' ? 'numeric' : '2-digit',
+    minute: '2-digit',
+    hour12: timeFormat === '12h',
+  });
 }
 
 function TodayStatusItem({ label, value, testId, icon: Icon, tone, onClick }) {
@@ -310,7 +319,9 @@ export default function DashboardView({ onOpenSearch, onOpenNotifications, unrea
   const birthdaySoonCount = getUpcomingBirthdayCount(summary);
   const nextUpEvent = Array.isArray(summary?.next_events) ? summary.next_events[0] : null;
   const locale = lang === 'de' ? 'de-DE' : 'en-US';
-  const todayStr = new Date().toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+  const currentMinute = useCurrentMinute();
+  const todayStr = currentMinute.toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+  const currentTimeStr = formatClockTime(currentMinute, locale, timeFormat);
   const currentFamily = Array.isArray(families) ? families.find((family) => String(family.family_id) === String(familyId)) : null;
 
   useEffect(() => {
@@ -519,7 +530,19 @@ export default function DashboardView({ onOpenSearch, onOpenNotifications, unrea
             <h1 className="view-title today-command-title">
               {getGreeting(messages)}, <span>{heroName}</span>{heroFamilyName && <span className="today-command-family-inline"> · {heroFamilyName}</span>} <span className="today-command-wave" aria-hidden="true">👋</span>
             </h1>
-            <p className="today-command-family">{todayStr}</p>
+            <p className="today-command-family">
+              <span>{todayStr}</span>
+              <span className="today-command-time-separator" aria-hidden="true"> · </span>
+              <time
+                className="today-command-clock"
+                data-testid="dashboard-clock"
+                dateTime={currentMinute.toISOString()}
+                aria-label={`${t(messages, 'module.dashboard.current_time')}: ${currentTimeStr}`}
+                suppressHydrationWarning
+              >
+                {currentTimeStr}
+              </time>
+            </p>
           </div>
           <div className="dashboard-header-actions">
             {typeof onOpenSearch === 'function' && (

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -43,6 +43,8 @@ test.describe('Dashboard', () => {
     await expect(page.getByRole('region', { name: 'Quick capture' })).toBeVisible({ timeout: 10000 });
     await expect(page.locator('.dashboard-header-actions .view-date')).toHaveCount(0);
     await expect(page.locator('.sidebar-search-btn')).toHaveCount(0);
+    await expect(page.getByTestId('dashboard-clock')).toBeVisible();
+    await expect(page.getByTestId('dashboard-clock')).toContainText(/^\d{1,2}:\d{2}(\s?[AP]M)?$/i);
 
     const dashboardSearch = page.locator('.dashboard-header-actions .dashboard-search-btn');
     if (testInfo.project.name.includes('Mobile')) {

--- a/frontend/hooks/useCurrentMinute.js
+++ b/frontend/hooks/useCurrentMinute.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+const MINUTE_MS = 60000;
+
+function msUntilNextMinute(now = Date.now()) {
+  const remainder = now % MINUTE_MS;
+  return remainder === 0 ? MINUTE_MS : MINUTE_MS - remainder;
+}
+
+export function useCurrentMinute() {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    let timeoutId;
+    let cancelled = false;
+
+    const scheduleNextTick = () => {
+      timeoutId = window.setTimeout(() => {
+        if (cancelled) return;
+        setNow(new Date());
+        scheduleNextTick();
+      }, msUntilNextMinute());
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'hidden') {
+        setNow(new Date());
+      }
+    };
+
+    scheduleNextTick();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return now;
+}

--- a/frontend/i18n/bg.json
+++ b/frontend/i18n/bg.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Домакинство",
   "nav.group.system": "Още / Система",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Текущ час",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/cs.json
+++ b/frontend/i18n/cs.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Domácnost",
   "nav.group.system": "Více / Systém",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Aktuální čas",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/da.json
+++ b/frontend/i18n/da.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Husstand",
   "nav.group.system": "Mere / System",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Aktuelt tidspunkt",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Haushalt",
   "nav.group.system": "Mehr / System",
   "module.dashboard.today_command_center": "Heute-Zentrale",
+  "module.dashboard.current_time": "Aktuelle Uhrzeit",
   "module.dashboard.next_up_title": "Als Nächstes",
   "module.dashboard.next_up_empty": "Heute ist nichts mehr geplant",
   "module.dashboard.next_up_empty_hint": "Nutze die Schnellerfassung, um festzuhalten, woran die Familie denken soll.",

--- a/frontend/i18n/el.json
+++ b/frontend/i18n/el.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Νοικοκυριό",
   "nav.group.system": "Περισσότερα / Σύστημα",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Τρέχουσα ώρα",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Household",
   "nav.group.system": "More / System",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Current time",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Hogar",
   "nav.group.system": "Más / Sistema",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Hora actual",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/et.json
+++ b/frontend/i18n/et.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Majapidamine",
   "nav.group.system": "Veel / Süsteem",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Praegune kellaaeg",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/fi.json
+++ b/frontend/i18n/fi.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Kotitalous",
   "nav.group.system": "Lisää / Järjestelmä",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Nykyinen aika",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Maison",
   "nav.group.system": "Plus / Système",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Heure actuelle",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/ga.json
+++ b/frontend/i18n/ga.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Teaghlach",
   "nav.group.system": "Tuilleadh / Córas",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Am reatha",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/hr.json
+++ b/frontend/i18n/hr.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Kućanstvo",
   "nav.group.system": "Više / Sustav",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Trenutačno vrijeme",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/hu.json
+++ b/frontend/i18n/hu.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Háztartás",
   "nav.group.system": "További / Rendszer",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Aktuális idő",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/it.json
+++ b/frontend/i18n/it.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Casa",
   "nav.group.system": "Altro / Sistema",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Ora attuale",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/lt.json
+++ b/frontend/i18n/lt.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Namai",
   "nav.group.system": "Daugiau / Sistema",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Dabartinis laikas",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/lv.json
+++ b/frontend/i18n/lv.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Mājsaimniecība",
   "nav.group.system": "Vairāk / Sistēma",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Pašreizējais laiks",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/nb.json
+++ b/frontend/i18n/nb.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Husholdning",
   "nav.group.system": "Mer / System",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Gjeldende klokkeslett",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/nl.json
+++ b/frontend/i18n/nl.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Huishouden",
   "nav.group.system": "Meer / Systeem",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Huidige tijd",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/pl.json
+++ b/frontend/i18n/pl.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Dom",
   "nav.group.system": "Więcej / System",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Aktualny czas",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/pt.json
+++ b/frontend/i18n/pt.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Casa",
   "nav.group.system": "Mais / Sistema",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Hora atual",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/ro.json
+++ b/frontend/i18n/ro.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Gospodărie",
   "nav.group.system": "Mai mult / Sistem",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Ora curentă",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/sk.json
+++ b/frontend/i18n/sk.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Domácnosť",
   "nav.group.system": "Viac / Systém",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Aktuálny čas",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/sl.json
+++ b/frontend/i18n/sl.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Gospodinjstvo",
   "nav.group.system": "Več / Sistem",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Trenutni čas",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/i18n/sv.json
+++ b/frontend/i18n/sv.json
@@ -711,6 +711,7 @@
   "nav.group.household": "Hushåll",
   "nav.group.system": "Mer / System",
   "module.dashboard.today_command_center": "Today command center",
+  "module.dashboard.current_time": "Aktuell tid",
   "module.dashboard.next_up_title": "Next up",
   "module.dashboard.next_up_empty": "Nothing else scheduled",
   "module.dashboard.next_up_empty_hint": "Use quick capture to park anything the family should remember.",

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -797,6 +797,8 @@ body { font-family: var(--font-ui); background: var(--void); color: var(--text-p
 .today-command-wave { display: inline-block; margin-left: 2px; font-size: 0.8em; transform: translateY(-1px); }
 .today-command-family-inline { color: var(--text-muted); font-weight: 700; }
 .today-command-family { margin: 7px 0 0; color: var(--text-secondary); font-size: 0.9rem; }
+.today-command-clock { color: var(--text-primary); font-variant-numeric: tabular-nums; font-weight: 700; letter-spacing: -0.01em; }
+.today-command-time-separator { color: var(--text-muted); }
 .today-command-grid { display: grid; grid-template-columns: minmax(320px, 0.95fr) minmax(380px, 1.35fr); gap: var(--space-md); align-items: stretch; }
 .next-up-card { position: relative; overflow: hidden; border: 1px solid rgba(139, 94, 159, 0.24); border-radius: 18px; background: linear-gradient(135deg, rgba(139, 94, 159, 0.15), rgba(32, 38, 56, 0.9)); color: #fff; padding: 14px; min-height: 126px; box-shadow: var(--shadow-soft); }
 .next-up-card::after { content: ''; position: absolute; right: -28px; bottom: -36px; width: 138px; height: 138px; border-radius: 999px; background: radial-gradient(circle, rgba(139, 94, 159, 0.14), rgba(139, 94, 159, 0)); pointer-events: none; }


### PR DESCRIPTION
## Summary
- Add a compact live clock to the Dashboard date line so the home/fridge dashboard shows the current time next to Today context.
- Update the clock once per minute and resync when the tab becomes visible again.
- Localize the clock accessibility label across the supported locale pack.

Discussion: #420

## Checks
- `npm test -- --runTestsByPath __tests__/hooks/useCurrentMinute.test.js __tests__/components/DashboardHero.test.js --runInBand`
- `npm test -- --runInBand`
- `git diff --check && npm run i18n:check`
- Locale pack validation across all supported languages
- `npm run build`
- `./scripts/e2e-local.sh e2e/tests/dashboard.spec.js --project='Desktop Chrome'`
- `./scripts/e2e-local.sh e2e/tests/dashboard.spec.js --project='Mobile Chrome'`
