### PR TITLE
fix(deps): upgrade lucide-react to v1 and vendor the GitHub mark

### DIFF
--- a/frontend/components/AuthPage.js
+++ b/frontend/components/AuthPage.js
@@ -1,10 +1,28 @@
 import { useEffect, useState } from 'react';
-import { Users, Play, Globe, CalendarDays, CheckSquare, ShoppingCart, Bell, Server, Lock, Github, KeyRound } from 'lucide-react';
+import { Users, Play, Globe, CalendarDays, CheckSquare, ShoppingCart, Bell, Server, Lock, KeyRound } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { useToast } from '../contexts/ToastContext';
 import { errorText } from '../lib/helpers';
 import { t } from '../lib/i18n';
 import * as api from '../lib/api';
+
+// lucide-react dropped its brand icons in v1, so the GitHub mark is kept
+// locally. It is decorative only: the link already carries a visible
+// "GitHub" label, so the SVG stays aria-hidden.
+function GithubMark({ size = 14 }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 .5C5.73.5.5 5.73.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2.17c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.2.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5Z" />
+    </svg>
+  );
+}
 
 // Translate a ?sso_error= tag from the callback redirect into a
 // user-facing string. Unknown tags fall back to the generic message
@@ -256,7 +274,7 @@ export default function AuthPage() {
       {/* Footer */}
       <footer className="landing-footer">
         <a href="https://github.com/itsDNNS/tribu" target="_blank" rel="noopener noreferrer" className="landing-footer-link">
-          <Github size={14} aria-hidden="true" />
+          <GithubMark size={14} />
           GitHub
         </a>
         <span className="landing-footer-dot">·</span>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tribu-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "lucide-react": "^0.542.0",
+        "lucide-react": "^1.31.0",
         "next": "16.2.12",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -4593,9 +4593,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.542.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
-      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.33.0.tgz",
+      "integrity": "sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "lucide-react": "^0.542.0",
+    "lucide-react": "^1.31.0",
     "next": "16.2.12",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## Summary

- Upgrades `lucide-react` from 0.542.0 to v1 (lockfile resolves to 1.33.0).
- v1 removed **all brand icons**, so the `Github` export no longer exists. `components/AuthPage.js` imported it for the landing page footer, which made the frontend build fail outright.
- The mark is now a small local `GithubMark` component in the same file.

Replaces #449, which bumped the version only and could not build.

### The failure #449 would have shipped

```
./components/AuthPage.js:2:1
Export Github doesn't exist in target module
The export Github was not found in module lucide-react/dist/esm/lucide-react.mjs
```

## Why this belongs here

The icon lives in the only file that used it, so no new module or boundary is introduced. A shared icon module would be premature for a single decorative usage.

The SVG is decorative: the footer link already renders a visible "GitHub" label next to it, so the mark keeps `aria-hidden="true"` and `focusable="false"` and carries no separate accessible name. `currentColor` preserves the existing `.landing-footer-link` hover behaviour.

## Test plan

- [x] frontend tests
- [x] build
- [ ] backend tests
- [ ] e2e
- [ ] not run
- [ ] docs only

| Gate | Command | Result |
|---|---|---|
| Build | `npm run build` | `Compiled successfully`, 5/5 static pages |
| Unit tests | `npm test` | 64/64 suites, **451/451 tests green** |
| Audit | `npm audit` | `found 0 vulnerabilities` |
| Icon coverage | export cross-check | all **97** remaining lucide icons used in the frontend exist in the installed version |
| Whitespace | `git diff --check` | clean, exit 0 |

The icon cross-check parses every `import { … } from 'lucide-react'` in the frontend and compares the names against the exports of the installed package, so a second removed icon could not slip through unnoticed.

## Docs impact

- [x] no docs changes needed

## Follow-up notes

Worth a quick look at the rendered footer after merge — the vendored mark is the official GitHub glyph path at 24x24, but only a visual check confirms it sits identically to the old lucide icon.