### PR TITLE
Preserve family member context in calendar sync

### DIFF
--- a/backend/app/core/ics_utils.py
+++ b/backend/app/core/ics_utils.py
@@ -1,11 +1,12 @@
 """ICS (RFC 5545) import/export utilities for Tribu calendar events."""
 
 from datetime import datetime, date, timedelta
+from typing import Mapping, Optional
 
 from app.core.clock import to_local_wall_naive
 from app.core.utils import utcnow
 
-from icalendar import Calendar, Event
+from icalendar import Calendar, Event, vCalAddress, vText
 
 RECURRENCE_MAP = {
     "daily": "DAILY",
@@ -23,8 +24,61 @@ ICS_FREQ_TO_TRIBU = {
 }
 
 
-def events_to_ics(events, calendar_name="Tribu") -> str:
-    """Convert a list of CalendarEvent ORM objects to an RFC 5545 ICS string."""
+def _assigned_member_ids(assigned_to, member_names: Mapping[int, str]) -> list[int]:
+    """Resolve an event's ``assigned_to`` value to current member ids.
+
+    ``assigned_to`` is null (nobody), ``"all"`` (whole family), or a list
+    of user ids. Membership is recomputed against ``member_names`` so
+    stale ids of users who left the family are silently skipped.
+    """
+    if assigned_to == "all":
+        return sorted(member_names)
+    if not isinstance(assigned_to, list):
+        return []
+    ids: list[int] = []
+    for value in assigned_to:
+        if isinstance(value, bool):
+            continue
+        try:
+            user_id = int(value)
+        except (TypeError, ValueError):
+            continue
+        if user_id in member_names and user_id not in ids:
+            ids.append(user_id)
+    return ids
+
+
+def _member_attendee(user_id: int, display_name: str) -> vCalAddress:
+    """Build a privacy-safe ATTENDEE for a family member.
+
+    The cal-address is synthetic (``.invalid`` is reserved by RFC 2606,
+    so no mail can ever be routed to it); the member's real login email
+    must never leak into calendar data. ``X-TRIBU-USER-ID`` carries the
+    stable id for round-tripping/debugging.
+    """
+    address = vCalAddress(f"mailto:user-{user_id}@tribu.invalid")
+    address.params["CN"] = vText(display_name)
+    address.params["CUTYPE"] = vText("INDIVIDUAL")
+    address.params["ROLE"] = vText("REQ-PARTICIPANT")
+    address.params["PARTSTAT"] = vText("ACCEPTED")
+    address.params["RSVP"] = vText("FALSE")
+    address.params["X-TRIBU-USER-ID"] = vText(str(user_id))
+    return address
+
+
+def events_to_ics(
+    events,
+    calendar_name="Tribu",
+    member_names: Optional[Mapping[int, str]] = None,
+) -> str:
+    """Convert a list of CalendarEvent ORM objects to an RFC 5545 ICS string.
+
+    ``member_names`` is an optional preloaded ``{user_id: display_name}``
+    mapping for the events' family. When supplied, assigned members are
+    projected as ATTENDEE properties; without it no attendee data is
+    emitted at all, so callers stay in control of what member
+    information leaves the system.
+    """
     cal = Calendar()
     cal.add("prodid", "-//Tribu//Family Calendar//EN")
     cal.add("version", "2.0")
@@ -42,6 +96,27 @@ def events_to_ics(events, calendar_name="Tribu") -> str:
             vevent.add("description", ev.description)
         if getattr(ev, "location", None):
             vevent.add("location", ev.location)
+
+        assigned_to = getattr(ev, "assigned_to", None)
+        if member_names:
+            for user_id in _assigned_member_ids(assigned_to, member_names):
+                vevent.add("attendee", _member_attendee(user_id, member_names[user_id]), encode=False)
+            if assigned_to == "all":
+                vevent.add("X-TRIBU-ASSIGNED", vText("ALL"))
+
+        category = getattr(ev, "category", None)
+        if isinstance(category, str) and category.strip():
+            # One Tribu category maps to one CATEGORIES entry; the list
+            # form makes icalendar escape embedded commas instead of
+            # splitting the value into several categories.
+            vevent.add("categories", [category])
+
+        color = getattr(ev, "color", None)
+        if isinstance(color, str) and color.strip():
+            # Tribu colors are exact hex strings, but RFC 7986 COLOR only
+            # permits CSS3 color names. Emitting a rounded name would be
+            # lossy, so the exact value travels as an X- property instead.
+            vevent.add("X-TRIBU-COLOR", vText(color))
 
         if ev.all_day:
             dt_start = ev.starts_at.date() if isinstance(ev.starts_at, datetime) else ev.starts_at

--- a/backend/app/dav/caldav_storage.py
+++ b/backend/app/dav/caldav_storage.py
@@ -12,6 +12,7 @@ back into ``CalendarEvent`` rows and handling DELETE.
 from __future__ import annotations
 
 import hashlib
+import json
 import threading
 from contextlib import contextmanager
 from datetime import datetime
@@ -70,6 +71,34 @@ def _http_last_modified(dt: Optional[datetime]) -> str:
     if dt is None:
         dt = datetime(2000, 1, 1)
     return dt.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+
+def _family_member_names(db, family_id: int) -> dict[int, str]:
+    """Preload ``{user_id: display_name}`` for a family in one query.
+
+    Collection operations pass the mapping down to ``events_to_ics`` so
+    attendee projection never triggers per-event member lookups.
+    """
+    rows = (
+        db.query(User.id, User.display_name)
+        .join(Membership, Membership.user_id == User.id)
+        .filter(Membership.family_id == family_id)
+        .all()
+    )
+    return {int(user_id): display_name for user_id, display_name in rows}
+
+
+def _membership_fingerprint(member_names: Mapping[int, str]) -> str:
+    """Stable identity/display-name fingerprint of a family's membership.
+
+    Canonical JSON of the sorted ``(user_id, display_name)`` pairs keeps
+    the encoding unambiguous: display names containing separator
+    characters cannot collide with a differently-shaped membership, and
+    Unicode names serialize deterministically (``ensure_ascii=False``
+    with fixed separators).
+    """
+    pairs = sorted((int(user_id), name) for user_id, name in member_names.items())
+    return json.dumps(pairs, separators=(",", ":"), ensure_ascii=False)
 
 
 CALENDAR_PREFIX = "cal-"
@@ -141,13 +170,16 @@ class CalendarCollection(BaseCollection):
                 .order_by(CalendarEvent.id.asc())
                 .all()
             )
+            member_names = _family_member_names(db, self._family_id)
         for ev in rows:
-            yield self._event_to_item(ev)
+            yield self._event_to_item(ev, member_names)
 
     def get_multi(self, hrefs: Iterable[str]) -> Iterable[Tuple[str, Optional["radicale_item.Item"]]]:
+        with _db() as db:
+            member_names = _family_member_names(db, self._family_id)
         for href in hrefs:
             ev = self._find_event_by_href(href)
-            yield href, (self._event_to_item(ev) if ev is not None else None)
+            yield href, (self._event_to_item(ev, member_names) if ev is not None else None)
 
     def has_uid(self, uid: str) -> bool:
         with _db() as db:
@@ -185,7 +217,8 @@ class CalendarCollection(BaseCollection):
                 .order_by(CalendarEvent.id.asc())
                 .all()
             )
-        return events_to_ics(events, calendar_name=self._family_name)
+            member_names = _family_member_names(db, self._family_id)
+        return events_to_ics(events, calendar_name=self._family_name, member_names=member_names)
 
     def sync(self, old_token: str = "") -> Tuple[str, Iterable[str]]:
         # Deletion tombstones are not tracked yet, so handing a client
@@ -228,6 +261,7 @@ class CalendarCollection(BaseCollection):
             uid = str(fields.get("title") or href)
 
         with _db() as db:
+            member_names = _family_member_names(db, self._family_id)
             existing_by_href = (
                 db.query(CalendarEvent)
                 .filter(
@@ -255,7 +289,7 @@ class CalendarCollection(BaseCollection):
             existing = existing_by_href
             replaced_item: Optional["radicale_item.Item"] = None
             if existing is not None:
-                replaced_item = self._event_to_item(existing)
+                replaced_item = self._event_to_item(existing, member_names)
                 _apply_event_fields(existing, fields)
                 existing.ical_uid = uid
                 existing.dav_href = href
@@ -278,7 +312,7 @@ class CalendarCollection(BaseCollection):
                 # deterministic 4xx instead of letting the 500 leak.
                 raise ValueError(f"concurrent write conflict: {exc.orig}") from exc
             db.refresh(row)
-            stored_item = self._event_to_item(row)
+            stored_item = self._event_to_item(row, member_names)
         return stored_item, replaced_item
 
     def delete(self, href: Optional[str] = None) -> None:
@@ -327,8 +361,15 @@ class CalendarCollection(BaseCollection):
             .first()
         )
 
-    def _event_to_item(self, ev: CalendarEvent) -> "radicale_item.Item":
-        ics = events_to_ics([ev], calendar_name=self._family_name)
+    def _event_to_item(
+        self,
+        ev: CalendarEvent,
+        member_names: Optional[Mapping[int, str]] = None,
+    ) -> "radicale_item.Item":
+        if member_names is None:
+            with _db() as db:
+                member_names = _family_member_names(db, self._family_id)
+        ics = events_to_ics([ev], calendar_name=self._family_name, member_names=member_names)
         etag = f'"{hashlib.sha256(ics.encode("utf-8")).hexdigest()[:16]}"'
         mtime = ev.updated_at or ev.created_at
         return radicale_item.Item(
@@ -356,8 +397,18 @@ class CalendarCollection(BaseCollection):
                 .filter(CalendarEvent.family_id == self._family_id)
                 .count()
             )
-            latest = self._latest_change()
-        return hashlib.sha256(f"{count}:{latest}".encode("utf-8")).hexdigest()
+            latest = (
+                db.query(CalendarEvent.updated_at)
+                .filter(CalendarEvent.family_id == self._family_id)
+                .order_by(CalendarEvent.updated_at.desc())
+                .limit(1)
+                .scalar()
+            )
+            # Membership identity/display names feed the emitted ATTENDEE
+            # content, so a member add/remove/rename must invalidate
+            # collection enumeration even though no event row changed.
+            members = _membership_fingerprint(_family_member_names(db, self._family_id))
+        return hashlib.sha256(f"{count}:{latest}:{members}".encode("utf-8")).hexdigest()
 
     @staticmethod
     def _uid_to_event_id(uid: str) -> Optional[int]:

--- a/backend/app/modules/calendar_router.py
+++ b/backend/app/modules/calendar_router.py
@@ -95,6 +95,18 @@ def list_calendar_events(
     return PaginatedCalendarEvents(items=items, total=total, offset=offset, limit=limit)
 
 
+def _family_member_names(db: Session, family_id: int) -> dict[int, str]:
+    """Preload ``{user_id: display_name}`` once so ICS attendee
+    projection needs no per-event member queries."""
+    rows = (
+        db.query(User.id, User.display_name)
+        .join(Membership, Membership.user_id == User.id)
+        .filter(Membership.family_id == family_id)
+        .all()
+    )
+    return {int(user_id): display_name for user_id, display_name in rows}
+
+
 @router.get(
     "/events/export.ics",
     summary="Export calendar as ICS",
@@ -109,7 +121,7 @@ def export_calendar_ics(
 ):
     ensure_adult(db, user.id, family_id)
     events = db.query(CalendarEvent).filter(CalendarEvent.family_id == family_id).all()
-    ics_text = events_to_ics(events)
+    ics_text = events_to_ics(events, member_names=_family_member_names(db, family_id))
     return Response(
         content=ics_text,
         media_type="text/calendar",
@@ -131,7 +143,7 @@ def calendar_feed_ics(
 ):
     ensure_family_membership(db, user.id, family_id)
     events = db.query(CalendarEvent).filter(CalendarEvent.family_id == family_id).all()
-    ics_text = events_to_ics(events)
+    ics_text = events_to_ics(events, member_names=_family_member_names(db, family_id))
     return Response(
         content=ics_text,
         media_type="text/calendar",

--- a/backend/tests/test_calendar_ics_import.py
+++ b/backend/tests/test_calendar_ics_import.py
@@ -11,6 +11,7 @@ Covers two pieces of the calendar interoperability work:
 """
 
 import hashlib
+from datetime import datetime
 
 import pytest
 from fastapi.testclient import TestClient
@@ -276,3 +277,57 @@ class TestReimportUpdates:
         assert resp.status_code == 200, resp.text
         assert resp.json()["created"] == 2
         assert resp.json()["updated"] == 0
+
+
+# --- export / feed member projection -----------------------------------
+
+
+class TestExportMemberProjection:
+    def _seed_assigned_event(self) -> tuple[str, int, int]:
+        token, family_id = _seed_adult()
+        db = TestSession()
+        try:
+            user = db.query(User).filter(User.email == "cal@example.com").one()
+            db.add(CalendarEvent(
+                family_id=family_id,
+                title="Swim class",
+                starts_at=datetime(2026, 4, 1, 16, 0),
+                ends_at=datetime(2026, 4, 1, 17, 0),
+                all_day=False,
+                created_by_user_id=user.id,
+                assigned_to=[user.id],
+                category="Sport",
+                color="#123abc",
+            ))
+            db.commit()
+            return token, family_id, user.id
+        finally:
+            db.close()
+
+    def test_export_ics_includes_member_attendees(self):
+        token, family_id, user_id = self._seed_assigned_event()
+        client = TestClient(app)
+
+        resp = client.get(
+            f"/calendar/events/export.ics?family_id={family_id}",
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 200, resp.text
+        assert f"mailto:user-{user_id}@tribu.invalid" in resp.text
+        assert "CN=Cal" in resp.text
+        assert "CATEGORIES:Sport" in resp.text
+        assert "X-TRIBU-COLOR:#123abc" in resp.text
+        # Never the real login email.
+        assert "cal@example.com" not in resp.text
+
+    def test_feed_ics_includes_member_attendees(self):
+        token, family_id, user_id = self._seed_assigned_event()
+        client = TestClient(app)
+
+        resp = client.get(
+            f"/calendar/events/feed.ics?family_id={family_id}",
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 200, resp.text
+        assert f"mailto:user-{user_id}@tribu.invalid" in resp.text
+        assert "cal@example.com" not in resp.text

--- a/backend/tests/test_dav_caldav_read.py
+++ b/backend/tests/test_dav_caldav_read.py
@@ -69,6 +69,9 @@ def seeded(app_under_test):
             ends_at=datetime(2026, 5, 4, 11, 0),
             all_day=False,
             created_by_user_id=user.id,
+            assigned_to=[user.id],
+            category="Sport, Outdoor",
+            color="#ff0000",
         ))
         db.add(CalendarEvent(
             family_id=family.id,
@@ -100,6 +103,25 @@ def seeded(app_under_test):
 
 def _basic(login: str, token: str) -> str:
     return "Basic " + base64.b64encode(f"{login}:{token}".encode("utf-8")).decode("ascii")
+
+
+def _fetch_ctag(client: TestClient, headers: dict, family_id: int) -> str:
+    import re
+
+    body = (
+        '<?xml version="1.0"?>'
+        '<propfind xmlns="DAV:" xmlns:CS="http://calendarserver.org/ns/">'
+        '<prop><CS:getctag/></prop></propfind>'
+    )
+    resp = client.request(
+        "PROPFIND",
+        f"/dav/{EMAIL}/cal-{family_id}/",
+        headers={**headers, "Depth": "0", "Content-Type": "application/xml"},
+        content=body,
+    )
+    assert resp.status_code == 207, resp.text
+    match = re.search(r"<CS:getctag[^>]*>([^<]+)</CS:getctag>", resp.text)
+    return match.group(1) if match else ""
 
 
 def _propfind(client: TestClient, path: str, *, headers=None, depth="1"):
@@ -167,30 +189,13 @@ class TestCalDAVRead:
     def test_ctag_changes_when_event_is_edited(self, app_under_test, seeded):
         """Editing a stored event must bump the collection ctag so clients
         that poll CS:getctag before refetching notice the change."""
-        import re
         import time
 
         token, family_id = seeded
         client = TestClient(app_under_test)
         headers = {"Authorization": _basic(EMAIL, token)}
 
-        def fetch_ctag() -> str:
-            body = (
-                '<?xml version="1.0"?>'
-                '<propfind xmlns="DAV:" xmlns:CS="http://calendarserver.org/ns/">'
-                '<prop><CS:getctag/></prop></propfind>'
-            )
-            resp = client.request(
-                "PROPFIND",
-                f"/dav/{EMAIL}/cal-{family_id}/",
-                headers={**headers, "Depth": "0", "Content-Type": "application/xml"},
-                content=body,
-            )
-            assert resp.status_code == 207, resp.text
-            match = re.search(r"<CS:getctag[^>]*>([^<]+)</CS:getctag>", resp.text)
-            return match.group(1) if match else ""
-
-        ctag_before = fetch_ctag()
+        ctag_before = _fetch_ctag(client, headers, family_id)
         assert ctag_before, "ctag must be present"
 
         # Edit an existing event directly and bump updated_at.
@@ -204,7 +209,7 @@ class TestCalDAVRead:
         finally:
             db.close()
 
-        ctag_after = fetch_ctag()
+        ctag_after = _fetch_ctag(client, headers, family_id)
         assert ctag_after != ctag_before, (
             f"Expected ctag to change after edit. before={ctag_before!r} after={ctag_after!r}"
         )
@@ -372,3 +377,216 @@ class TestCalDAVRead:
         )
         # Radicale maps a ValueError from storage to a 4xx.
         assert 400 <= put.status_code < 500, put.text
+
+
+def _seeded_ids(family_id: int) -> tuple[int, int]:
+    """Return ``(user_id, team_sync_event_id)`` for the seeded fixture."""
+    db = SessionLocal()
+    try:
+        user = db.query(User).filter(User.email == EMAIL).one()
+        ev = (
+            db.query(CalendarEvent)
+            .filter(CalendarEvent.family_id == family_id, CalendarEvent.title == "Team sync")
+            .one()
+        )
+        return user.id, ev.id
+    finally:
+        db.close()
+
+
+def _attendee_list(vevent):
+    value = vevent.get("attendee")
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+class TestMembershipFingerprint:
+    def test_separator_characters_in_names_cannot_collide(self):
+        from app.dav.caldav_storage import _membership_fingerprint
+
+        # A display name containing the old separator characters must not
+        # serialize to the same fingerprint as a two-member family.
+        tricky = _membership_fingerprint({1: "A,2=B"})
+        two_members = _membership_fingerprint({1: "A", 2: "B"})
+        assert tricky != two_members
+
+    def test_equivalent_mappings_share_a_stable_fingerprint(self):
+        from app.dav.caldav_storage import _membership_fingerprint
+
+        ordered = _membership_fingerprint({1: "Änna", 2: "Ben"})
+        reversed_insertion = _membership_fingerprint({2: "Ben", 1: "Änna"})
+        assert ordered == reversed_insertion
+
+
+class TestCalDAVMemberProjection:
+    """Discussion #438: assigned members, category, and color must be
+    visible to CalDAV clients without letting lossy clients erase them."""
+
+    def test_event_get_emits_member_attendees_category_and_color(self, app_under_test, seeded):
+        from icalendar import Calendar
+
+        token, family_id = seeded
+        user_id, event_id = _seeded_ids(family_id)
+        client = TestClient(app_under_test)
+        auth = {"Authorization": _basic(EMAIL, token)}
+
+        resp = client.get(
+            f"/dav/{EMAIL}/cal-{family_id}/tribu-event-{event_id}.ics",
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        (vevent,) = [c for c in Calendar.from_ical(resp.text).walk("VEVENT")]
+
+        (attendee,) = _attendee_list(vevent)
+        assert str(attendee) == f"mailto:user-{user_id}@tribu.invalid"
+        assert str(attendee.params["CN"]) == "CalDAV User"
+        assert str(attendee.params["X-TRIBU-USER-ID"]) == str(user_id)
+
+        cats = vevent.get("categories")
+        assert [str(c) for c in cats.cats] == ["Sport, Outdoor"]
+        assert str(vevent.get("X-TRIBU-COLOR")) == "#ff0000"
+
+        # Privacy: the member's real login email must never appear in
+        # calendar data, and we do not emit ORGANIZER or lossy COLOR.
+        assert EMAIL not in resp.text
+        assert "ORGANIZER" not in resp.text
+        assert vevent.get("COLOR") is None
+
+    def test_lossy_put_preserves_assignment_category_and_color(self, app_under_test, seeded):
+        """A phone client that never saw ATTENDEE/CATEGORIES/X-TRIBU-COLOR
+        PUTs the event back without them; Tribu's fields must survive and
+        the following GET must re-emit them."""
+        token, family_id = seeded
+        user_id, _ = _seeded_ids(family_id)
+        client = TestClient(app_under_test)
+        auth = {"Authorization": _basic(EMAIL, token)}
+        put_headers = {**auth, "Content-Type": "text/calendar"}
+
+        def phone_ics(summary: str) -> str:
+            return (
+                "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Phone//EN\r\n"
+                "BEGIN:VEVENT\r\nUID:phone-lossy@example.com\r\n"
+                "DTSTAMP:20260101T000000Z\r\n"
+                "DTSTART:20260901T100000Z\r\nDTEND:20260901T110000Z\r\n"
+                f"SUMMARY:{summary}\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+            )
+
+        put1 = client.put(
+            f"/dav/{EMAIL}/cal-{family_id}/phone-lossy.ics",
+            headers=put_headers,
+            content=phone_ics("Doctor"),
+        )
+        assert put1.status_code in (201, 204), put1.text
+
+        # The family assigns the event in the Tribu UI.
+        db = SessionLocal()
+        try:
+            ev = (
+                db.query(CalendarEvent)
+                .filter(CalendarEvent.family_id == family_id, CalendarEvent.dav_href == "phone-lossy.ics")
+                .one()
+            )
+            ev.assigned_to = [user_id]
+            ev.category = "Health"
+            ev.color = "#00ff00"
+            db.commit()
+            event_pk = ev.id
+        finally:
+            db.close()
+
+        # Phone-like lossy overwrite: only the summary changed.
+        put2 = client.put(
+            f"/dav/{EMAIL}/cal-{family_id}/phone-lossy.ics",
+            headers=put_headers,
+            content=phone_ics("Doctor (moved)"),
+        )
+        assert put2.status_code in (201, 204), put2.text
+
+        db = SessionLocal()
+        try:
+            ev = db.query(CalendarEvent).filter(CalendarEvent.id == event_pk).one()
+            assert ev.title == "Doctor (moved)"
+            assert ev.assigned_to == [user_id]
+            assert ev.category == "Health"
+            assert ev.color == "#00ff00"
+        finally:
+            db.close()
+
+        get = client.get(f"/dav/{EMAIL}/cal-{family_id}/phone-lossy.ics", headers=auth)
+        assert get.status_code == 200, get.text
+        assert "Doctor (moved)" in get.text
+        assert f"mailto:user-{user_id}@tribu.invalid" in get.text
+        assert "CATEGORIES:Health" in get.text
+        assert "X-TRIBU-COLOR:#00ff00" in get.text
+
+    def test_ctag_changes_after_member_rename_and_membership_change(self, app_under_test, seeded):
+        """Member renames/additions change emitted ATTENDEE content without
+        touching any event row, so the collection ctag must reflect the
+        family membership fingerprint."""
+        token, family_id = seeded
+        client = TestClient(app_under_test)
+        headers = {"Authorization": _basic(EMAIL, token)}
+
+        ctag_initial = _fetch_ctag(client, headers, family_id)
+        assert ctag_initial
+
+        db = SessionLocal()
+        try:
+            user = db.query(User).filter(User.email == EMAIL).one()
+            user.display_name = "CalDAV User (renamed)"
+            db.commit()
+        finally:
+            db.close()
+
+        ctag_after_rename = _fetch_ctag(client, headers, family_id)
+        assert ctag_after_rename != ctag_initial
+
+        db = SessionLocal()
+        try:
+            extra = User(
+                email="dav-caldav-second@example.com",
+                password_hash=hash_password("x"),
+                display_name="Second Member",
+            )
+            db.add(extra)
+            db.flush()
+            db.add(Membership(user_id=extra.id, family_id=family_id, role="member", is_adult=True))
+            db.commit()
+        finally:
+            db.close()
+
+        ctag_after_join = _fetch_ctag(client, headers, family_id)
+        assert ctag_after_join not in (ctag_initial, ctag_after_rename)
+
+    def test_collection_serialize_has_no_per_event_member_queries(self, app_under_test, seeded):
+        """The member mapping must be preloaded once per collection
+        operation, not looked up per event (N+1)."""
+        from typing import cast
+
+        from sqlalchemy import event as sa_event
+
+        from app.database import engine
+        from app.dav.caldav_storage import CalendarCollection, Storage
+
+        token, family_id = seeded
+        coll = CalendarCollection(cast(Storage, None), EMAIL, family_id, "CalDAV Family")
+
+        statements: list[str] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        sa_event.listen(engine, "before_cursor_execute", record)
+        try:
+            ics = coll.serialize()
+        finally:
+            sa_event.remove(engine, "before_cursor_execute", record)
+
+        # Both seeded events serialize with member context...
+        assert ics.count("BEGIN:VEVENT") == 2
+        # ...from exactly one event query and at most one member query.
+        event_queries = [s for s in statements if "calendar_events" in s]
+        member_queries = [s for s in statements if "users" in s]
+        assert len(event_queries) == 1, statements
+        assert len(member_queries) <= 1, statements

--- a/backend/tests/test_ics_utils.py
+++ b/backend/tests/test_ics_utils.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from types import SimpleNamespace
 
+from icalendar import Calendar
 
 from app.core.ics_utils import events_to_ics, ics_to_event_dicts
 
@@ -119,6 +120,140 @@ class TestEventsToIcs:
         assert "Event A" in ics
         assert "Event B" in ics
         assert "Event C" in ics
+
+
+# --- member/category/color projection ---
+
+
+def _vevents(ics: str):
+    return [c for c in Calendar.from_ical(ics).walk("VEVENT")]
+
+
+def _attendees(component):
+    value = component.get("attendee")
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+class TestMemberProjection:
+    MEMBERS = {1: "Anna", 2: "Ben", 3: "Chris, the 3rd"}
+
+    def test_attendee_per_assigned_member(self):
+        ev = make_event(assigned_to=[1, 2])
+        ics = events_to_ics([ev], member_names=self.MEMBERS)
+        (vevent,) = _vevents(ics)
+        attendees = _attendees(vevent)
+        assert len(attendees) == 2
+        by_id = {str(a.params["X-TRIBU-USER-ID"]): a for a in attendees}
+        assert set(by_id) == {"1", "2"}
+        anna = by_id["1"]
+        assert str(anna) == "mailto:user-1@tribu.invalid"
+        assert str(anna.params["CN"]) == "Anna"
+        assert str(anna.params["CUTYPE"]) == "INDIVIDUAL"
+        assert str(anna.params["ROLE"]) == "REQ-PARTICIPANT"
+        assert str(anna.params["PARTSTAT"]) == "ACCEPTED"
+        assert str(anna.params["RSVP"]) == "FALSE"
+
+    def test_assigned_all_emits_every_member_and_marker(self):
+        ev = make_event(assigned_to="all")
+        ics = events_to_ics([ev], member_names=self.MEMBERS)
+        (vevent,) = _vevents(ics)
+        attendees = _attendees(vevent)
+        assert len(attendees) == len(self.MEMBERS)
+        ids = {str(a.params["X-TRIBU-USER-ID"]) for a in attendees}
+        assert ids == {"1", "2", "3"}
+        assert str(vevent.get("X-TRIBU-ASSIGNED")) == "ALL"
+
+    def test_list_assignment_has_no_all_marker(self):
+        ev = make_event(assigned_to=[1])
+        ics = events_to_ics([ev], member_names=self.MEMBERS)
+        assert "X-TRIBU-ASSIGNED" not in ics
+
+    def test_stale_member_ids_are_skipped(self):
+        ev = make_event(assigned_to=[1, 999, "not-an-id", None])
+        ics = events_to_ics([ev], member_names=self.MEMBERS)
+        (vevent,) = _vevents(ics)
+        attendees = _attendees(vevent)
+        assert len(attendees) == 1
+        assert str(attendees[0].params["X-TRIBU-USER-ID"]) == "1"
+
+    def test_no_attendees_without_mapping(self):
+        ev = make_event(assigned_to=[1, 2])
+        ics = events_to_ics([ev])
+        assert "ATTENDEE" not in ics
+        assert "X-TRIBU-ASSIGNED" not in ics
+
+    def test_no_attendees_for_null_or_empty_assignment(self):
+        for assigned in (None, []):
+            ev = make_event(assigned_to=assigned)
+            ics = events_to_ics([ev], member_names=self.MEMBERS)
+            assert "ATTENDEE" not in ics
+            assert "X-TRIBU-ASSIGNED" not in ics
+
+    def test_no_real_email_addresses_leak(self):
+        members = {1: "anna.real@example.com"}
+        ev = make_event(assigned_to=[1])
+        ics = events_to_ics([ev], member_names=members)
+        (vevent,) = _vevents(ics)
+        (attendee,) = _attendees(vevent)
+        # The cal-address must be synthetic even if a display name looks
+        # like an email; the name only ever appears as the CN parameter.
+        assert str(attendee) == "mailto:user-1@tribu.invalid"
+        assert "mailto:anna.real@example.com" not in ics
+
+    def test_no_organizer_emitted(self):
+        ev = make_event(assigned_to=[1, 2])
+        ics = events_to_ics([ev], member_names=self.MEMBERS)
+        assert "ORGANIZER" not in ics
+
+    def test_attendee_output_reparses_cleanly(self):
+        ev = make_event(assigned_to="all")
+        ics = events_to_ics([ev], member_names=self.MEMBERS)
+        valid, errors = ics_to_event_dicts(ics, family_id=1, user_id=1)
+        assert errors == []
+        assert len(valid) == 1
+
+
+class TestCategoryProjection:
+    def test_category_emitted_as_categories(self):
+        ev = make_event(category="Sport")
+        ics = events_to_ics([ev])
+        (vevent,) = _vevents(ics)
+        cats = vevent.get("categories")
+        assert [str(c) for c in cats.cats] == ["Sport"]
+
+    def test_category_with_comma_survives_as_single_category(self):
+        ev = make_event(category="Family, Fun")
+        ics = events_to_ics([ev])
+        (vevent,) = _vevents(ics)
+        cats = vevent.get("categories")
+        # One Tribu category containing a comma must stay ONE category
+        # (escaped per RFC 5545), not split into two.
+        assert [str(c) for c in cats.cats] == ["Family, Fun"]
+
+    def test_no_categories_for_empty_or_missing_category(self):
+        for category in (None, "", "   "):
+            ev = make_event(category=category)
+            ics = events_to_ics([ev])
+            assert "CATEGORIES" not in ics
+
+
+class TestColorProjection:
+    def test_hex_color_emitted_as_x_prop_only(self):
+        ev = make_event(color="#a1b2c3")
+        ics = events_to_ics([ev])
+        (vevent,) = _vevents(ics)
+        assert str(vevent.get("X-TRIBU-COLOR")) == "#a1b2c3"
+        # RFC 7986 COLOR only allows CSS3 named colors; emitting the hex
+        # value there would be lossy/non-conformant, so it must be absent.
+        assert vevent.get("COLOR") is None
+
+    def test_no_color_props_when_color_missing(self):
+        ev = make_event(color=None)
+        ics = events_to_ics([ev])
+        assert "X-TRIBU-COLOR" not in ics
+        assert "COLOR" not in ics.replace("X-TRIBU-COLOR", "")
 
 
 # --- ics_to_event_dicts ---


### PR DESCRIPTION
## Summary

- expose assigned family members in CalDAV and ICS output with privacy-safe synthetic attendee addresses and readable member names
- include event categories and exact Tribu colors without exposing login email addresses or enabling invitation scheduling
- keep Tribu-owned assignment, category, and color values intact when a calendar client writes back a reduced event
- invalidate CalDAV collection state when family membership or display names change

## File placement

- iCalendar projection stays in the pure ICS serializer
- DAV and REST entry points preload family-member context before serialization
- database writes keep their existing narrow field allowlist

## Validation

- 62 focused ICS, export, and CalDAV tests
- 57 neighboring calendar and DAV tests
- regression tests cover privacy, escaping, stale members, all-family assignment, lossy client writes, collection invalidation, and query shape

## Compatibility

Existing clients can ignore the additional fields. Tribu does not emit `ORGANIZER`, real member email addresses, or standards-based `COLOR` with an invalid hex value. Actual attendee rendering varies between calendar clients, so an iOS and DAVx5 smoke remains useful after deployment.

Discussion: https://github.com/itsDNNS/tribu/discussions/438
