### PR TITLE
ci: limit the github-actions group to minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: /backend


### PR DESCRIPTION
## Summary

- The `github-actions` group in `.github/dependabot.yml` matched every update type, so major action bumps were bundled together with routine ones.
- The `npm` and `pip` groups were already restricted to `minor` and `patch`. This brings the actions group in line.
- Major action updates now arrive as individual pull requests.

This surfaced immediately: #444 combined `actions/checkout`, `actions/setup-node` and `actions/setup-python` from v6 to v7 — three major bumps in one grouped pull request. That is exactly the case the grouping was not meant to cover.

## Why this belongs here

Same file and same concern as the configuration added in #441; no new boundary is introduced.

## Test plan

- [x] not run
- [ ] frontend tests
- [ ] backend tests
- [ ] build
- [ ] e2e
- [ ] docs only

No test suite applies. Verified with `yaml.safe_load` (valid, all three groups now carry `update-types: [minor, patch]`) and `git diff --check` (clean).

## Docs impact

- [x] no docs changes needed