### PR TITLE
Fix Quick Capture contrast across themes

### DIFF
--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -8,6 +8,14 @@ function parseRgb(value) {
   return match.slice(1, 4).map(Number);
 }
 
+function compositeRgb(foreground, background, opacity = 1) {
+  const foregroundRgb = parseRgb(foreground);
+  const backgroundRgb = Array.isArray(background) ? background : parseRgb(background);
+  const alphaMatch = foreground.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\s*\)/);
+  const alpha = (alphaMatch ? Number(alphaMatch[1]) : 1) * opacity;
+  return foregroundRgb.map((channel, index) => (channel * alpha) + (backgroundRgb[index] * (1 - alpha)));
+}
+
 function relativeLuminance([r, g, b]) {
   const [rs, gs, bs] = [r, g, b].map((channel) => {
     const value = channel / 255;
@@ -175,6 +183,41 @@ test.describe('Dashboard', () => {
     await expect(quickCapture.getByRole('button', { name: 'Task' })).toBeEnabled();
     await expect(quickCapture.getByRole('button', { name: 'Shopping' })).toBeEnabled();
     await expect(quickCapture.getByRole('button', { name: 'Note' })).toBeEnabled();
+  });
+
+  test('keeps the quick capture placeholder readable in all themes', async ({ authedPage: page }) => {
+    for (const theme of ['light', 'dark', 'midnight-glass']) {
+      await page.evaluate((themeKey) => {
+        window.localStorage.setItem('tribu_theme', themeKey);
+      }, theme);
+      await page.reload();
+      await expect(page.locator('html')).toHaveAttribute('data-theme', theme, { timeout: 10000 });
+
+      const input = page.locator('.quick-capture-input');
+      await expect(input).toBeVisible({ timeout: 10000 });
+      const colors = await input.evaluate((element) => {
+        const inputStyle = window.getComputedStyle(element);
+        const placeholderStyle = window.getComputedStyle(element, '::placeholder');
+        const surfaceStyle = window.getComputedStyle(element.closest('.bento-card'));
+        return {
+          inputBackground: inputStyle.backgroundColor,
+          inputColor: inputStyle.color,
+          placeholderColor: placeholderStyle.color,
+          placeholderOpacity: Number(placeholderStyle.opacity),
+          surfaceBackground: surfaceStyle.backgroundColor,
+        };
+      });
+
+      const renderedBackground = compositeRgb(colors.inputBackground, colors.surfaceBackground);
+      const renderedPlaceholder = compositeRgb(colors.placeholderColor, renderedBackground, colors.placeholderOpacity);
+      const ratio = contrastRatio(renderedPlaceholder, renderedBackground);
+      expect(ratio, `${theme} quick capture placeholder contrast`).toBeGreaterThanOrEqual(4.5);
+
+      await input.fill('Readable quick capture text');
+      await expect(input).toHaveValue('Readable quick capture text');
+      const inputRatio = contrastRatio(parseRgb(colors.inputColor), renderedBackground);
+      expect(inputRatio, `${theme} quick capture text contrast`).toBeGreaterThanOrEqual(4.5);
+    }
   });
 
   test('today status tiles navigate to their owning modules', async ({ authedPage: page }) => {

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -939,7 +939,8 @@ body { font-family: var(--font-ui); background: var(--void); color: var(--text-p
 .quick-capture-intro { margin: 4px 0 0; color: var(--text-muted); font-size: 0.84rem; }
 .quick-capture-form { display: grid; gap: var(--space-sm); }
 .quick-capture-form--command { grid-template-columns: minmax(220px, 1fr) auto; align-items: center; gap: 12px; }
-.quick-capture-input { width: 100%; min-height: 44px; max-height: 44px; resize: none; border: 1px solid rgba(120, 130, 180, 0.16); border-radius: 10px; padding: 12px 14px; background: rgba(255, 255, 255, 0.36); color: var(--text-primary); font: inherit; line-height: 1.2; overflow: hidden; }
+.quick-capture-input { width: 100%; min-height: 44px; max-height: 44px; resize: none; border: 1px solid rgba(120, 130, 180, 0.16); border-radius: 10px; padding: 12px 14px; background: var(--surface-raised); color: var(--text-primary); font: inherit; line-height: 1.2; overflow: hidden; }
+.quick-capture-input::placeholder { color: var(--text-muted); opacity: 1; }
 .quick-capture-input:focus { outline: 2px solid rgba(139, 92, 246, 0.24); border-color: rgba(139, 92, 246, 0.36); }
 .quick-capture-actions { display: flex; flex-wrap: nowrap; gap: 10px; justify-content: flex-start; }
 .quick-capture-actions .btn-sm { min-height: 44px; padding: 0 15px; border-radius: 10px; background: var(--surface-raised); border: 1px solid var(--glass-border); color: var(--text-primary); box-shadow: none; white-space: nowrap; }


### PR DESCRIPTION
## Summary
- use theme surface and text tokens for the Quick Capture input and placeholder
- keep placeholder and entered text readable in light, dark, and midnight glass themes
- add browser contrast coverage for all three themes

## Checks
- Frontend unit tests: 451 passed
- Next.js production build
- Quick Capture Playwright regression in Desktop Chrome and Mobile Chrome
- Visual smoke in light, dark, and midnight glass

Follow-up to https://github.com/itsDNNS/tribu/discussions/154#discussioncomment-18096568
