### PR TITLE
ci: add Dependabot configuration for all four ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,83 @@
+version: 2
+
+# Keeps dependencies current across all four ecosystems used in this repo.
+# Security updates run immediately and are not bound by this schedule.
+#
+# Grouping: minor and patch updates are bundled into one PR per ecosystem,
+# while major updates are raised individually. This keeps the weekly PR load
+# low without hiding breaking changes inside a combined PR.
+
+updates:
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      frontend-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      backend-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore(ci)
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore(docker)
+
+  - package-ecosystem: docker
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore(docker)


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml`. There was no configuration before, so **only** security updates were raised as pull requests — regular version updates never happened at all.
- Covers every ecosystem present in the repo: npm (`/frontend`), pip (`/backend`), github-actions (`/`) and docker (both Dockerfiles).
- Minor and patch updates are grouped per ecosystem; major updates are raised individually.

## Why this belongs here

`.github/dependabot.yml` is the only path GitHub reads this configuration from, so the file placement is fixed. It touches no application boundary and no runtime code; it only controls which pull requests Dependabot opens.

No workflow is modified directly. Indirectly, the `github-actions` ecosystem will keep the pins in `backend-tests.yml`, `docker.yml` and `e2e.yml` current (currently `actions/checkout@v6`, `docker/build-push-action@v7` and others).

## Test plan

- [x] not run
- [ ] frontend tests
- [ ] backend tests
- [ ] build
- [ ] e2e
- [ ] docs only

No test suite applies — the file contains no executable code. Verified instead:

| Gate | Result |
|---|---|
| YAML syntax (`yaml.safe_load`) | valid, `version: 2`, 5 entries parsed correctly |
| `git diff --check` | clean, exit 0 |
| Ecosystem cross-check against the repo | npm / pip / actions / docker — every existing manifest covered, no superfluous entries |

GitHub itself provides the final confirmation: after merge, **Insights → Dependency graph → Dependabot** shows whether the file was accepted and when the next run is due.

## Docs impact

- [x] no docs changes needed

Pure CI configuration with no effect on setup, operation or self-hosting.

## Follow-up notes

Two deliberate choices you may want to revisit:

1. **Schedule `weekly`, Monday 06:00 Europe/Berlin.** `daily` would produce noticeably more pull requests. Security updates are independent of this and still arrive immediately.
2. **Grouping minor + patch.** This cuts the pull request load significantly but makes each combined pull request larger. Major updates stay ungrouped on purpose.

`open-pull-requests-limit` is 5 for npm and pip, 3 for actions and docker. That is the first knob to turn if the weekly load feels too high.