### PR TITLE
Promote future next-up dates

### DIFF
--- a/frontend/__tests__/components/DashboardHero.test.js
+++ b/frontend/__tests__/components/DashboardHero.test.js
@@ -103,6 +103,14 @@ function todayAt(hour = 10, minute = 0) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(hour)}:${pad(minute)}:00`;
 }
 
+function daysFromTodayAt(daysFromToday, hour = 10, minute = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromToday);
+  d.setHours(hour, minute, 0, 0);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(hour)}:${pad(minute)}:00`;
+}
+
 describe('DashboardView hero', () => {
   beforeEach(() => {
     mockAppState = baseApp();
@@ -191,6 +199,44 @@ describe('DashboardView hero', () => {
     expect(nextUp).toHaveTextContent('Nothing else scheduled');
     expect(nextUp).toHaveTextContent('Use quick capture to park anything the family should remember.');
     expect(within(nextUp).getByRole('button', { name: 'Open calendar' })).toBeVisible();
+  });
+
+  it('promotes the date inside the next-up chip when the next event is not today', () => {
+    const startsAt = daysFromTodayAt(2, 14, 5);
+    const expectedDate = new Date(startsAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    mockAppState = baseApp({
+      summary: {
+        next_events: [{ id: 7, title: 'Dentist', starts_at: startsAt, location: 'Downtown' }],
+        upcoming_birthdays: [],
+      },
+    });
+
+    render(<DashboardView />);
+
+    const nextUp = screen.getByRole('region', { name: 'Next up' });
+    const chip = nextUp.querySelector('.next-up-time-chip');
+    expect(chip).toHaveClass('is-stacked');
+    expect(chip.querySelector('.next-up-chip-date')).toHaveTextContent(expectedDate);
+    expect(chip.querySelector('.next-up-chip-time')).toHaveTextContent('14:05');
+    expect(nextUp).toHaveTextContent('Dentist');
+    expect(nextUp).toHaveTextContent('Downtown');
+  });
+
+  it('formats 12-hour next-up times without a leading zero', () => {
+    mockAppState = baseApp({
+      timeFormat: '12h',
+      summary: {
+        next_events: [{ id: 8, title: 'Sample visit', starts_at: todayAt(9, 0), location: 'Gerald' }],
+        upcoming_birthdays: [],
+      },
+    });
+
+    render(<DashboardView />);
+
+    const chip = screen.getByRole('region', { name: 'Next up' }).querySelector('.next-up-time-chip');
+    expect(chip).not.toHaveClass('is-stacked');
+    expect(chip.textContent).toMatch(/^9:00\s?AM$/i);
+    expect(chip.textContent).not.toMatch(/^09:00/);
   });
 
   it('keeps the greeting with the user display name', () => {

--- a/frontend/components/DashboardView.js
+++ b/frontend/components/DashboardView.js
@@ -112,7 +112,13 @@ function getUpcomingBirthdayCount(summary) {
 function formatEventTime(value, locale, timeFormat) {
   const date = parseDate(value);
   if (!date) return '';
-  return date.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: timeFormat === '12h' });
+  return formatClockTime(date, locale, timeFormat);
+}
+
+function formatChipDate(value, locale) {
+  const date = parseDate(value);
+  if (!date) return '';
+  return date.toLocaleDateString(locale, { month: 'short', day: 'numeric' });
 }
 
 function formatClockTime(value, locale, timeFormat) {
@@ -198,6 +204,9 @@ function DailyLoopCard({ mealsTodayCount, shoppingOpenCount, routineDueCount, me
 
 function NextUpCard({ event, locale, lang, timeFormat, messages, members, setActiveView, isChild }) {
   const eventDate = event ? parseDate(event.starts_at) : null;
+  const eventTime = event ? formatEventTime(event.starts_at, locale, timeFormat) : '';
+  const isEventToday = event ? getEventOccurrenceDate(event) === todayIsoDate() : false;
+  const chipDate = event && !isEventToday ? formatChipDate(event.starts_at, locale) : '';
   const assignedMember = event?.assigned_to
     ? members.find((member) => String(member.user_id) === String(event.assigned_to))
     : null;
@@ -212,8 +221,9 @@ function NextUpCard({ event, locale, lang, timeFormat, messages, members, setAct
       <div className="next-up-eyebrow">{t(messages, 'module.dashboard.next_up_title')}</div>
       {event ? (
         <button type="button" className="next-up-content" onClick={goToEvent}>
-          <span className="next-up-time-chip">
-            <span>{formatEventTime(event.starts_at, locale, timeFormat)}</span>
+          <span className={`next-up-time-chip${chipDate ? ' is-stacked' : ''}`}>
+            {chipDate && <span className="next-up-chip-date">{chipDate}</span>}
+            <span className="next-up-chip-time">{eventTime}</span>
           </span>
           <span className="next-up-details">
             <span className="next-up-title">{event.title}</span>

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -22,6 +22,14 @@ function contrastRatio(foreground, background) {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+function localIsoDaysFromToday(daysFromToday, hour = 9, minute = 0) {
+  const date = new Date();
+  date.setDate(date.getDate() + daysFromToday);
+  date.setHours(hour, minute, 0, 0);
+  const pad = (value) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(hour)}:${pad(minute)}:00`;
+}
+
 test.describe('Dashboard', () => {
   test('shows greeting with username', async ({ authedPage: page, testUser }) => {
     const greeting = page.locator('.view-title');
@@ -59,6 +67,34 @@ test.describe('Dashboard', () => {
     await dashboardSearch.click();
     await expect(page.locator('.search-overlay')).toBeVisible();
     await expect(page.getByPlaceholder(/Search/i)).toBeFocused();
+  });
+
+  test('promotes a future next-up date inside the time chip without overflowing', async ({ authedPage: page, apiCtx }) => {
+    const startsAt = localIsoDaysFromToday(2, 9, 0);
+    const expectedDate = new Date(startsAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const familyId = await getFamilyId(apiCtx);
+    await seedCalendarEvent(apiCtx, familyId, {
+      title: 'Future next-up chip event',
+      starts_at: startsAt,
+      location: 'Kitchen calendar',
+    });
+
+    await page.reload();
+    await expect(page.getByRole('region', { name: 'Next up' })).toBeVisible({ timeout: 10000 });
+
+    const nextUp = page.getByRole('region', { name: 'Next up' });
+    await expect(nextUp).toContainText('Future next-up chip event');
+    const chip = nextUp.locator('.next-up-time-chip');
+    await expect(chip).toHaveClass(/is-stacked/);
+    await expect(chip.locator('.next-up-chip-date')).toContainText(expectedDate);
+    await expect(chip.locator('.next-up-chip-time')).toContainText(/^0?9:00(\s?[AP]M)?$/i);
+
+    const chipBox = await chip.boundingBox();
+    const cardBox = await nextUp.boundingBox();
+    expect(chipBox).not.toBeNull();
+    expect(cardBox).not.toBeNull();
+    expect(chipBox.x + chipBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
+    expect(chipBox.y + chipBox.height).toBeLessThanOrEqual(cardBox.y + cardBox.height + 1);
   });
 
   test('keeps dashboard header search usable on narrow desktop widths', async ({ authedPage: page }) => {

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -804,7 +804,11 @@ body { font-family: var(--font-ui); background: var(--void); color: var(--text-p
 .next-up-card::after { content: ''; position: absolute; right: -28px; bottom: -36px; width: 138px; height: 138px; border-radius: 999px; background: radial-gradient(circle, rgba(139, 94, 159, 0.14), rgba(139, 94, 159, 0)); pointer-events: none; }
 .next-up-eyebrow { position: relative; z-index: 1; color: #fff; font-size: 0.82rem; font-weight: 800; letter-spacing: 0; text-transform: none; margin-bottom: 10px; }
 .next-up-content { position: relative; z-index: 1; width: 100%; min-height: 82px; display: grid; grid-template-columns: minmax(72px, auto) minmax(0, 1fr) auto; column-gap: 14px; row-gap: 10px; align-items: center; text-align: left; color: var(--text-primary); background: transparent; border: 0; padding: 0; font: inherit; cursor: pointer; }
-.next-up-time-chip { min-width: 72px; min-height: 52px; display: inline-flex; align-items: center; justify-content: center; border-radius: 13px; background: rgba(255, 255, 255, 0.08); color: #fff; font-weight: 850; font-size: 0.98rem; box-shadow: inset 0 0 0 1px rgba(197, 203, 224, 0.12); }
+.next-up-time-chip { min-width: 72px; min-height: 52px; display: inline-flex; align-items: center; justify-content: center; border-radius: 13px; background: rgba(255, 255, 255, 0.08); color: #fff; font-weight: 850; font-size: 0.98rem; box-shadow: inset 0 0 0 1px rgba(197, 203, 224, 0.12); padding: 0 10px; }
+.next-up-time-chip.is-stacked { flex-direction: column; gap: 2px; align-items: center; line-height: 1.05; }
+.next-up-chip-date { font-size: 1.02rem; letter-spacing: -0.02em; white-space: nowrap; }
+.next-up-chip-time { font-size: 0.86em; white-space: nowrap; }
+.next-up-time-chip:not(.is-stacked) .next-up-chip-time { font-size: 1em; }
 .next-up-details { display: grid; gap: 7px; min-width: 0; }
 .next-up-title { display: block; color: #fff; font-size: 1rem; font-weight: 850; line-height: 1.18; letter-spacing: -0.015em; }
 .next-up-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 5px 10px; color: rgba(255, 255, 255, 0.78); font-size: 0.82rem; }
@@ -2107,8 +2111,9 @@ body { font-family: var(--font-ui); background: var(--void); color: var(--text-p
   .next-up-card { min-height: 0; padding: 10px; border-radius: 14px; }
   .next-up-card::after { width: 92px; height: 92px; right: -32px; bottom: -42px; }
   .next-up-eyebrow { margin-bottom: 7px; font-size: 0.76rem; }
-  .next-up-content { min-height: 0; grid-template-columns: 62px minmax(0, 1fr); column-gap: 10px; row-gap: 8px; align-items: center; }
-  .next-up-time-chip { justify-self: start; min-height: 44px; min-width: 58px; border-radius: 12px; font-size: 0.82rem; }
+  .next-up-content { min-height: 0; grid-template-columns: minmax(62px, auto) minmax(0, 1fr); column-gap: 10px; row-gap: 8px; align-items: center; }
+  .next-up-time-chip { justify-self: start; min-height: 44px; min-width: 58px; border-radius: 12px; font-size: 0.82rem; padding: 0 8px; }
+  .next-up-time-chip.is-stacked { min-height: 50px; }
   .next-up-details { grid-column: 2; grid-row: 1; gap: 4px; }
   .next-up-visual { display: none; }
   .next-up-title { font-size: 0.88rem; line-height: 1.16; }


### PR DESCRIPTION
## Summary
- Promote the event date inside the Dashboard Next up chip when the next event is not today.
- Keep today's Next up chip time-only, while future events show a stacked date-over-time chip.
- Format 12-hour Next up chip times without a leading zero and keep 24-hour times two-digit.
- Add unit and E2E coverage for the future-date chip and no-overflow layout.

## Tests
- `npm test -- --runTestsByPath __tests__/components/DashboardHero.test.js --runInBand`
- `git diff --check && npm run i18n:check && npm run build`
- `npm test -- --runInBand`
- `./scripts/e2e-local.sh e2e/tests/dashboard.spec.js --project='Desktop Chrome' --project='Mobile Chrome'`

## Discussion
- Closes https://github.com/itsDNNS/tribu/discussions/421
