### PR TITLE
Fix shopping item category reuse and duplicate merging

### DIFF
--- a/backend/alembic/versions/0054_add_family_product_preferences.py
+++ b/backend/alembic/versions/0054_add_family_product_preferences.py
@@ -1,0 +1,87 @@
+"""add family product category preferences
+
+Revision ID: 0054_product_preferences
+Revises: 0053_ui_preferences
+Create Date: 2026-08-20 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0054_product_preferences"
+down_revision: Union[str, None] = "0053_ui_preferences"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "family_product_preferences",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("family_id", sa.Integer(), nullable=False),
+        sa.Column("normalized_name", sa.String(length=400), nullable=False),
+        sa.Column("category", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["family_id"], ["families.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "length(trim(category)) > 0",
+            name="ck_family_product_preference_category_nonempty",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "family_id",
+            "normalized_name",
+            name="uq_family_product_preference_family_name",
+        ),
+    )
+    op.create_index(
+        op.f("ix_family_product_preferences_family_id"),
+        "family_product_preferences",
+        ["family_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_family_product_preferences_id"),
+        "family_product_preferences",
+        ["id"],
+        unique=False,
+    )
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.text("""
+        SELECT sl.family_id, si.name, si.category, si.created_at, si.id
+        FROM shopping_items AS si
+        JOIN shopping_lists AS sl ON sl.id = si.list_id
+        WHERE si.category IS NOT NULL
+        ORDER BY sl.family_id ASC, si.created_at ASC, si.id ASC
+    """)).mappings()
+    latest: dict[tuple[int, str], dict[str, object]] = {}
+    for row in rows:
+        name = str(row["name"] or "").strip()
+        category = str(row["category"] or "").strip()
+        if not name or not category:
+            continue
+        normalized_name = name.casefold()
+        latest[(int(row["family_id"]), normalized_name)] = {
+            "family_id": int(row["family_id"]),
+            "normalized_name": normalized_name,
+            "category": category,
+        }
+    if latest:
+        preferences = sa.table(
+            "family_product_preferences",
+            sa.column("family_id", sa.Integer()),
+            sa.column("normalized_name", sa.String()),
+            sa.column("category", sa.String()),
+        )
+        op.bulk_insert(preferences, list(latest.values()))
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_family_product_preferences_id"), table_name="family_product_preferences")
+    op.drop_index(op.f("ix_family_product_preferences_family_id"), table_name="family_product_preferences")
+    op.drop_table("family_product_preferences")

--- a/backend/app/core/shopping_domain.py
+++ b/backend/app/core/shopping_domain.py
@@ -1,0 +1,302 @@
+"""Backend-authoritative shopping-item reuse and product preferences.
+
+This module owns shopping name/detail normalization and the add/merge/restore
+state transition.  It deliberately does not commit or dispatch any events;
+route handlers retain those orchestration responsibilities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+import re
+from typing import Literal
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.utils import utcnow
+from app.models import FamilyProductPreference, ShoppingItem, ShoppingList
+
+
+ShoppingItemAction = Literal["created", "merged", "restored"]
+
+
+class InvalidShoppingItemName(ValueError):
+    """Raised when a shopping-item name is empty after trimming."""
+
+
+@dataclass(frozen=True)
+class ParsedQuantity:
+    amount: Decimal
+    unit: str | None
+    display_unit: str | None
+
+
+@dataclass(frozen=True)
+class ShoppingItemTransition:
+    item: ShoppingItem
+    action: ShoppingItemAction
+    previous_spec: str | None = None
+    previous_category: str | None = None
+
+
+_QUANTITY_RE = re.compile(
+    r"^(?P<amount>(?:\d+(?:[.,]\d+)?|[.,]\d+))(?:\s*(?P<unit>[^\d\s.,].*))?$"
+)
+
+
+def clean_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def normalize_item_name(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise InvalidShoppingItemName("Shopping item name cannot be blank")
+    return f"{cleaned[:1].upper()}{cleaned[1:]}"
+
+
+def normalize_product_name(value: str) -> str:
+    """Return the durable family-preference and matching key for a name."""
+    return value.strip().casefold()
+
+
+def _clean_unit(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = " ".join(value.split())
+    return cleaned or None
+
+
+def parse_quantity(value: str | None) -> ParsedQuantity | None:
+    cleaned = clean_optional_text(value)
+    if cleaned is None:
+        return None
+    match = _QUANTITY_RE.fullmatch(cleaned)
+    if match is None:
+        return None
+    try:
+        amount = Decimal(match.group("amount").replace(",", "."))
+    except InvalidOperation:
+        return None
+    display_unit = _clean_unit(match.group("unit"))
+    return ParsedQuantity(
+        amount=amount,
+        unit=display_unit.casefold() if display_unit is not None else None,
+        display_unit=display_unit,
+    )
+
+
+def _format_decimal(value: Decimal) -> str:
+    formatted = format(value, "f")
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
+def format_quantity(quantity: ParsedQuantity, *, display_unit: str | None = None) -> str:
+    unit = display_unit if display_unit is not None else quantity.display_unit
+    amount = _format_decimal(quantity.amount)
+    return f"{amount} {unit}" if unit else amount
+
+
+def normalize_spec(value: str | None) -> str | None:
+    cleaned = clean_optional_text(value)
+    quantity = parse_quantity(cleaned)
+    return format_quantity(quantity) if quantity is not None else cleaned
+
+
+def specs_are_compatible(left: str | None, right: str | None) -> bool:
+    left_clean = clean_optional_text(left)
+    right_clean = clean_optional_text(right)
+    if left_clean is None or right_clean is None:
+        return True
+
+    left_quantity = parse_quantity(left_clean)
+    right_quantity = parse_quantity(right_clean)
+    if left_quantity is not None or right_quantity is not None:
+        return (
+            left_quantity is not None
+            and right_quantity is not None
+            and left_quantity.unit == right_quantity.unit
+        )
+    return left_clean.casefold() == right_clean.casefold()
+
+
+def _merged_active_spec(existing: str | None, incoming: str | None) -> str | None:
+    existing_clean = clean_optional_text(existing)
+    incoming_clean = clean_optional_text(incoming)
+    if existing_clean is None:
+        return normalize_spec(incoming_clean)
+    if incoming_clean is None:
+        return existing_clean
+
+    existing_quantity = parse_quantity(existing_clean)
+    incoming_quantity = parse_quantity(incoming_clean)
+    if existing_quantity is not None and incoming_quantity is not None:
+        merged = ParsedQuantity(
+            amount=existing_quantity.amount + incoming_quantity.amount,
+            unit=existing_quantity.unit,
+            display_unit=existing_quantity.display_unit or incoming_quantity.display_unit,
+        )
+        return format_quantity(merged)
+    return existing_clean
+
+
+def _restored_spec(existing: str | None, incoming: str | None) -> str | None:
+    existing_clean = clean_optional_text(existing)
+    incoming_clean = clean_optional_text(incoming)
+    if incoming_clean is None:
+        return existing_clean
+    return normalize_spec(incoming_clean)
+
+
+def remember_category(
+    db: Session,
+    *,
+    family_id: int,
+    name: str,
+    category: str | None,
+) -> FamilyProductPreference | None:
+    """Persist an explicit category without poisoning the caller transaction.
+
+    The nested transaction confines a concurrent unique-key insert failure to
+    a savepoint.  The winning row is then loaded and updated portably without
+    dialect-specific upsert syntax.
+    """
+    cleaned_category = clean_optional_text(category)
+    if cleaned_category is None:
+        return None
+    normalized_name = normalize_product_name(name)
+    preference = db.query(FamilyProductPreference).filter(
+        FamilyProductPreference.family_id == family_id,
+        FamilyProductPreference.normalized_name == normalized_name,
+    ).first()
+    if preference is not None:
+        preference.category = cleaned_category
+        preference.updated_at = utcnow()
+        db.flush()
+        return preference
+
+    try:
+        with db.begin_nested():
+            preference = FamilyProductPreference(
+                family_id=family_id,
+                normalized_name=normalized_name,
+                category=cleaned_category,
+            )
+            db.add(preference)
+            db.flush()
+    except IntegrityError:
+        preference = db.query(FamilyProductPreference).filter(
+            FamilyProductPreference.family_id == family_id,
+            FamilyProductPreference.normalized_name == normalized_name,
+        ).one()
+        preference.category = cleaned_category
+        preference.updated_at = utcnow()
+        db.flush()
+    return preference
+
+
+def resolve_category(
+    db: Session,
+    *,
+    family_id: int,
+    name: str,
+    category: str | None,
+) -> str | None:
+    explicit = clean_optional_text(category)
+    if explicit is not None:
+        remember_category(db, family_id=family_id, name=name, category=explicit)
+        return explicit
+    preference = db.query(FamilyProductPreference).filter(
+        FamilyProductPreference.family_id == family_id,
+        FamilyProductPreference.normalized_name == normalize_product_name(name),
+    ).first()
+    return preference.category if preference is not None else None
+
+
+def add_or_merge_shopping_item(
+    db: Session,
+    *,
+    shopping_list: ShoppingList,
+    name: str,
+    spec: str | None = None,
+    category: str | None = None,
+    added_by_user_id: int | None = None,
+    position: int | None = None,
+) -> ShoppingItemTransition:
+    """Create, merge into an active row, or restore a checked compatible row."""
+    display_name = normalize_item_name(name)
+    incoming_spec = clean_optional_text(spec)
+    resolved_category = resolve_category(
+        db,
+        family_id=shopping_list.family_id,
+        name=display_name,
+        category=category,
+    )
+
+    candidates = (
+        db.query(ShoppingItem)
+        .filter(ShoppingItem.list_id == shopping_list.id)
+        .order_by(ShoppingItem.checked.asc(), ShoppingItem.position.asc(), ShoppingItem.id.asc())
+        .all()
+    )
+    normalized_name = normalize_product_name(display_name)
+    match = next(
+        (
+            item
+            for item in candidates
+            if normalize_product_name(item.name) == normalized_name
+            and specs_are_compatible(item.spec, incoming_spec)
+        ),
+        None,
+    )
+    if match is not None:
+        previous_spec = match.spec
+        previous_category = match.category
+        match.name = display_name
+        if match.checked:
+            match.spec = _restored_spec(match.spec, incoming_spec)
+            match.checked = False
+            match.checked_at = None
+            action: ShoppingItemAction = "restored"
+        else:
+            match.spec = _merged_active_spec(match.spec, incoming_spec)
+            action = "merged"
+        if resolved_category is not None:
+            match.category = resolved_category
+        db.flush()
+        return ShoppingItemTransition(
+            item=match,
+            action=action,
+            previous_spec=previous_spec,
+            previous_category=previous_category,
+        )
+
+    if position is None:
+        max_position = db.query(func.max(ShoppingItem.position)).filter(
+            ShoppingItem.list_id == shopping_list.id,
+        ).scalar()
+        position = (max_position if max_position is not None else -1) + 1
+    item = ShoppingItem(
+        list_id=shopping_list.id,
+        name=display_name,
+        spec=normalize_spec(incoming_spec),
+        category=resolved_category,
+        added_by_user_id=added_by_user_id,
+        position=position,
+    )
+    db.add(item)
+    db.flush()
+    return ShoppingItemTransition(item=item, action="created")
+
+
+# Concise aliases for callers/tests that use the domain vocabulary directly.
+details_are_compatible = specs_are_compatible
+add_or_merge_item = add_or_merge_shopping_item

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 
 from app.core.clock import utcnow, utcnow_aware
 
-from sqlalchemy import Column, Date, Index, Integer, String, ForeignKey, UniqueConstraint, DateTime, Boolean, func, Text, JSON, text, Time
+from sqlalchemy import CheckConstraint, Column, Date, Index, Integer, String, ForeignKey, UniqueConstraint, DateTime, Boolean, func, Text, JSON, text, Time
 from sqlalchemy.orm import relationship
 
 from .database import Base
@@ -56,6 +56,7 @@ class Family(Base):
     birthdays = relationship("FamilyBirthday", back_populates="family", cascade="all, delete-orphan")
     tasks = relationship("Task", back_populates="family", cascade="all, delete-orphan")
     shopping_lists = relationship("ShoppingList", back_populates="family", cascade="all, delete-orphan")
+    product_preferences = relationship("FamilyProductPreference", back_populates="family", cascade="all, delete-orphan")
     shopping_templates = relationship("ShoppingTemplate", back_populates="family", cascade="all, delete-orphan")
     household_templates = relationship("HouseholdTemplate", back_populates="family", cascade="all, delete-orphan")
     recipes = relationship("Recipe", back_populates="family", cascade="all, delete-orphan")
@@ -480,6 +481,23 @@ class ShoppingItem(Base):
     position = Column(Integer, nullable=False, default=0)
 
     shopping_list = relationship("ShoppingList", back_populates="items")
+
+
+class FamilyProductPreference(Base):
+    __tablename__ = "family_product_preferences"
+    __table_args__ = (
+        UniqueConstraint("family_id", "normalized_name", name="uq_family_product_preference_family_name"),
+        CheckConstraint("length(trim(category)) > 0", name="ck_family_product_preference_category_nonempty"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
+    normalized_name = Column(String(400), nullable=False)
+    category = Column(String, nullable=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    updated_at = Column(DateTime, nullable=False, default=utcnow, onupdate=utcnow, server_default=func.now())
+
+    family = relationship("Family", back_populates="product_preferences")
 
 
 class ShoppingTemplate(Base):

--- a/backend/app/modules/household_templates_router.py
+++ b/backend/app/modules/household_templates_router.py
@@ -9,8 +9,10 @@ from app.core.deps import current_user, ensure_adult
 from app.core.errors import error_detail, SHOPPING_LIST_NOT_FOUND
 from app.core.scopes import require_scope
 from app.core.shopping_notifications import dispatch_shopping_destination_event
+from app.core.shopping_domain import ShoppingItemTransition, add_or_merge_shopping_item
+from app.core.ws_broadcast import broadcast_shopping_event
 from app.database import get_db
-from app.models import HouseholdTemplate, ShoppingItem, ShoppingList, Task, User
+from app.models import HouseholdTemplate, ShoppingList, Task, User
 from app.schemas import (
     AUTH_RESPONSES,
     NOT_FOUND_RESPONSE,
@@ -194,23 +196,20 @@ def _apply_template(
         shopping_items=shopping_items,
         payload=payload,
     )
-    created_shopping_items: list[ShoppingItem] = []
+    shopping_transitions: list[ShoppingItemTransition] = []
     if shopping_list is not None:
-        max_position = max((item.position for item in shopping_list.items), default=-1)
-        for offset, item in enumerate(shopping_items):
-            shopping_item = ShoppingItem(
-                list_id=shopping_list.id,
+        for item in shopping_items:
+            shopping_transitions.append(add_or_merge_shopping_item(
+                db,
+                shopping_list=shopping_list,
                 name=item["name"],
                 spec=item.get("spec"),
                 category=item.get("category"),
                 added_by_user_id=user.id,
-                position=max_position + offset + 1,
-            )
-            db.add(shopping_item)
-            created_shopping_items.append(shopping_item)
+            ))
 
     db.flush()
-    if created_tasks or created_shopping_items:
+    if created_tasks or shopping_transitions:
         record_activity(
             db,
             family_id=family_id,
@@ -226,8 +225,14 @@ def _apply_template(
     db.commit()
     for task in created_tasks:
         db.refresh(task)
-    for item in created_shopping_items:
-        db.refresh(item)
+    for transition in shopping_transitions:
+        db.refresh(transition.item)
+        broadcast_shopping_event(
+            "list",
+            transition.item.list_id,
+            "item_added" if transition.action == "created" else "item_updated",
+            {"item": ShoppingItemResponse.model_validate(transition.item).model_dump(mode="json")},
+        )
     if shopping_list is not None:
         db.refresh(shopping_list)
         if shopping_list_created:
@@ -241,12 +246,12 @@ def _apply_template(
                 source_id=shopping_list.id,
                 action="household_template_list_created",
             )
-        if created_shopping_items:
+        if shopping_transitions:
             dispatch_shopping_destination_event(
                 family_id=family_id,
                 event_type="shopping.item.changed",
                 title="Shopping items added",
-                body=f'{user.display_name or "Someone"} added {len(created_shopping_items)} items from a household template to "{shopping_list.name}".',
+                body=f'{user.display_name or "Someone"} added {len(shopping_transitions)} items from a household template to "{shopping_list.name}".',
                 link=f"/shopping?list={shopping_list.id}",
                 source_type="shopping_list",
                 source_id=shopping_list.id,
@@ -255,10 +260,11 @@ def _apply_template(
     return HouseholdTemplateApplyResponse(
         template_id=template_id,
         created_task_count=len(created_tasks),
-        created_shopping_count=len(created_shopping_items),
+        created_shopping_count=sum(result.action == "created" for result in shopping_transitions),
+        merged_shopping_count=sum(result.action != "created" for result in shopping_transitions),
         shopping_list_id=shopping_list.id if shopping_list else None,
         tasks=[TaskResponse.model_validate(task) for task in created_tasks],
-        shopping_items=[ShoppingItemResponse.model_validate(item) for item in created_shopping_items],
+        shopping_items=[ShoppingItemResponse.model_validate(result.item) for result in shopping_transitions],
     )
 
 

--- a/backend/app/modules/meal_plans_router.py
+++ b/backend/app/modules/meal_plans_router.py
@@ -28,9 +28,10 @@ from app.core.errors import (
 )
 from app.core.scopes import require_scope
 from app.core.shopping_notifications import dispatch_shopping_destination_event
+from app.core.shopping_domain import ShoppingItemTransition, add_or_merge_shopping_item
 from app.core.ws_broadcast import broadcast_shopping_event
 from app.database import get_db
-from app.models import MealPlan, Membership, ShoppingItem, ShoppingList, User
+from app.models import MealPlan, Membership, ShoppingList, User
 from app.schemas import (
     AUTH_RESPONSES,
     MEAL_SLOTS,
@@ -457,37 +458,41 @@ def add_week_ingredients_to_shopping(
         .all()
     )
 
-    created: list[ShoppingItem] = []
+    transitions: list[ShoppingItemTransition] = []
     for entry in _aggregate_week_ingredients(plans):
-        item = ShoppingItem(
-            list_id=shopping_list.id,
+        transitions.append(add_or_merge_shopping_item(
+            db,
+            shopping_list=shopping_list,
             name=entry["name"].strip(),
             spec=_format_spec(entry["amount"], entry["unit"]),
             added_by_user_id=user.id,
-        )
-        db.add(item)
-        created.append(item)
+        ))
     db.commit()
-    for item in created:
+    for transition in transitions:
+        item = transition.item
         db.refresh(item)
         broadcast_shopping_event(
             "list",
             shopping_list.id,
-            "item_added",
+            "item_added" if transition.action == "created" else "item_updated",
             {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
         )
-    if created:
+    if transitions:
         dispatch_shopping_destination_event(
             family_id=payload.family_id,
             event_type="shopping.item.changed",
             title="Meal plan ingredients added",
-            body=f'{user.display_name or "Someone"} added {len(created)} ingredients from the meal plan week to "{shopping_list.name}".',
+            body=f'{user.display_name or "Someone"} added {len(transitions)} ingredients from the meal plan week to "{shopping_list.name}".',
             link=f"/shopping?list={shopping_list.id}",
             source_type="shopping_list",
             source_id=shopping_list.id,
             action="meal_plan_week_added",
         )
-    return MealPlanAddToShoppingResponse(added_count=len(created))
+    return MealPlanAddToShoppingResponse(
+        added_count=len(transitions),
+        created_count=sum(result.action == "created" for result in transitions),
+        merged_count=sum(result.action != "created" for result in transitions),
+    )
 
 
 @router.post(
@@ -541,34 +546,38 @@ def add_ingredients_to_shopping(
                 )
             selected.append(match)
 
-    created: list[ShoppingItem] = []
+    transitions: list[ShoppingItemTransition] = []
     for entry in selected:
-        item = ShoppingItem(
-            list_id=shopping_list.id,
+        transitions.append(add_or_merge_shopping_item(
+            db,
+            shopping_list=shopping_list,
             name=entry["name"].strip(),
             spec=_format_spec(entry["amount"], entry["unit"]),
             added_by_user_id=user.id,
-        )
-        db.add(item)
-        created.append(item)
+        ))
     db.commit()
-    for item in created:
+    for transition in transitions:
+        item = transition.item
         db.refresh(item)
         broadcast_shopping_event(
             "list",
             shopping_list.id,
-            "item_added",
+            "item_added" if transition.action == "created" else "item_updated",
             {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
         )
-    if created:
+    if transitions:
         dispatch_shopping_destination_event(
             family_id=plan.family_id,
             event_type="shopping.item.changed",
             title="Meal ingredients added",
-            body=f'{user.display_name or "Someone"} added {len(created)} ingredients from "{plan.meal_name}" to "{shopping_list.name}".',
+            body=f'{user.display_name or "Someone"} added {len(transitions)} ingredients from "{plan.meal_name}" to "{shopping_list.name}".',
             link=f"/shopping?list={shopping_list.id}",
             source_type="shopping_list",
             source_id=shopping_list.id,
             action="meal_plan_added",
         )
-    return MealPlanAddToShoppingResponse(added_count=len(created))
+    return MealPlanAddToShoppingResponse(
+        added_count=len(transitions),
+        created_count=sum(result.action == "created" for result in transitions),
+        merged_count=sum(result.action != "created" for result in transitions),
+    )

--- a/backend/app/modules/quick_capture_router.py
+++ b/backend/app/modules/quick_capture_router.py
@@ -8,6 +8,8 @@ from app.core.deps import current_user, ensure_adult
 from app.core.errors import error_detail
 from app.core.scopes import require_scope
 from app.core.shopping_notifications import dispatch_shopping_destination_event
+from app.core.shopping_domain import ShoppingItemTransition, add_or_merge_shopping_item
+from app.core.ws_broadcast import broadcast_shopping_event
 from app.core.webhooks import dispatch_webhook_event
 from app.database import get_db
 from app.models import QuickCaptureItem, ShoppingItem, ShoppingList, Task, User
@@ -88,28 +90,34 @@ def _create_task(db: Session, *, family_id: int, user: User, text: str) -> Task:
     return task
 
 
-def _create_shopping_item(db: Session, *, family_id: int, user: User, text: str) -> tuple[ShoppingItem, ShoppingList, bool]:
+def _create_shopping_item(
+    db: Session,
+    *,
+    family_id: int,
+    user: User,
+    text: str,
+) -> tuple[ShoppingItemTransition, ShoppingList, bool]:
     shopping_list, shopping_list_created = _get_or_create_quick_list(db, family_id, user.id)
-    item = ShoppingItem(
-        list_id=shopping_list.id,
+    transition = add_or_merge_shopping_item(
+        db,
+        shopping_list=shopping_list,
         name=text,
         added_by_user_id=user.id,
     )
-    db.add(item)
-    db.flush()
-    record_activity(
-        db,
-        family_id=family_id,
-        actor_user_id=user.id,
-        actor_display_name=user.display_name,
-        action="added",
-        object_type="shopping_item",
-        object_id=item.id,
-        object_label=item.name,
-        verb="added",
-        object_kind="to shopping",
-    )
-    return item, shopping_list, shopping_list_created
+    if transition.action == "created":
+        record_activity(
+            db,
+            family_id=family_id,
+            actor_user_id=user.id,
+            actor_display_name=user.display_name,
+            action="added",
+            object_type="shopping_item",
+            object_id=transition.item.id,
+            object_label=transition.item.name,
+            verb="added",
+            object_kind="to shopping",
+        )
+    return transition, shopping_list, shopping_list_created
 
 
 def _created_payload(destination: QuickCaptureDestination, created_item: Task | ShoppingItem) -> QuickCaptureResponse:
@@ -123,9 +131,10 @@ def _dispatch_quick_capture_shopping_events(
     family_id: int,
     user: User,
     shopping_list: ShoppingList,
-    item: ShoppingItem,
+    transition: ShoppingItemTransition,
     shopping_list_created: bool,
 ) -> None:
+    item = transition.item
     if shopping_list_created:
         dispatch_shopping_destination_event(
             family_id=family_id,
@@ -137,15 +146,38 @@ def _dispatch_quick_capture_shopping_events(
             source_id=shopping_list.id,
             action="quick_capture_list_created",
         )
+    broadcast_shopping_event(
+        "list",
+        shopping_list.id,
+        "item_added" if transition.action == "created" else "item_updated",
+        {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
+    )
+    action_copy = {
+        "created": (
+            "Shopping item added",
+            f'{user.display_name or "Someone"} added "{item.name}" to "{shopping_list.name}" from quick capture.',
+            "quick_capture_added",
+        ),
+        "merged": (
+            "Shopping item merged",
+            f'{user.display_name or "Someone"} merged "{item.name}" on "{shopping_list.name}" from quick capture.',
+            "quick_capture_merged",
+        ),
+        "restored": (
+            "Shopping item restored",
+            f'{user.display_name or "Someone"} restored "{item.name}" on "{shopping_list.name}" from quick capture.',
+            "quick_capture_restored",
+        ),
+    }[transition.action]
     dispatch_shopping_destination_event(
         family_id=family_id,
         event_type="shopping.item.changed",
-        title="Shopping item added",
-        body=f'{user.display_name or "Someone"} added "{item.name}" to "{shopping_list.name}" from quick capture.',
+        title=action_copy[0],
+        body=action_copy[1],
         link=f"/shopping?list={shopping_list.id}&item={item.id}",
         source_type="shopping_item",
         source_id=item.id,
-        action="quick_capture_added",
+        action=action_copy[2],
     )
 
 
@@ -177,21 +209,22 @@ def create_quick_capture(
         return _created_payload(payload.destination, task)
 
     if payload.destination == QuickCaptureDestination.shopping:
-        item, shopping_list, shopping_list_created = _create_shopping_item(db, family_id=payload.family_id, user=user, text=text)
+        transition, shopping_list, shopping_list_created = _create_shopping_item(db, family_id=payload.family_id, user=user, text=text)
+        item = transition.item
         db.commit()
         db.refresh(item)
         db.refresh(shopping_list)
         dispatch_webhook_event(
             db,
             family_id=payload.family_id,
-            event_type="shopping.item.created",
+            event_type="shopping.item.created" if transition.action == "created" else "shopping.item.updated",
             data={"list_id": item.list_id, "item_id": item.id, "name": item.name, "source": "quick_capture"},
         )
         _dispatch_quick_capture_shopping_events(
             family_id=payload.family_id,
             user=user,
             shopping_list=shopping_list,
-            item=item,
+            transition=transition,
             shopping_list_created=shopping_list_created,
         )
         return _created_payload(payload.destination, item)
@@ -274,7 +307,13 @@ def convert_quick_capture_item(
     if payload.destination == QuickCaptureDestination.task:
         created = _create_task(db, family_id=item.family_id, user=user, text=item.text)
     else:
-        created, shopping_list, shopping_list_created = _create_shopping_item(db, family_id=item.family_id, user=user, text=item.text)
+        shopping_transition, shopping_list, shopping_list_created = _create_shopping_item(
+            db,
+            family_id=item.family_id,
+            user=user,
+            text=item.text,
+        )
+        created = shopping_transition.item
 
     item.status = "converted"
     item.converted_to = payload.destination.value
@@ -284,11 +323,22 @@ def convert_quick_capture_item(
     db.refresh(created)
     if payload.destination == QuickCaptureDestination.shopping and shopping_list is not None:
         db.refresh(shopping_list)
+        dispatch_webhook_event(
+            db,
+            family_id=item.family_id,
+            event_type="shopping.item.created" if shopping_transition.action == "created" else "shopping.item.updated",
+            data={
+                "list_id": created.list_id,
+                "item_id": created.id,
+                "name": created.name,
+                "source": "quick_capture_inbox",
+            },
+        )
         _dispatch_quick_capture_shopping_events(
             family_id=item.family_id,
             user=user,
             shopping_list=shopping_list,
-            item=created,
+            transition=shopping_transition,
             shopping_list_created=shopping_list_created,
         )
     return QuickCaptureConvertResponse(

--- a/backend/app/modules/recipes_router.py
+++ b/backend/app/modules/recipes_router.py
@@ -21,9 +21,10 @@ from app.core.errors import (
 )
 from app.core.scopes import require_scope
 from app.core.shopping_notifications import dispatch_shopping_destination_event
+from app.core.shopping_domain import ShoppingItemTransition, add_or_merge_shopping_item
 from app.core.ws_broadcast import broadcast_shopping_event
 from app.database import get_db
-from app.models import Membership, Recipe, ShoppingItem, ShoppingList, User
+from app.models import Membership, Recipe, ShoppingList, User
 from app.schemas import (
     AUTH_RESPONSES,
     IngredientItem,
@@ -358,35 +359,39 @@ def add_recipe_ingredients_to_shopping(
                 )
             selected.append(match)
 
-    created: list[ShoppingItem] = []
+    transitions: list[ShoppingItemTransition] = []
     for entry in selected:
-        item = ShoppingItem(
-            list_id=shopping_list.id,
+        transitions.append(add_or_merge_shopping_item(
+            db,
+            shopping_list=shopping_list,
             name=entry["name"].strip(),
             spec=_format_spec(entry["amount"], entry["unit"]),
             added_by_user_id=user.id,
-        )
-        db.add(item)
-        created.append(item)
+        ))
     recipe.last_used_at = datetime.now(timezone.utc)
     db.commit()
-    for item in created:
+    for transition in transitions:
+        item = transition.item
         db.refresh(item)
         broadcast_shopping_event(
             "list",
             shopping_list.id,
-            "item_added",
+            "item_added" if transition.action == "created" else "item_updated",
             {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
         )
-    if created:
+    if transitions:
         dispatch_shopping_destination_event(
             family_id=recipe.family_id,
             event_type="shopping.item.changed",
             title="Recipe ingredients added",
-            body=f'{user.display_name or "Someone"} added {len(created)} ingredients from "{recipe.title}" to "{shopping_list.name}".',
+            body=f'{user.display_name or "Someone"} added {len(transitions)} ingredients from "{recipe.title}" to "{shopping_list.name}".',
             link=f"/shopping?list={shopping_list.id}",
             source_type="shopping_list",
             source_id=shopping_list.id,
             action="recipe_added",
         )
-    return RecipeAddToShoppingResponse(added_count=len(created))
+    return RecipeAddToShoppingResponse(
+        added_count=len(transitions),
+        created_count=sum(result.action == "created" for result in transitions),
+        merged_count=sum(result.action != "created" for result in transitions),
+    )

--- a/backend/app/modules/shopping_router.py
+++ b/backend/app/modules/shopping_router.py
@@ -10,6 +10,14 @@ from app.database import get_db
 from app.models import ShoppingItem, ShoppingList, ShoppingTemplate, ShoppingTemplateItem, User
 from app.core.ws_broadcast import broadcast_shopping_event
 from app.core.shopping_notifications import dispatch_shopping_destination_event
+from app.core.shopping_domain import (
+    InvalidShoppingItemName,
+    ShoppingItemTransition,
+    add_or_merge_shopping_item,
+    clean_optional_text,
+    normalize_item_name,
+    remember_category,
+)
 from app.core.webhooks import dispatch_webhook_event
 from app.schemas import (
     AUTH_RESPONSES,
@@ -38,32 +46,14 @@ router = APIRouter(prefix="/shopping", tags=["shopping"], responses={**AUTH_RESP
 
 
 def _clean_optional_text(value: str | None) -> str | None:
-    if value is None:
-        return None
-    cleaned = value.strip()
-    return cleaned or None
-
-
-def _capitalize_first(value: str) -> str:
-    cleaned = value.strip()
-    if not cleaned:
-        return cleaned
-    return f"{cleaned[:1].upper()}{cleaned[1:]}"
+    return clean_optional_text(value)
 
 
 def _normalize_item_name(value: str) -> str:
-    item_name = _capitalize_first(value)
-    if not item_name:
+    try:
+        return normalize_item_name(value)
+    except InvalidShoppingItemName:
         raise HTTPException(status_code=422, detail="Shopping item name cannot be blank")
-    return item_name
-
-
-def _same_item_name(left: str, right: str) -> bool:
-    return left.strip().casefold() == right.strip().casefold()
-
-
-def _same_optional_text(left: str | None, right: str | None) -> bool:
-    return _clean_optional_text(left) == _clean_optional_text(right)
 
 
 def _list_response(sl: ShoppingList) -> ShoppingListResponse:
@@ -233,36 +223,38 @@ def apply_template(
     if not sl or sl.family_id != template.family_id:
         raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
 
-    created_items = []
+    transitions: list[ShoppingItemTransition] = []
     ordered_template_items = sorted(template.items, key=lambda item: item.position)
-    max_position = max((item.position for item in sl.items), default=-1)
-    for offset, template_item in enumerate(ordered_template_items):
-        item = ShoppingItem(
-            list_id=sl.id,
-            name=template_item.name,
-            spec=template_item.spec,
-            category=template_item.category,
-            added_by_user_id=user.id,
-            position=max_position + offset + 1,
-        )
-        db.add(item)
-        created_items.append(item)
+    for template_item in ordered_template_items:
+        try:
+            transition = add_or_merge_shopping_item(
+                db,
+                shopping_list=sl,
+                name=template_item.name,
+                spec=template_item.spec,
+                category=template_item.category,
+                added_by_user_id=user.id,
+            )
+        except InvalidShoppingItemName:
+            raise HTTPException(status_code=422, detail="Shopping item name cannot be blank")
+        transitions.append(transition)
 
     db.commit()
-    for item in created_items:
+    for transition in transitions:
+        item = transition.item
         db.refresh(item)
         broadcast_shopping_event(
             "list",
             sl.id,
-            "item_added",
+            "item_added" if transition.action == "created" else "item_updated",
             {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
         )
-    if created_items:
+    if transitions:
         dispatch_shopping_destination_event(
             family_id=sl.family_id,
             event_type="shopping.item.changed",
             title="Shopping items added",
-            body=f'{user.display_name or "Someone"} added {len(created_items)} items from "{template.name}" to "{sl.name}".',
+            body=f'{user.display_name or "Someone"} added {len(transitions)} items from "{template.name}" to "{sl.name}".',
             link=f"/shopping?list={sl.id}",
             source_type="shopping_list",
             source_id=sl.id,
@@ -272,8 +264,10 @@ def apply_template(
     return ShoppingTemplateApplyResponse(
         template_id=template.id,
         list_id=sl.id,
-        added_count=len(created_items),
-        items=created_items,
+        added_count=len(transitions),
+        created_count=sum(result.action == "created" for result in transitions),
+        merged_count=sum(result.action != "created" for result in transitions),
+        items=[result.item for result in transitions],
     )
 
 
@@ -508,92 +502,64 @@ def add_item(
     if not sl:
         raise HTTPException(status_code=404, detail=error_detail(SHOPPING_LIST_NOT_FOUND))
     ensure_adult(db, user.id, sl.family_id)
-    item_name = _normalize_item_name(payload.name)
-    item_spec = _clean_optional_text(payload.spec)
-    item_category = _clean_optional_text(payload.category)
-    checked_match = next(
-        (
-            existing
-            for existing in sl.items
-            if existing.checked
-            and _same_item_name(existing.name, item_name)
-            and _same_optional_text(existing.spec, item_spec)
-            and _same_optional_text(existing.category, item_category)
-        ),
-        None,
-    )
-    if checked_match:
-        checked_match.name = item_name
-        checked_match.spec = item_spec
-        checked_match.category = item_category
-        checked_match.checked = False
-        checked_match.checked_at = None
-        db.commit()
-        db.refresh(checked_match)
-        resp = ShoppingItemResponse.model_validate(checked_match).model_dump(mode="json")
-        broadcast_shopping_event("list", list_id, "item_updated", {"item": resp})
-        dispatch_webhook_event(
+    try:
+        transition = add_or_merge_shopping_item(
+            db,
+            shopping_list=sl,
+            name=payload.name,
+            spec=payload.spec,
+            category=payload.category,
+            added_by_user_id=user.id,
+        )
+    except InvalidShoppingItemName:
+        raise HTTPException(status_code=422, detail="Shopping item name cannot be blank")
+    item = transition.item
+    if transition.action == "created":
+        record_activity(
             db,
             family_id=sl.family_id,
-            event_type="shopping.item.updated",
-            data={"list_id": list_id, "item_id": checked_match.id, "name": checked_match.name, "checked": checked_match.checked},
+            actor_user_id=user.id,
+            actor_display_name=user.display_name,
+            action="added",
+            object_type="shopping_item",
+            object_id=item.id,
+            object_label=item.name,
+            verb="added",
+            object_kind="to shopping",
         )
-        dispatch_shopping_destination_event(
-            family_id=sl.family_id,
-            event_type="shopping.item.changed",
-            title="Shopping item restored",
-            body=f'{user.display_name or "Someone"} restored "{checked_match.name}" on "{sl.name}".',
-            link=f"/shopping?list={list_id}&item={checked_match.id}",
-            source_type="shopping_item",
-            source_id=checked_match.id,
-            action="restored",
-        )
-        return checked_match
-
-    item = ShoppingItem(
-        list_id=list_id,
-        name=item_name,
-        spec=item_spec,
-        category=item_category,
-        added_by_user_id=user.id,
-    )
-    db.add(item)
-    db.flush()
-    record_activity(
-        db,
-        family_id=sl.family_id,
-        actor_user_id=user.id,
-        actor_display_name=user.display_name,
-        action="added",
-        object_type="shopping_item",
-        object_id=item.id,
-        object_label=item.name,
-        verb="added",
-        object_kind="to shopping",
-    )
     db.commit()
     db.refresh(item)
+    created = transition.action == "created"
     broadcast_shopping_event(
         "list",
         list_id,
-        "item_added",
+        "item_added" if created else "item_updated",
         {"item": ShoppingItemResponse.model_validate(item).model_dump(mode="json")},
     )
     dispatch_webhook_event(
         db,
         family_id=sl.family_id,
-        event_type="shopping.item.created",
+        event_type="shopping.item.created" if created else "shopping.item.updated",
         data={"list_id": list_id, "item_id": item.id, "name": item.name, "checked": item.checked},
     )
+    if transition.action == "created":
+        title = "Shopping item added"
+        body = f'{user.display_name or "Someone"} added "{item.name}" to "{sl.name}".'
+    elif transition.action == "merged":
+        title = "Shopping item merged"
+        body = f'{user.display_name or "Someone"} merged "{item.name}" on "{sl.name}".'
+    else:
+        title = "Shopping item restored"
+        body = f'{user.display_name or "Someone"} restored "{item.name}" on "{sl.name}".'
     dispatch_shopping_destination_event(
         family_id=sl.family_id,
         event_type="shopping.item.changed",
-        title="Shopping item added",
-        body=f'{user.display_name or "Someone"} added "{item.name}" to "{sl.name}".',
+        title=title,
+        body=body,
         link=f"/shopping?list={list_id}&item={item.id}",
         source_type="shopping_item",
         source_id=item.id,
-        action="created",
+        action=transition.action,
     )
     return item
 
@@ -634,6 +600,13 @@ def update_item(
         item.spec = _clean_optional_text(payload.spec)
     if "category" in fields:
         item.category = _clean_optional_text(payload.category)
+        if item.category is not None:
+            remember_category(
+                db,
+                family_id=sl.family_id,
+                name=item.name,
+                category=item.category,
+            )
     if payload.list_id is not None and payload.list_id != item.list_id:
         target_list = db.query(ShoppingList).filter(ShoppingList.id == payload.list_id).first()
         if not target_list or target_list.family_id != sl.family_id:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -749,7 +749,9 @@ class ShoppingTemplateApplyResponse(BaseModel):
     template_id: int = Field(..., description="Template ID")
     list_id: int = Field(..., description="Destination shopping list ID")
     added_count: int = Field(0, description="Number of added items")
-    items: list[ShoppingItemResponse] = Field(default_factory=list, description="Created shopping items")
+    created_count: int = Field(0, description="Number of newly created rows")
+    merged_count: int = Field(0, description="Number of existing rows merged or restored")
+    items: list[ShoppingItemResponse] = Field(default_factory=list, description="Affected shopping items")
 
 
 # ---------------------------------------------------------------------------
@@ -815,6 +817,7 @@ class HouseholdTemplateApplyResponse(BaseModel):
     template_id: Union[int, str]
     created_task_count: int = 0
     created_shopping_count: int = 0
+    merged_shopping_count: int = 0
     shopping_list_id: Optional[int] = None
     tasks: list[TaskResponse] = Field(default_factory=list)
     shopping_items: list[ShoppingItemResponse] = Field(default_factory=list)
@@ -1684,6 +1687,8 @@ class MealPlanAddToShoppingRequest(BaseModel):
 
 class MealPlanAddToShoppingResponse(BaseModel):
     added_count: int
+    created_count: int = 0
+    merged_count: int = 0
 
 
 
@@ -1772,6 +1777,8 @@ class RecipeAddToShoppingRequest(BaseModel):
 
 class RecipeAddToShoppingResponse(BaseModel):
     added_count: int
+    created_count: int = 0
+    merged_count: int = 0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_alembic_revisions.py
+++ b/backend/tests/test_alembic_revisions.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import ast
+import logging
 import sqlite3
 from pathlib import Path
 
+import pytest
 from alembic import command
 from alembic.config import Config
 from alembic.script import ScriptDirectory
@@ -13,6 +15,20 @@ from alembic.script import ScriptDirectory
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 VERSIONS_DIR = Path(__file__).resolve().parents[1] / "alembic" / "versions"
 MAX_ALEMBIC_VERSION_LENGTH = 32
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_disabled_state():
+    """Keep Alembic's fileConfig from leaking disabled loggers to later tests."""
+    disabled_before = {
+        name: logger.disabled
+        for name, logger in logging.root.manager.loggerDict.items()
+        if isinstance(logger, logging.Logger)
+    }
+    yield
+    for name, logger in logging.root.manager.loggerDict.items():
+        if isinstance(logger, logging.Logger):
+            logger.disabled = disabled_before.get(name, False)
 
 
 def _literal_assignment(module: ast.Module, name: str) -> str:
@@ -56,3 +72,40 @@ def test_alembic_upgrades_fresh_sqlite_database(tmp_path, monkeypatch) -> None:
     with sqlite3.connect(db_path) as conn:
         version = conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
     assert version == head
+
+
+def test_product_preferences_migration_backfills_latest_and_downgrades(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "product-preferences.db"
+    config = Config(str(BACKEND_DIR / "alembic.ini"))
+    config.set_main_option("script_location", str(BACKEND_DIR / "alembic"))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.syspath_prepend(str(BACKEND_DIR))
+    command.upgrade(config, "0053_ui_preferences")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT INTO families (id, name) VALUES (1, 'One'), (2, 'Two')")
+        conn.execute("INSERT INTO shopping_lists (id, family_id, name) VALUES (1, 1, 'A'), (2, 2, 'B')")
+        conn.execute(
+            """
+            INSERT INTO shopping_items (id, list_id, name, category, checked, position, created_at)
+            VALUES
+                (1, 1, 'Straße', 'Old', 0, 0, '2026-01-01 10:00:00'),
+                (2, 1, 'STRASSE', 'Newest by id', 0, 1, '2026-01-02 10:00:00'),
+                (3, 1, ' strasse ', 'Latest', 0, 2, '2026-01-02 10:00:00'),
+                (4, 2, 'Straße', 'Other family', 0, 0, '2026-01-03 10:00:00'),
+                (5, 1, 'Ignored', '   ', 0, 3, '2026-01-04 10:00:00')
+            """
+        )
+        conn.commit()
+
+    command.upgrade(config, "0054_product_preferences")
+    with sqlite3.connect(db_path) as conn:
+        preferences = conn.execute(
+            "SELECT family_id, normalized_name, category FROM family_product_preferences ORDER BY family_id"
+        ).fetchall()
+    assert preferences == [(1, "strasse", "Latest"), (2, "strasse", "Other family")]
+
+    command.downgrade(config, "0053_ui_preferences")
+    with sqlite3.connect(db_path) as conn:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    assert "family_product_preferences" not in tables

--- a/backend/tests/test_household_templates.py
+++ b/backend/tests/test_household_templates.py
@@ -191,6 +191,21 @@ def test_apply_custom_template_adds_tasks_and_shopping_without_overwriting_exist
     assert shopping_items.status_code == 200
     assert [item["name"] for item in shopping_items.json()] == ["Existing milk", "Apples", "Bread"]
 
+    reapplied = client.post(
+        f"/household-templates/{created.json()['id']}/apply",
+        json={"target_date": "2026-05-04", "shopping_list_id": list_id},
+        headers=_auth(token),
+    )
+    assert reapplied.status_code == 200, reapplied.json()
+    assert reapplied.json()["created_shopping_count"] == 0
+    assert reapplied.json()["merged_shopping_count"] == 2
+    merged = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
+    assert [(item["name"], item["spec"]) for item in merged] == [
+        ("Existing milk", None),
+        ("Apples", "12"),
+        ("Bread", None),
+    ]
+
 
 def test_apply_builtin_template_can_create_a_new_shopping_list():
     token, family_id = _seed_member(suffix="builtin")

--- a/backend/tests/test_meal_plans.py
+++ b/backend/tests/test_meal_plans.py
@@ -443,6 +443,7 @@ class TestWeeklyMealPlanShoppingIntegration:
         )
         assert push.status_code == 200, push.json()
         assert push.json()["added_count"] == 5
+        assert push.json()["created_count"] == 5
 
         items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
         pairs = sorted((item["name"], item["spec"]) for item in items)
@@ -453,6 +454,20 @@ class TestWeeklyMealPlanShoppingIntegration:
             ("Milk", "500 ml"),
             ("Sugar", "2 tbsp"),
         ])
+
+        pushed_again = client.post(
+            "/meal-plans/week/add-to-shopping",
+            json={
+                "family_id": family_id,
+                "week_start": "2026-04-13",
+                "shopping_list_id": list_id,
+            },
+            headers=_auth(token),
+        )
+        assert pushed_again.status_code == 200, pushed_again.json()
+        assert pushed_again.json()["added_count"] == 5
+        assert pushed_again.json()["created_count"] == 0
+        assert pushed_again.json()["merged_count"] == 5
 
     def test_push_week_only_uses_selected_family_week_and_target_list_family(self):
         token, family_id = _seed_member("*", "week-scope")
@@ -575,6 +590,20 @@ class TestMealPlanShoppingIntegration:
 
         items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
         assert sorted(i["name"] for i in items) == ["Kartoffeln", "Zwiebeln"]
+
+        pushed_again = client.post(
+            f"/meal-plans/{plan_id}/add-to-shopping",
+            json={"shopping_list_id": list_id, "ingredient_names": ["Zwiebeln", "Kartoffeln"]},
+            headers=_auth(token),
+        )
+        assert pushed_again.status_code == 200, pushed_again.json()
+        assert pushed_again.json()["created_count"] == 0
+        assert pushed_again.json()["merged_count"] == 2
+        merged = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
+        assert sorted((item["name"], item["spec"]) for item in merged) == [
+            ("Kartoffeln", "2 kg"),
+            ("Zwiebeln", "4 Stueck"),
+        ]
 
     def test_push_unknown_ingredient_returns_400(self):
         """Reject names that aren't on the meal so this endpoint can't be a backdoor shopping writer."""

--- a/backend/tests/test_quick_capture.py
+++ b/backend/tests/test_quick_capture.py
@@ -137,6 +137,40 @@ def test_quick_capture_routes_to_task_shopping_and_inbox_public_safely():
     assert long_resp.json()["inbox_item"]["text"] == long_text
 
 
+def test_quick_capture_direct_and_inbox_conversion_reuse_active_item():
+    token, family_id, _ = _seed_member("*", "shopping-reuse")
+    first = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "dish soap", "destination": "shopping"},
+        headers=_auth(token),
+    )
+    second = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": " Dish soap ", "destination": "shopping"},
+        headers=_auth(token),
+    )
+    inbox = client.post(
+        "/quick-capture",
+        json={"family_id": family_id, "text": "DISH SOAP", "destination": "inbox"},
+        headers=_auth(token),
+    )
+    converted = client.post(
+        f"/quick-capture/inbox/{inbox.json()['inbox_item']['id']}/convert",
+        json={"destination": "shopping"},
+        headers=_auth(token),
+    )
+
+    assert first.status_code == second.status_code == converted.status_code == 200
+    item_id = first.json()["created_item"]["id"]
+    assert second.json()["created_item"]["id"] == item_id
+    assert converted.json()["converted_item"]["id"] == item_id
+    db = TestSession()
+    try:
+        assert db.query(ShoppingItem).filter(ShoppingItem.id == item_id).count() == 1
+    finally:
+        db.close()
+
+
 def test_quick_capture_inbox_convert_and_dismiss_enforces_family_scope():
     token, family_id, _ = _seed_member("*", "owner")
     intruder_token, _, _ = _seed_member("*", "intruder")

--- a/backend/tests/test_recipes.py
+++ b/backend/tests/test_recipes.py
@@ -247,6 +247,56 @@ class TestRecipeShopping:
         assert data[0]["spec"] == "250 g"
         assert data[1]["spec"] is None
 
+        pushed_again = client.post(
+            f"/recipes/{recipe['id']}/add-to-shopping",
+            json={"shopping_list_id": list_id, "ingredient_names": ["Flour", "Salt"]},
+            headers=_auth(token),
+        )
+        assert pushed_again.status_code == 200, pushed_again.json()
+        assert pushed_again.json()["added_count"] == 2
+        assert pushed_again.json()["created_count"] == 0
+        assert pushed_again.json()["merged_count"] == 2
+        merged = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
+        assert [(item["name"], item["spec"]) for item in merged] == [
+            ("Flour", "500 g"),
+            ("Salt", None),
+        ]
+
+    def test_recipe_push_inherits_category_after_manual_item_is_cleared(self):
+        token, family_id = _seed_member("*", "shopping-category-memory")
+        recipe = _create_recipe(token, family_id)
+        list_id = _seed_shopping_list(family_id)
+        manual = client.post(
+            f"/shopping/lists/{list_id}/items",
+            json={"name": "Flour", "spec": "250 g", "category": "Baking"},
+            headers=_auth(token),
+        )
+        assert manual.status_code == 200, manual.json()
+        checked = client.patch(
+            f"/shopping/items/{manual.json()['id']}",
+            json={"checked": True},
+            headers=_auth(token),
+        )
+        assert checked.status_code == 200, checked.json()
+        cleared = client.delete(f"/shopping/lists/{list_id}/checked", headers=_auth(token))
+        assert cleared.status_code == 200, cleared.json()
+
+        pushed = client.post(
+            f"/recipes/{recipe['id']}/add-to-shopping",
+            json={"shopping_list_id": list_id, "ingredient_names": ["Flour"]},
+            headers=_auth(token),
+        )
+        assert pushed.status_code == 200, pushed.json()
+        assert pushed.json() == {
+            "added_count": 1,
+            "created_count": 1,
+            "merged_count": 0,
+        }
+        items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
+        assert [(item["name"], item["spec"], item["category"]) for item in items] == [
+            ("Flour", "250 g", "Baking"),
+        ]
+
     def test_rejects_unknown_ingredient_name(self):
         token, family_id = _seed_member("*", "shopping-b")
         recipe = _create_recipe(token, family_id)

--- a/backend/tests/test_shopping_domain.py
+++ b/backend/tests/test_shopping_domain.py
@@ -1,0 +1,175 @@
+"""Focused contracts for backend-authoritative shopping reuse."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from app.core.shopping_domain import (
+    add_or_merge_shopping_item,
+    normalize_product_name,
+    parse_quantity,
+    remember_category,
+    specs_are_compatible,
+)
+from app.database import Base
+from app.models import Family, FamilyProductPreference, ShoppingItem, ShoppingList, User
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "compatible"),
+    [
+        (None, "", True),
+        (None, "organic", True),
+        (" Organic ", "organic", True),
+        ("organic", "ripe", False),
+        ("2 L", "1 l", True),
+        ("2 L", "1 kg", False),
+        ("2", "1,5", True),
+        ("2", "organic", False),
+        ("0,5 kg", "1.25 KG", True),
+    ],
+)
+def test_detail_compatibility_truth_table(left, right, compatible):
+    assert specs_are_compatible(left, right) is compatible
+
+
+def test_quantity_parser_rejects_adversarial_whitespace_suffix():
+    assert parse_quantity("9" + (" " * 200) + ".") is None
+
+
+def test_product_name_uses_trimmed_unicode_casefold():
+    assert normalize_product_name("  Straße ") == normalize_product_name("STRASSE") == "strasse"
+
+
+def test_add_merge_restore_quantity_and_family_category_preference(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'domain.db'}")
+
+    @event.listens_for(engine, "connect")
+    def _foreign_keys(dbapi_connection, _record):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    original_user = User(email="first@example.com", password_hash="hash", display_name="First")
+    other_user = User(email="other@example.com", password_hash="hash", display_name="Other")
+    first_family = Family(name="First")
+    second_family = Family(name="Second")
+    db.add_all([original_user, other_user, first_family, second_family])
+    db.flush()
+    first_list = ShoppingList(family_id=first_family.id, name="Groceries")
+    second_list = ShoppingList(family_id=second_family.id, name="Groceries")
+    db.add_all([first_list, second_list])
+    db.flush()
+
+    created = add_or_merge_shopping_item(
+        db,
+        shopping_list=first_list,
+        name="  milk  ",
+        spec="2 L",
+        category=" Dairy ",
+        added_by_user_id=original_user.id,
+    )
+    assert created.action == "created"
+    assert (created.item.name, created.item.spec, created.item.category) == ("Milk", "2 L", "Dairy")
+    checked_variant = ShoppingItem(
+        list_id=first_list.id,
+        name="Milk",
+        spec="1 L",
+        checked=True,
+        position=1,
+    )
+    db.add(checked_variant)
+    db.flush()
+
+    merged = add_or_merge_shopping_item(
+        db,
+        shopping_list=first_list,
+        name="MILK",
+        spec="1 l",
+        added_by_user_id=other_user.id,
+    )
+    assert merged.action == "merged"
+    assert merged.item.id == created.item.id
+    assert merged.item.spec == "3 L"
+    assert merged.item.category == "Dairy"
+    assert merged.item.added_by_user_id == original_user.id
+    assert checked_variant.checked is True
+
+    merged.item.checked = True
+    restored = add_or_merge_shopping_item(
+        db,
+        shopping_list=first_list,
+        name="milk",
+        spec="0,5 l",
+    )
+    assert restored.action == "restored"
+    assert restored.item.spec == "0.5 l"
+    assert restored.item.checked is False
+
+    isolated = add_or_merge_shopping_item(db, shopping_list=second_list, name="milk")
+    assert isolated.action == "created"
+    assert isolated.item.category is None
+
+    bare = add_or_merge_shopping_item(db, shopping_list=first_list, name="Eggs", spec="2")
+    bare_merged = add_or_merge_shopping_item(db, shopping_list=first_list, name="eggs", spec="1")
+    assert bare_merged.item.id == bare.item.id
+    assert bare_merged.item.spec == "3"
+
+    decimal = add_or_merge_shopping_item(db, shopping_list=first_list, name="Sugar", spec="1,25 kg")
+    decimal_merged = add_or_merge_shopping_item(db, shopping_list=first_list, name="sugar", spec="0.75 KG")
+    assert decimal_merged.item.id == decimal.item.id
+    assert decimal_merged.item.spec == "2 kg"
+
+    blank = add_or_merge_shopping_item(db, shopping_list=first_list, name="Apples")
+    filled = add_or_merge_shopping_item(db, shopping_list=first_list, name="apples", spec=" Organic ")
+    equal_text = add_or_merge_shopping_item(db, shopping_list=first_list, name="APPLES", spec="organic")
+    unequal_text = add_or_merge_shopping_item(db, shopping_list=first_list, name="Apples", spec="ripe")
+    assert filled.item.id == equal_text.item.id == blank.item.id
+    assert equal_text.item.spec == "Organic"
+    assert unequal_text.action == "created"
+    assert unequal_text.item.id != blank.item.id
+
+    explicit = add_or_merge_shopping_item(
+        db,
+        shopping_list=first_list,
+        name="milk",
+        spec="1 kg",
+        category="Chilled",
+    )
+    assert explicit.action == "created"
+    assert explicit.item.category == "Chilled"
+    assert db.query(FamilyProductPreference).filter_by(
+        family_id=first_family.id,
+        normalized_name=normalize_product_name("Milk"),
+    ).one().category == "Chilled"
+
+
+def test_category_upsert_recovers_unique_race_inside_savepoint():
+    db = MagicMock()
+    query = db.query.return_value.filter.return_value
+    winner = FamilyProductPreference(family_id=1, normalized_name="milk", category="Old")
+    query.first.return_value = None
+    query.one.return_value = winner
+    db.flush.side_effect = [IntegrityError("insert", {}, Exception("unique")), None]
+
+    result = remember_category(db, family_id=1, name="Milk", category="Dairy")
+
+    assert result is winner
+    assert winner.category == "Dairy"
+    db.begin_nested.assert_called_once_with()
+    db.rollback.assert_not_called()
+
+
+def test_shopping_item_construction_is_centralized():
+    modules = Path(__file__).resolve().parents[1] / "app" / "modules"
+    offenders = [
+        path.name
+        for path in modules.glob("*.py")
+        if "ShoppingItem(" in path.read_text()
+    ]
+    assert offenders == []

--- a/backend/tests/test_shopping_item_reuse.py
+++ b/backend/tests/test_shopping_item_reuse.py
@@ -118,6 +118,123 @@ def test_add_item_reactivates_checked_match_without_creating_duplicate():
     ]
 
 
+def test_add_item_merges_compatible_active_quantity_instead_of_creating_duplicate():
+    token, _family_id, list_id = _seed_owner()
+    first = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "Milk", "spec": "2 L"},
+        headers=_auth(token),
+    )
+    assert first.status_code == 200, first.json()
+
+    second = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": " milk ", "spec": "1 l"},
+        headers=_auth(token),
+    )
+
+    assert second.status_code == 200, second.json()
+    assert second.json()["id"] == first.json()["id"]
+    assert second.json()["spec"] == "3 L"
+    items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token))
+    assert items.status_code == 200
+    assert [(item["name"], item["spec"], item["checked"]) for item in items.json()] == [
+        ("Milk", "3 L", False),
+    ]
+
+
+def test_add_item_emits_created_then_updated_events_for_merge(monkeypatch):
+    token, _family_id, list_id = _seed_owner()
+    from app.modules import shopping_router
+
+    ws_events = []
+    webhook_events = []
+    monkeypatch.setattr(
+        shopping_router,
+        "broadcast_shopping_event",
+        lambda scope, scope_id, event_type, payload: ws_events.append(event_type),
+    )
+    monkeypatch.setattr(
+        shopping_router,
+        "dispatch_webhook_event",
+        lambda _db, **kwargs: webhook_events.append(kwargs["event_type"]),
+    )
+    monkeypatch.setattr(shopping_router, "dispatch_shopping_destination_event", lambda **_kwargs: None)
+
+    first = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "Milk", "spec": "2 L"},
+        headers=_auth(token),
+    )
+    second = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "milk", "spec": "1 l"},
+        headers=_auth(token),
+    )
+
+    assert first.status_code == second.status_code == 200
+    assert ws_events == ["item_added", "item_updated"]
+    assert webhook_events == ["shopping.item.created", "shopping.item.updated"]
+
+
+def test_category_is_remembered_after_checked_item_is_cleared_and_readded():
+    token, _family_id, list_id = _seed_owner()
+    created = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "Limes", "category": "Fruit & Vegetables"},
+        headers=_auth(token),
+    )
+    assert created.status_code == 200, created.json()
+    checked = client.patch(
+        f"/shopping/items/{created.json()['id']}",
+        json={"checked": True},
+        headers=_auth(token),
+    )
+    assert checked.status_code == 200, checked.json()
+    cleared = client.delete(f"/shopping/lists/{list_id}/checked", headers=_auth(token))
+    assert cleared.status_code == 200, cleared.json()
+    assert cleared.json()["deleted_count"] == 1
+
+    readded = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "limes"},
+        headers=_auth(token),
+    )
+
+    assert readded.status_code == 200, readded.json()
+    assert readded.json()["category"] == "Fruit & Vegetables"
+
+
+def test_explicit_category_edit_wins_and_updates_memory():
+    token, _family_id, list_id = _seed_owner()
+    created = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "Bread", "category": "Pantry"},
+        headers=_auth(token),
+    )
+    edited = client.patch(
+        f"/shopping/items/{created.json()['id']}",
+        json={"category": " Bakery "},
+        headers=_auth(token),
+    )
+    assert edited.status_code == 200, edited.json()
+    assert edited.json()["category"] == "Bakery"
+    assert client.patch(
+        f"/shopping/items/{created.json()['id']}",
+        json={"checked": True},
+        headers=_auth(token),
+    ).status_code == 200
+    assert client.delete(f"/shopping/lists/{list_id}/checked", headers=_auth(token)).status_code == 200
+
+    readded = client.post(
+        f"/shopping/lists/{list_id}/items",
+        json={"name": "bread", "category": ""},
+        headers=_auth(token),
+    )
+    assert readded.status_code == 200, readded.json()
+    assert readded.json()["category"] == "Bakery"
+
+
 def test_add_item_keeps_separate_rows_when_details_differ_and_capitalizes_names():
     token, _family_id, list_id = _seed_owner()
     db = TestSession()
@@ -135,20 +252,20 @@ def test_add_item_keeps_separate_rows_when_details_differ_and_capitalizes_names(
 
     response = client.post(
         f"/shopping/lists/{list_id}/items",
-        json={"name": "milk", "spec": "2 L"},
+        json={"name": "milk", "spec": "2 kg"},
         headers=_auth(token),
     )
 
     assert response.status_code == 200, response.json()
     assert response.json()["id"] != existing_id
     assert response.json()["name"] == "Milk"
-    assert response.json()["spec"] == "2 L"
+    assert response.json()["spec"] == "2 kg"
     assert response.json()["checked"] is False
 
     items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token))
     assert items.status_code == 200
     assert [(item["name"], item["spec"], item["checked"]) for item in items.json()] == [
-        ("Milk", "2 L", False),
+        ("Milk", "2 kg", False),
         ("Milk", "1 L", True),
     ]
 

--- a/backend/tests/test_shopping_templates.py
+++ b/backend/tests/test_shopping_templates.py
@@ -153,6 +153,18 @@ def test_template_create_edit_list_delete_and_apply_to_shopping_list():
         ("Milk", "2 L", "Dairy", False),
     ]
 
+    reapplied = client.post(
+        f"/shopping/templates/{template['id']}/apply",
+        json={"list_id": list_id},
+        headers=_auth(token),
+    )
+    assert reapplied.status_code == 200, reapplied.json()
+    assert reapplied.json()["added_count"] == 2
+    assert reapplied.json()["created_count"] == 0
+    assert reapplied.json()["merged_count"] == 2
+    merged_items = client.get(f"/shopping/lists/{list_id}/items", headers=_auth(token)).json()
+    assert [(item["name"], item["spec"]) for item in merged_items] == [("Oats", "2 kg"), ("Milk", "4 L")]
+
     deleted = client.delete(f"/shopping/templates/{template['id']}", headers=_auth(token))
     assert deleted.status_code == 200
     assert deleted.json() == {"status": "deleted", "template_id": template["id"]}

--- a/frontend/__tests__/hooks/useShoppingHelpers.test.js
+++ b/frontend/__tests__/hooks/useShoppingHelpers.test.js
@@ -1,4 +1,9 @@
-import { findReusableCheckedItem, formatShoppingItemName } from '../../hooks/useShopping';
+import {
+  findReusableCheckedItem,
+  formatShoppingItemName,
+  predictShoppingItemTransition,
+  shoppingSpecsAreCompatible,
+} from '../../hooks/useShopping';
 
 describe('shopping item helpers', () => {
   test('capitalizes the first product name letter and trims whitespace', () => {
@@ -6,16 +11,54 @@ describe('shopping item helpers', () => {
     expect(formatShoppingItemName('Äpfel')).toBe('Äpfel');
   });
 
-  test('finds a reusable checked item by normalized name and matching details', () => {
+  test('finds a reusable checked item by normalized name and compatible details, independent of category', () => {
     const items = [
       { id: 1, name: 'Milch', spec: null, category: null, checked: true },
       { id: 2, name: 'Milch', spec: '2 L', category: null, checked: true },
       { id: 3, name: 'Brot', spec: null, category: null, checked: false },
     ];
 
-    expect(findReusableCheckedItem(items, { name: ' milch ', spec: '', category: null })).toEqual(items[0]);
-    expect(findReusableCheckedItem(items, { name: 'milch', spec: '2 L', category: null })).toEqual(items[1]);
+    expect(findReusableCheckedItem(items, { name: ' milch ', spec: '', category: 'Other' })).toEqual(items[0]);
+    expect(findReusableCheckedItem(items, { name: 'milch', spec: '2 L', category: null })).toEqual(items[0]);
     expect(findReusableCheckedItem(items, { name: 'brot', spec: null, category: null })).toBeNull();
-    expect(findReusableCheckedItem(items, { name: 'milch', spec: '1 L', category: null })).toBeNull();
+    expect(findReusableCheckedItem([items[1]], { name: 'milch', spec: '1 kg', category: null })).toBeNull();
+  });
+
+  test('predicts active merge before checked restore and sums matching quantities', () => {
+    const items = [
+      { id: 1, name: 'Milch', spec: '2 L', category: 'Dairy', checked: true },
+      { id: 2, name: 'Milch', spec: '1 l', category: 'Other', checked: false },
+    ];
+    expect(predictShoppingItemTransition(items, { name: ' milch ', spec: '0,5 L' })).toEqual({
+      item: items[1], action: 'merged', spec: '1.5 l',
+    });
+  });
+
+  test('uses Unicode-aware normalized product names', () => {
+    const item = { id: 1, name: 'Straße', spec: null, category: null, checked: false };
+    expect(predictShoppingItemTransition([item], { name: 'STRASSE', spec: null })).toMatchObject({
+      item, action: 'merged',
+    });
+  });
+
+  test('restores checked quantities without summing and keeps nonblank details', () => {
+    const checked = { id: 1, name: 'Flour', spec: '2 kg', category: 'Pantry', checked: true };
+    expect(predictShoppingItemTransition([checked], { name: 'flour', spec: '1 KG' })).toEqual({
+      item: checked, action: 'restored', spec: '1 KG',
+    });
+    expect(predictShoppingItemTransition([checked], { name: 'flour', spec: '' })).toEqual({
+      item: checked, action: 'restored', spec: '2 kg',
+    });
+  });
+
+  test('matches the detail compatibility truth table', () => {
+    expect(shoppingSpecsAreCompatible(null, '')).toBe(true);
+    expect(shoppingSpecsAreCompatible(null, 'organic')).toBe(true);
+    expect(shoppingSpecsAreCompatible(' Organic ', 'organic')).toBe(true);
+    expect(shoppingSpecsAreCompatible('organic', 'ripe')).toBe(false);
+    expect(shoppingSpecsAreCompatible('2 L', '1 l')).toBe(true);
+    expect(shoppingSpecsAreCompatible('2 L', '1 kg')).toBe(false);
+    expect(shoppingSpecsAreCompatible('2', '1')).toBe(true);
+    expect(shoppingSpecsAreCompatible('2', 'organic')).toBe(false);
   });
 });

--- a/frontend/e2e/tests/calendar.spec.js
+++ b/frontend/e2e/tests/calendar.spec.js
@@ -233,7 +233,11 @@ test.describe('Calendar', () => {
     const candidateDays = [21, 22, 23, 24, 25, 26, 27].filter((day) => {
       const iconDate = new Date(now.getFullYear(), now.getMonth(), day, 9, 0, 0);
       const plainDate = new Date(now.getFullYear(), now.getMonth(), day + 1, 9, 0, 0);
-      return plainDate.getMonth() === now.getMonth() && iconDate.getDay() !== 0 && iconDate.getDay() !== 6;
+      return plainDate.getMonth() === now.getMonth()
+        && iconDate.toDateString() !== now.toDateString()
+        && plainDate.toDateString() !== now.toDateString()
+        && iconDate.getDay() !== 0
+        && iconDate.getDay() !== 6;
     });
 
     await navigateTo(page, 'Calendar');
@@ -254,31 +258,41 @@ test.describe('Calendar', () => {
     expect(plainDayNumber).toBeDefined();
 
     const iconDate = new Date(now.getFullYear(), now.getMonth(), iconDayNumber, 9, 0, 0);
-    await seedCalendarEvent(apiCtx, familyId, {
-      title: 'Alignment Soccer',
-      starts_at: iconDate.toISOString(),
-      icon: 'soccer',
-    });
+    let iconEvent;
+    let primaryError;
 
-    await page.reload();
-    await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
+    try {
+      iconEvent = await seedCalendarEvent(apiCtx, familyId, {
+        title: 'Alignment Soccer',
+        starts_at: iconDate.toISOString(),
+        icon: 'soccer',
+      });
 
-    const iconDay = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${iconDayNumber}$`) }) }).first();
-    const plainDay = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${plainDayNumber}$`) }) }).first();
-    await expect(iconDay.locator('.calendar-day-icon-indicator').first()).toBeVisible({ timeout: 10000 });
-    await expect(plainDay.locator('.calendar-day-dots > *')).toHaveCount(0);
+      await page.reload();
+      await page.locator('.calendar-grid-wrapper').waitFor({ timeout: 10000 });
 
-    const iconBox = await iconDay.locator('.calendar-day-num').boundingBox();
-    const plainBox = await plainDay.locator('.calendar-day-num').boundingBox();
-    const iconCellBox = await iconDay.boundingBox();
-    const plainCellBox = await plainDay.boundingBox();
-    expect(iconBox).not.toBeNull();
-    expect(plainBox).not.toBeNull();
-    expect(iconCellBox).not.toBeNull();
-    expect(plainCellBox).not.toBeNull();
-    expect(Math.abs(iconBox.y - plainBox.y)).toBeLessThanOrEqual(0.5);
-    expect(Math.abs((iconBox.x + iconBox.width / 2) - (iconCellBox.x + iconCellBox.width / 2))).toBeLessThanOrEqual(1);
-    expect(Math.abs((plainBox.x + plainBox.width / 2) - (plainCellBox.x + plainCellBox.width / 2))).toBeLessThanOrEqual(1);
+      const iconDay = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${iconDayNumber}$`) }) }).first();
+      const plainDay = page.locator('.calendar-day:not(.empty)').filter({ has: page.locator('.calendar-day-num', { hasText: new RegExp(`^${plainDayNumber}$`) }) }).first();
+      await expect(iconDay.locator('.calendar-day-icon-indicator').first()).toBeVisible({ timeout: 10000 });
+      await expect(plainDay.locator('.calendar-day-dots > *')).toHaveCount(0);
+
+      const iconBox = await iconDay.locator('.calendar-day-num').boundingBox();
+      const plainBox = await plainDay.locator('.calendar-day-num').boundingBox();
+      const iconCellBox = await iconDay.boundingBox();
+      const plainCellBox = await plainDay.boundingBox();
+      expect(iconBox).not.toBeNull();
+      expect(plainBox).not.toBeNull();
+      expect(iconCellBox).not.toBeNull();
+      expect(plainCellBox).not.toBeNull();
+      expect(Math.abs(iconBox.y - plainBox.y)).toBeLessThanOrEqual(0.5);
+      expect(Math.abs((iconBox.x + iconBox.width / 2) - (iconCellBox.x + iconCellBox.width / 2))).toBeLessThanOrEqual(1);
+      expect(Math.abs((plainBox.x + plainBox.width / 2) - (plainCellBox.x + plainCellBox.width / 2))).toBeLessThanOrEqual(1);
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      await cleanupCalendarEvents(apiCtx, [iconEvent?.id], primaryError);
+    }
   });
 
   test('desktop event form gives date-time fields enough room for time entry', async ({ authedPage: page }) => {

--- a/frontend/e2e/tests/dashboard.spec.js
+++ b/frontend/e2e/tests/dashboard.spec.js
@@ -81,28 +81,43 @@ test.describe('Dashboard', () => {
     const startsAt = localIsoDaysFromToday(2, 9, 0);
     const expectedDate = new Date(startsAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     const familyId = await getFamilyId(apiCtx);
-    await seedCalendarEvent(apiCtx, familyId, {
-      title: 'Future next-up chip event',
-      starts_at: startsAt,
-      location: 'Kitchen calendar',
-    });
+    let event;
+    let primaryError;
 
-    await page.reload();
-    await expect(page.getByRole('region', { name: 'Next up' })).toBeVisible({ timeout: 10000 });
+    try {
+      event = await seedCalendarEvent(apiCtx, familyId, {
+        title: 'Future next-up chip event',
+        starts_at: startsAt,
+        location: 'Kitchen calendar',
+      });
 
-    const nextUp = page.getByRole('region', { name: 'Next up' });
-    await expect(nextUp).toContainText('Future next-up chip event');
-    const chip = nextUp.locator('.next-up-time-chip');
-    await expect(chip).toHaveClass(/is-stacked/);
-    await expect(chip.locator('.next-up-chip-date')).toContainText(expectedDate);
-    await expect(chip.locator('.next-up-chip-time')).toContainText(/^0?9:00(\s?[AP]M)?$/i);
+      await page.reload();
+      await expect(page.getByRole('region', { name: 'Next up' })).toBeVisible({ timeout: 10000 });
 
-    const chipBox = await chip.boundingBox();
-    const cardBox = await nextUp.boundingBox();
-    expect(chipBox).not.toBeNull();
-    expect(cardBox).not.toBeNull();
-    expect(chipBox.x + chipBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
-    expect(chipBox.y + chipBox.height).toBeLessThanOrEqual(cardBox.y + cardBox.height + 1);
+      const nextUp = page.getByRole('region', { name: 'Next up' });
+      await expect(nextUp).toContainText('Future next-up chip event');
+      const chip = nextUp.locator('.next-up-time-chip');
+      await expect(chip).toHaveClass(/is-stacked/);
+      await expect(chip.locator('.next-up-chip-date')).toContainText(expectedDate);
+      await expect(chip.locator('.next-up-chip-time')).toContainText(/^0?9:00(\s?[AP]M)?$/i);
+
+      const chipBox = await chip.boundingBox();
+      const cardBox = await nextUp.boundingBox();
+      expect(chipBox).not.toBeNull();
+      expect(cardBox).not.toBeNull();
+      expect(chipBox.x + chipBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
+      expect(chipBox.y + chipBox.height).toBeLessThanOrEqual(cardBox.y + cardBox.height + 1);
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      if (event?.id) {
+        const cleanup = await apiCtx.delete(`/api/calendar/events/${event.id}`);
+        if (!cleanup.ok() && !primaryError) {
+          throw new Error(`Failed to clean up dashboard event ${event.id}: ${cleanup.status()}`);
+        }
+      }
+    }
   });
 
   test('keeps dashboard header search usable on narrow desktop widths', async ({ authedPage: page }) => {

--- a/frontend/hooks/useShopping.js
+++ b/frontend/hooks/useShopping.js
@@ -17,24 +17,100 @@ function cleanOptionalText(value) {
   return cleaned || null;
 }
 
-function sameItemName(left, right) {
-  return left.trim().toLocaleLowerCase() === right.trim().toLocaleLowerCase();
+function caseFold(value) {
+  return value.trim().normalize('NFKC').toLocaleLowerCase().replaceAll('ß', 'ss').replaceAll('ς', 'σ');
 }
 
-function sameOptionalText(left, right) {
-  return cleanOptionalText(left) === cleanOptionalText(right);
+function sameItemName(left, right) {
+  return caseFold(left) === caseFold(right);
+}
+
+function parseQuantity(value) {
+  const cleaned = cleanOptionalText(value);
+  if (cleaned == null) return null;
+  const match = cleaned.match(/^((?:\d+(?:[.,]\d+)?|[.,]\d+))\s*([^\d.,].*)?$/u);
+  if (!match) return null;
+  const amount = match[1].replace(',', '.');
+  const [whole, fraction = ''] = amount.split('.');
+  const unit = cleanOptionalText(match[2]);
+  return {
+    coefficient: BigInt(`${whole || '0'}${fraction}`),
+    scale: fraction.length,
+    unit: unit == null ? null : caseFold(unit.replace(/\s+/g, ' ')),
+    displayUnit: unit == null ? null : unit.replace(/\s+/g, ' '),
+  };
+}
+
+function formatQuantity(quantity, displayUnit = quantity.displayUnit) {
+  let digits = quantity.coefficient.toString();
+  if (quantity.scale) {
+    digits = digits.padStart(quantity.scale + 1, '0');
+    digits = `${digits.slice(0, -quantity.scale)}.${digits.slice(-quantity.scale)}`;
+    digits = digits.replace(/0+$/, '').replace(/\.$/, '');
+  }
+  return displayUnit ? `${digits} ${displayUnit}` : digits;
+}
+
+function normalizeSpec(value) {
+  const cleaned = cleanOptionalText(value);
+  const quantity = parseQuantity(cleaned);
+  return quantity ? formatQuantity(quantity) : cleaned;
+}
+
+export function shoppingSpecsAreCompatible(left, right) {
+  const leftClean = cleanOptionalText(left);
+  const rightClean = cleanOptionalText(right);
+  if (leftClean == null || rightClean == null) return true;
+  const leftQuantity = parseQuantity(leftClean);
+  const rightQuantity = parseQuantity(rightClean);
+  if (leftQuantity || rightQuantity) {
+    return Boolean(leftQuantity && rightQuantity && leftQuantity.unit === rightQuantity.unit);
+  }
+  return caseFold(leftClean) === caseFold(rightClean);
+}
+
+function mergeActiveSpec(existing, incoming) {
+  const existingClean = cleanOptionalText(existing);
+  const incomingClean = cleanOptionalText(incoming);
+  if (existingClean == null) return normalizeSpec(incomingClean);
+  if (incomingClean == null) return existingClean;
+  const left = parseQuantity(existingClean);
+  const right = parseQuantity(incomingClean);
+  if (!left || !right) return existingClean;
+  const scale = Math.max(left.scale, right.scale);
+  const coefficient = (
+    left.coefficient * (10n ** BigInt(scale - left.scale))
+    + right.coefficient * (10n ** BigInt(scale - right.scale))
+  );
+  return formatQuantity({ ...left, coefficient, scale }, left.displayUnit || right.displayUnit);
 }
 
 export function findReusableCheckedItem(items, payload) {
   const itemName = formatShoppingItemName(payload.name);
   const itemSpec = cleanOptionalText(payload.spec);
-  const itemCategory = cleanOptionalText(payload.category);
   return items.find((item) => (
     item.checked
     && sameItemName(item.name, itemName)
-    && sameOptionalText(item.spec, itemSpec)
-    && sameOptionalText(item.category, itemCategory)
+    && shoppingSpecsAreCompatible(item.spec, itemSpec)
   )) || null;
+}
+
+export function predictShoppingItemTransition(items, payload) {
+  const itemName = formatShoppingItemName(payload.name);
+  const itemSpec = cleanOptionalText(payload.spec);
+  const candidates = [...items.filter((item) => !item.checked), ...items.filter((item) => item.checked)];
+  const item = candidates.find((candidate) => (
+    sameItemName(candidate.name, itemName)
+    && shoppingSpecsAreCompatible(candidate.spec, itemSpec)
+  ));
+  if (!item) return null;
+  return {
+    item,
+    action: item.checked ? 'restored' : 'merged',
+    spec: item.checked
+      ? (itemSpec == null ? cleanOptionalText(item.spec) : normalizeSpec(itemSpec))
+      : mergeActiveSpec(item.spec, itemSpec),
+  };
 }
 
 export function useShopping() {
@@ -239,19 +315,28 @@ export function useShopping() {
       spec: cleanOptionalText(newItemSpec),
       category: cleanOptionalText(newItemCategory),
     };
-    const reusableCheckedItem = findReusableCheckedItem(items, payload);
+    const predictedTransition = predictShoppingItemTransition(items, payload);
     if (demoMode) {
-      if (reusableCheckedItem) {
-        setItems((prev) => prev.map((item) => item.id === reusableCheckedItem.id
-          ? { ...item, ...payload, checked: false, checked_at: null }
+      if (predictedTransition) {
+        const mergedPayload = {
+          name: payload.name,
+          spec: predictedTransition.spec,
+          category: payload.category || predictedTransition.item.category || null,
+          checked: false,
+          checked_at: null,
+        };
+        setItems((prev) => prev.map((item) => item.id === predictedTransition.item.id
+          ? { ...item, ...mergedPayload }
           : item));
         setShoppingLists((prev) =>
           prev.map((l) => l.id === activeListId
             ? {
                 ...l,
-                checked_count: Math.max((l.checked_count || 0) - 1, 0),
-                items: (l.items || []).map((item) => item.id === reusableCheckedItem.id
-                  ? { ...item, ...payload, checked: false, checked_at: null }
+                checked_count: predictedTransition.action === 'restored'
+                  ? Math.max((l.checked_count || 0) - 1, 0)
+                  : (l.checked_count || 0),
+                items: (l.items || []).map((item) => item.id === predictedTransition.item.id
+                  ? { ...item, ...mergedPayload }
                   : item),
               }
             : l
@@ -262,6 +347,7 @@ export function useShopping() {
           id: Date.now(),
           list_id: activeListId,
           ...payload,
+          spec: normalizeSpec(payload.spec),
           checked: false,
           checked_at: null,
           added_by_user_id: 1,


### PR DESCRIPTION
## Summary
- remember the latest explicit shopping category per family and product name, including existing categorized items during migration
- merge compatible active items, restore compatible checked items, sum matching quantities, and keep incompatible variants separate
- apply the same behavior to manual entry, recipes, meal plans, templates, and quick capture while preserving accurate realtime and webhook events

## File placement
- shopping matching, quantity handling, category memory, and item transitions live in one backend shopping domain module
- the new family product preference table stores durable category defaults with a unique family/name boundary
- route modules retain authorization, transactions, activity, response serialization, and external event dispatch

## Tests
- Backend: 599 passed
- Frontend unit tests: 455 passed
- Frontend production build: passed
- Playwright: 150 passed, 4 viewport-specific tests skipped
- Migration: fresh upgrade, historical category backfill, and downgrade verified

Closes #452
Closes #453
