### PR TITLE
fix(deps): resolve frontend security advisories via overrides

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2620,9 +2620,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4457,9 +4457,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4712,9 +4712,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,10 +22,12 @@
   },
   "overrides": {
     "minimatch": "^10.2.4",
+    "brace-expansion": "^5.0.9",
     "glob": "^11.0.2",
     "postcss": "^8.5.23",
     "@babel/core": "7.29.6",
-    "js-yaml": "4.3.0",
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.18",
     "sharp": "^0.35.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Schliesst die beiden offenen Frontend-Dependabot-Alerts und einen zusaetzlichen Befund, den `npm audit` meldet, Dependabot aber nicht gelistet hat.

| Paket | Vorher | Nachher | Advisory | Scope |
|---|---|---|---|---|
| js-yaml | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj (#61) | dev |
| nanoid | 3.3.16 | 3.3.18 | GHSA-2v37-7h3g-55p8 (#63) | runtime, transitiv via postcss |
| brace-expansion | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 | dev, transitiv via minimatch |

### Der eigentliche Befund bei js-yaml

Der `overrides`-Block in `frontend/package.json` nagelte js-yaml auf exakt `4.3.0` fest — genau die verwundbare Version. **Dependabot konnte diesen Alert prinzipiell nicht selbst schliessen**, weil ein npm-Override jedes Update ueberstimmt. Der Eintrag steht jetzt auf `^4.3.1`, damit kuenftige Patches ohne manuellen Eingriff durchkommen.

### brace-expansion ausserhalb der Alert-Liste

`npm audit` meldete nach dem Lockfile-Refresh eine dritte High-Severity-Luecke, die auf der Dependabot-Seite nicht steht. Da sie dieselbe Datei betrifft und mit einer Zeile sicher behebbar war, ist sie hier mit erledigt statt separat nachgereicht.

## Geaenderte Dateien

| Datei | Grund |
|---|---|
| `frontend/package.json` | drei Override-Eintraege korrigiert bzw. ergaenzt |
| `frontend/package-lock.json` | Refresh via `npm install --package-lock-only`; Diff umfasst **ausschliesslich** diese drei Pakete (6 Zeilen +/-), keine Kollateral-Upgrades |

## Verifikation

| Gate | Befehl | Ergebnis |
|---|---|---|
| Audit | `npm audit` | `found 0 vulnerabilities` (vorher: 1 high) |
| Unit-Tests | `npm test` | 64/64 Suites, **451/451 Tests gruen**, 4.9s |
| Build | `npm run build` | `Compiled successfully`, 5/5 statische Seiten generiert |
| Install | `npm ci` | sauber aus dem Lockfile |
| Whitespace | `git diff --check` | clean, Exit 0 |

## Risiken

Gering. Alle drei Aenderungen sind Patch-Level innerhalb derselben Major-Version. Zwei der drei Pakete sind dev-only und erreichen kein Nutzer-Artefakt. nanoid liegt im Runtime-Baum, wird aber nur von postcss zur Build-Zeit genutzt.

Anmerkung zum Stil: `js-yaml` war exakt gepinnt, ist jetzt ein Caret-Range. Das war Absicht — die exakte Pinnung war die Ursache des Alerts. Wenn du die harte Pinnung bevorzugst, ist das ein Ein-Wort-Change.